### PR TITLE
Migrate from deprecated Bukkit ChatColor system to Adventure components

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
@@ -14,7 +14,6 @@ import me.mykindos.betterpvp.core.utilities.UtilItem;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -36,14 +35,13 @@ public class BuildMenu extends Menu implements IRefreshingMenu {
 
     @Override
     public void refresh() {
-        addButton(new Button(0, new ItemStack(Material.EMERALD_BLOCK), ChatColor.GREEN.toString() + ChatColor.BOLD + "Back"));
-        addButton(new Button(18, new ItemStack(role.getHelmet()), ChatColor.GREEN.toString() + ChatColor.BOLD + role.getName() + " Helmet"));
-        addButton(new Button(27, new ItemStack(role.getChestplate()), ChatColor.GREEN.toString() + ChatColor.BOLD + role.getName() + " Chestplate"));
-        addButton(new Button(36, new ItemStack(role.getLeggings()), ChatColor.GREEN.toString() + ChatColor.BOLD + role.getName() + " Leggings"));
-        addButton(new Button(45, new ItemStack(role.getBoots()), ChatColor.GREEN.toString() + ChatColor.BOLD + role.getName() + " Boots"));
+        addButton(new Button(0, new ItemStack(Material.EMERALD_BLOCK), Component.text("Back", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(18, new ItemStack(role.getHelmet()), Component.text(role.getName() + " Helmet", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(27, new ItemStack(role.getChestplate()), Component.text(role.getName() + " Chestplate", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(36, new ItemStack(role.getLeggings()), Component.text(role.getName() + " Leggings", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(45, new ItemStack(role.getBoots()), Component.text(role.getName() + " Boots", NamedTextColor.GREEN, TextDecoration.BOLD)));
 
         int slot = 9;
-
 
         for (int i = 1; i < 5; i++) {
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import me.mykindos.betterpvp.champions.champions.builds.BuildSkill;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
@@ -14,16 +16,22 @@ import me.mykindos.betterpvp.core.menu.Menu;
 import me.mykindos.betterpvp.core.menu.interfaces.IRefreshingMenu;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class SkillMenu extends Menu implements IRefreshingMenu {
 
+    /**
+     * The tag resolver for skill descriptions.
+     * It will parse all tags with the name 'val'
+     */
+    public static final TagResolver TAG_RESOLVER = TagResolver.resolver("val", Tag.styling(NamedTextColor.GREEN));
+    
     private final Role role;
 
     private final SkillManager skillManager;
@@ -87,21 +95,22 @@ public class SkillMenu extends Menu implements IRefreshingMenu {
     }
 
     public SkillButton buildButton(Skill skill, int slot, int level) {
-        String[] lore;
-        lore = skill.getDescription(level);
+        String[] lore = skill.getDescription(level);
 
-        List<String> tempLore = new ArrayList<>();
+        List<Component> tempLore = new ArrayList<>();
         for (String str : lore) {
-            tempLore.add(ChatColor.GRAY + str);
+            Component component = MiniMessage.miniMessage().deserialize("<gray>" + str, TAG_RESOLVER);
+            tempLore.add(component);
         }
-        ItemStack book = null;
-        String name = "";
+
+        ItemStack book;
+        Component name;
         if (isSkillActive(skill)) {
             book = new ItemStack(Material.ENCHANTED_BOOK);
-            name = ChatColor.GREEN.toString() + ChatColor.BOLD + skill.getName() + " (" + level + " / " + skill.getMaxLevel() + ")";
+            name = Component.text(skill.getName() + " (" + level + " / " + skill.getMaxLevel() + ")", NamedTextColor.GREEN, TextDecoration.BOLD);
         } else {
             book = new ItemStack(Material.BOOK);
-            name = ChatColor.RED + skill.getName();
+            name = Component.text(skill.getName(), NamedTextColor.RED);
         }
 
 
@@ -120,13 +129,13 @@ public class SkillMenu extends Menu implements IRefreshingMenu {
     }
 
     private void addDefaultButtons() {
-        addButton(new Button(0, new ItemStack(Material.IRON_SWORD), ChatColor.GREEN.toString() + ChatColor.BOLD + "Sword Skills"));
-        addButton(new Button(9, new ItemStack(Material.IRON_AXE), ChatColor.GREEN.toString() + ChatColor.BOLD + "Axe Skills"));
-        addButton(new Button(18, new ItemStack(Material.BOW), ChatColor.GREEN.toString() + ChatColor.BOLD + "Bow Skills"));
-        addButton(new Button(27, new ItemStack(Material.RED_DYE, 1), ChatColor.GREEN.toString() + ChatColor.BOLD + "Class Passive A Skills"));
-        addButton(new Button(36, new ItemStack(Material.ORANGE_DYE, 1), ChatColor.GREEN.toString() + ChatColor.BOLD + "Class Passive B Skills"));
-        addButton(new Button(45, new ItemStack(Material.YELLOW_DYE, 1), ChatColor.GREEN.toString() + ChatColor.BOLD + "Global Passive Skills"));
-        addButton(new Button(8, new ItemStack(Material.EMERALD, roleBuild.getPoints()), ChatColor.GREEN.toString() + ChatColor.BOLD + "Skill Points"));
+        addButton(new Button(0, new ItemStack(Material.IRON_SWORD), Component.text("Sword Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(9, new ItemStack(Material.IRON_AXE), Component.text("Axe Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(18, new ItemStack(Material.BOW), Component.text("Bow Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(27, new ItemStack(Material.RED_DYE), Component.text("Class Passive A Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(36, new ItemStack(Material.ORANGE_DYE), Component.text("Class Passive B Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(45, new ItemStack(Material.YELLOW_DYE), Component.text("Global Passive Skills", NamedTextColor.GREEN, TextDecoration.BOLD)));
+        addButton(new Button(8, new ItemStack(Material.EMERALD, roleBuild.getPoints()), Component.text("Skill Points", NamedTextColor.GREEN, TextDecoration.BOLD)));
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ApplyBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ApplyBuildButton.java
@@ -1,18 +1,19 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
+import java.util.Optional;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.ApplyBuildEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Optional;
 
 public class ApplyBuildButton extends Button {
 
@@ -21,7 +22,7 @@ public class ApplyBuildButton extends Button {
     private final int buildNumber;
 
     public ApplyBuildButton(GamerBuilds builds, Role role, int buildNumber, int slot, ItemStack item) {
-        super(slot, item, ChatColor.GREEN.toString() + ChatColor.BOLD + "Apply Build - " + buildNumber);
+        super(slot, item, Component.text("Apply Build - " + buildNumber, NamedTextColor.GREEN, TextDecoration.BOLD));
         this.builds = builds;
         this.role = role;
         this.buildNumber = buildNumber;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
@@ -6,7 +6,9 @@ import me.mykindos.betterpvp.champions.champions.skills.SkillManager;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.menu.MenuManager;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -20,7 +22,7 @@ public class ClassSelectionButton extends Button {
 
 
     public ClassSelectionButton(GamerBuilds builds, Role role, SkillManager skillManager, int slot, ItemStack item) {
-        super(slot, item, ChatColor.GREEN.toString() + ChatColor.BOLD + role.getName());
+        super(slot, item, Component.text(role.getName(), NamedTextColor.GREEN, TextDecoration.BOLD));
         this.builds = builds;
         this.role = role;
         this.skillManager = skillManager;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
@@ -1,19 +1,20 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
+import java.util.Optional;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.DeleteBuildEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Optional;
 
 public class DeleteBuildButton extends Button {
 
@@ -22,7 +23,7 @@ public class DeleteBuildButton extends Button {
     private final int buildNumber;
 
     public DeleteBuildButton(GamerBuilds builds, Role role, int buildNumber, int slot) {
-        super(slot, new ItemStack(Material.TNT), ChatColor.GREEN.toString() + ChatColor.BOLD + "Delete Build - " + buildNumber);
+        super(slot, new ItemStack(Material.TNT), Component.text("Delete Build - " + buildNumber, NamedTextColor.GREEN, TextDecoration.BOLD));
         this.builds = builds;
         this.role = role;
         this.buildNumber = buildNumber;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -6,7 +6,9 @@ import me.mykindos.betterpvp.champions.champions.skills.SkillManager;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.menu.MenuManager;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -21,7 +23,7 @@ public class EditBuildButton extends Button {
     private final SkillManager skillManager;
 
     public EditBuildButton(GamerBuilds builds, Role role, int buildNumber, SkillManager skillManager, int slot) {
-        super(slot, new ItemStack(Material.ANVIL), ChatColor.GREEN.toString() + ChatColor.BOLD + "Edit & Save Build - " + buildNumber);
+        super(slot, new ItemStack(Material.ANVIL), Component.text("Edit & Save Build - " + buildNumber, NamedTextColor.GREEN, TextDecoration.BOLD));
         this.builds = builds;
         this.role = role;
         this.buildNumber = buildNumber;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillUpdate
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -20,7 +21,7 @@ public class SkillButton extends Button {
     private final Skill skill;
     private final RoleBuild roleBuild;
 
-    public SkillButton(Skill skill, RoleBuild roleBuild, int slot, ItemStack item, String name, List<String> lore) {
+    public SkillButton(Skill skill, RoleBuild roleBuild, int slot, ItemStack item, Component name, List<Component> lore) {
         super(slot, item, name, lore);
         this.skill = skill;
         this.roleBuild = roleBuild;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/menu/KitButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/menu/KitButton.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.commands.menu;
 
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Button;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -11,7 +13,7 @@ public class KitButton extends Button {
 
     private final Role role;
     public KitButton(int slot, ItemStack item, String name, Role role) {
-        super(slot, item, name);
+        super(slot, item, Component.text(name, NamedTextColor.GREEN));
 
         this.role = role;
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/menu/KitMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/menu/KitMenu.java
@@ -4,7 +4,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.menu.Menu;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -16,10 +15,10 @@ public class KitMenu extends Menu {
         int[] start = new int[]{0, 1, 3, 5, 7, 8};
         int count = 0;
         for (Role role : Role.values()) {
-            addButton(new KitButton(start[count], new ItemStack(role.getHelmet()).clone(), ChatColor.GREEN + role.getName(), role));
-            addButton(new KitButton(start[count] + 9, new ItemStack(role.getChestplate()).clone(), ChatColor.GREEN + role.getName(), role));
-            addButton(new KitButton(start[count] + 18, new ItemStack(role.getLeggings()).clone(), ChatColor.GREEN + role.getName(), role));
-            addButton(new KitButton(start[count] + 27, new ItemStack(role.getBoots()).clone(), ChatColor.GREEN + role.getName(), role));
+            addButton(new KitButton(start[count], new ItemStack(role.getHelmet()).clone(), role.getName(), role));
+            addButton(new KitButton(start[count] + 9, new ItemStack(role.getChestplate()).clone(), role.getName(), role));
+            addButton(new KitButton(start[count] + 18, new ItemStack(role.getLeggings()).clone(), role.getName(), role));
+            addButton(new KitButton(start[count] + 27, new ItemStack(role.getBoots()).clone(), role.getName(), role));
             count++;
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.roles.listeners;
 
 import com.google.inject.Inject;
+import java.util.Optional;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
@@ -20,8 +21,9 @@ import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -32,8 +34,6 @@ import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
-
-import java.util.Optional;
 
 @BPvPListener
 public class RoleListener implements Listener {
@@ -189,7 +189,7 @@ public class RoleListener implements Listener {
         return false;
     }
 
-    public String[] equipMessage(Player player, Role role) {
+    public Component[] equipMessage(Player player, Role role) {
         Optional<GamerBuilds> gamerBuildsOptional = buildManager.getObject(player.getUniqueId().toString());
         if (gamerBuildsOptional.isPresent()) {
             GamerBuilds builds = gamerBuildsOptional.get();
@@ -203,19 +203,18 @@ public class RoleListener implements Listener {
                 String passivea = build.getPassiveA() == null ? "" : build.getPassiveA().getString();
                 String passiveb = build.getPassiveB() == null ? "" : build.getPassiveB().getString();
                 String global = build.getGlobal() == null ? "" : build.getGlobal().getString();
-                return new String[]{
-                        ChatColor.GREEN + "Sword: " + ChatColor.WHITE + sword,
-                        ChatColor.GREEN + "Axe: " + ChatColor.WHITE + axe,
-                        ChatColor.GREEN + "Bow: " + ChatColor.WHITE + bow,
-                        ChatColor.GREEN + "Passive A: " + ChatColor.WHITE + passivea,
-                        ChatColor.GREEN + "Passive B: " + ChatColor.WHITE + passiveb,
-                        ChatColor.GREEN + "Global: " + ChatColor.WHITE + global
+                return new Component[]{
+                        Component.text("Sword: ", NamedTextColor.GREEN).append(Component.text(sword, NamedTextColor.WHITE)),
+                        Component.text("Axe: ", NamedTextColor.GREEN).append(Component.text(axe, NamedTextColor.WHITE)),
+                        Component.text("Bow: ", NamedTextColor.GREEN).append(Component.text(bow, NamedTextColor.WHITE)),
+                        Component.text("Passive A: ", NamedTextColor.GREEN).append(Component.text(passivea, NamedTextColor.WHITE)),
+                        Component.text("Passive B: ", NamedTextColor.GREEN).append(Component.text(passiveb, NamedTextColor.WHITE)),
+                        Component.text("Global: ", NamedTextColor.GREEN).append(Component.text(global, NamedTextColor.WHITE))
                 };
             }
         }
 
-        return new String[]{};
-
+        return new Component[]{};
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillChatListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillChatListener.java
@@ -1,6 +1,9 @@
 package me.mykindos.betterpvp.champions.champions.skills.listeners;
 
 import com.google.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.champions.champions.skills.SkillManager;
 import me.mykindos.betterpvp.champions.properties.ChampionsProperty;
@@ -13,14 +16,11 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-
-import java.util.Map;
-import java.util.Optional;
 
 @BPvPListener
 public class SkillChatListener implements Listener {
@@ -82,10 +82,14 @@ public class SkillChatListener implements Listener {
     }
 
     private Component getDescriptionComponent(Skill skill) {
-        StringBuilder description = new StringBuilder();
-        for (String text : skill.getDescription(1)) {
-            description.append(ChatColor.GRAY).append(text).append("\n");
+        String[] lore = skill.getDescription(1);
+        
+        Component component = Component.empty();
+        for (String str : lore) {
+            component = component.append(MiniMessage.miniMessage().deserialize("<gray>" + str, SkillMenu.TAG_RESOLVER));
+            component = component.append(Component.newline());
         }
-        return Component.text(description.toString());
+        
+        return component;
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.listeners;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Arrays;
+import java.util.Optional;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.BuildSkill;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
@@ -25,7 +27,6 @@ import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -37,10 +38,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.Arrays;
-import java.util.Optional;
-
 
 @Singleton
 @BPvPListener
@@ -235,8 +232,7 @@ public class SkillListener implements Listener {
         ISkill skill = event.getSkill();
 
         if (!skill.isEnabled()) {
-            UtilMessage.message(player, skill.getClassType().getName(), "%s has been disabled by the server.",
-                    ChatColor.GREEN + skill.getName() + ChatColor.GRAY);
+            UtilMessage.simpleMessage(player, skill.getClassType().getName(), "<alt>%s</alt> has been disabled by the server.", skill.getName());
             event.setCancelled(true);
 
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -16,7 +17,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -27,8 +27,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -63,7 +61,7 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
                 "returning you to your original location.",
                 "Cannot be used while Slowed.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -123,9 +121,9 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
             if (!championsManager.getCooldowns().isCooling(player, "Deblink") || force) {
 
                 if (!force) {
-                    UtilMessage.message(player, getClassType().getName(), "You used " + ChatColor.GREEN + "Deblink" + " " + getLevel(player) + ChatColor.GRAY + ".");
+                    UtilMessage.simpleMessage(player, getClassType().getName(), "You used <alt>Deblink " + getLevel(player) + "</alt>.");
                 } else {
-                    UtilMessage.message(player, getClassType().getName(), "The target location was invalid, Blink cooldown has been reduced.");
+                    UtilMessage.simpleMessage(player, getClassType().getName(), "The target location was invalid, Blink cooldown has been reduced.");
                     championsManager.getCooldowns().removeCooldown(player, "Blink", true);
                     championsManager.getCooldowns().add(player, "Blink", 2, true);
                 }
@@ -169,13 +167,12 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
 
 
         if (player.hasPotionEffect(PotionEffectType.SLOW)) {
-            UtilMessage.message(player, getClassType().getName(), "You cannot use " + getName() + " while Slowed.");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "You cannot use " + getName() + " while Slowed.");
             return false;
         }
 
         if (championsManager.getEffects().hasEffect(player, EffectType.STUN)) {
-            UtilMessage.message(player, getClassType().getName(), "You cannot use " + ChatColor.GREEN
-                    + getName() + ChatColor.GRAY + " while stunned.");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "You cannot use <alt>%s</alt> while stunned.", getName());
             return false;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
@@ -62,7 +62,7 @@ public class Flash extends Skill implements InteractSkill, Listener {
                 "Stores up to 4 charges.",
                 "",
                 "Cannot be used while Slowed.",
-                "Recharge: 1 charge per " + ChatColor.GREEN + (timeBetweenCharges - level) + ChatColor.GRAY + " seconds."
+                "Recharge: 1 charge per <val>" + (timeBetweenCharges - level) + "</val> seconds."
         };
     }
 
@@ -113,7 +113,7 @@ public class Flash extends Skill implements InteractSkill, Listener {
 
             if (UtilTime.elapsed(lastRecharge.get(player), (long) ((timeBetweenCharges * 1000L) - (level * 1000L)))) {
                 charges.put(player, Math.min(maxCharges, charge + 1));
-                UtilMessage.message(player, getClassType().getName(), "Flash Charges: " + ChatColor.GREEN + (charge + 1));
+                UtilMessage.simpleMessage(player, getClassType().getName(), "Flash Charges: <alt>" + (charge + 1));
                 lastRecharge.put(player, System.currentTimeMillis());
             }
         }
@@ -166,7 +166,7 @@ public class Flash extends Skill implements InteractSkill, Listener {
             UtilMessage.message(player, getClassType().getName(), "The target location was invalid, You will be refunded a charge shortly.");
             UtilServer.runTaskLater(champions, () -> {
                 charges.put(player, Math.min(maxCharges, charges.get(player) + 1));
-                UtilMessage.message(player, getClassType().getName(), "Flash Charges: " + ChatColor.GREEN + charges.get(player));
+                UtilMessage.simpleMessage(player, getClassType().getName(), "Flash Charges: <alt>" + charges.get(player));
                 lastRecharge.put(player, System.currentTimeMillis());
             }, 20);
 
@@ -185,7 +185,7 @@ public class Flash extends Skill implements InteractSkill, Listener {
 
         if (charges.containsKey(player)) {
             if (charges.get(player) == 0) {
-                UtilMessage.message(player, getClassType().getName(), "You don't have any " + ChatColor.GREEN + getName() + ChatColor.GRAY + " charges.");
+                UtilMessage.simpleMessage(player, getClassType().getName(), "You don't have any <alt>" + getName() + "</alt> charges.");
                 return false;
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
@@ -14,8 +14,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -46,7 +44,7 @@ public class Leap extends Skill implements InteractSkill, CooldownSkill, Listene
                 "Right click with a axe to activate.",
                 "",
                 "You take a great leap",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -65,7 +63,7 @@ public class Leap extends Skill implements InteractSkill, CooldownSkill, Listene
             Vector vec = player.getLocation().getDirection();
             vec.setY(0);
             UtilVelocity.velocity(player, vec, 0.9D, false, 0.0D, 0.8D, 2.0D, true);
-            UtilMessage.message(player, getClassType().getName(), "You used " + ChatColor.GREEN + "Wall Kick" + ChatColor.GRAY + ".");
+            UtilMessage.message(player, getClassType().getName(), "You used <alt>Wall Kick</alt>.");
         }
 
         player.getWorld().spawnEntity(player.getLocation(), EntityType.LLAMA_SPIT);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -11,14 +11,12 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
-
 
 @Singleton
 @BPvPListener
@@ -44,11 +42,11 @@ public class MarkedForDeath extends PrepareArrowSkill {
         return new String[]{
                 "Your next arrow will mark players",
                 "for death, giving them Vulnerability I",
-                "for " + ChatColor.GREEN + (baseDuration + level) + ChatColor.GRAY + " seconds",
+                "for <val>" + (baseDuration + level) + "</val> seconds",
                 "Causing them to take 25% additional damage",
                 "from all targets.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -67,8 +65,7 @@ public class MarkedForDeath extends PrepareArrowSkill {
         if (!(target instanceof Player damagee)) return;
 
         championsManager.getEffects().addEffect(damagee, EffectType.VULNERABILITY, 1, (long) ((baseDuration + level) * 1000L));
-        UtilMessage.message(damagee, getClassType().getName(), "%s hit you with %s",
-                ChatColor.YELLOW + damager.getName() + ChatColor.GRAY, ChatColor.GREEN + getName());
+        UtilMessage.simpleMessage(damagee, getClassType().getName(), "<alt2>%s</alt2> hit you with <alt>%s</alt>.", damager.getName(), getName());
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.bow;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -9,16 +11,12 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 @Singleton
 @BPvPListener
@@ -37,8 +35,11 @@ public class SilencingArrow extends PrepareArrowSkill {
     @Override
     public String[] getDescription(int level) {
 
-        return new String[]{"Your next arrow will silence your", "target for " + ChatColor.GREEN + (3 + level) + ChatColor.GRAY + " seconds.", "Making them unable to use any active skills", "", "Cooldown: " + ChatColor.GREEN + getCooldown(level)
-
+        return new String[]{
+                "Your next arrow will silence your", "target for <val>" + (3 + level) + "</val> seconds.",
+                "Making them unable to use any active skills",
+                "",
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -63,7 +64,7 @@ public class SilencingArrow extends PrepareArrowSkill {
         if (!(target instanceof Player damagee)) return;
         championsManager.getEffects().addEffect(damagee, EffectType.SILENCE, ((3 + level) * 1000L));
         if (championsManager.getEffects().hasEffect(damagee, EffectType.IMMUNETOEFFECTS)) {
-            UtilMessage.message(damager, getClassType().getName(), ChatColor.GREEN + damagee.getName() + ChatColor.GRAY + " is immune to your silence!");
+            UtilMessage.simpleMessage(damager, getClassType().getName(), "<alt>" + damagee.getName() + "</alt> is immune to your silence!");
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -9,7 +9,6 @@ import me.mykindos.betterpvp.champions.champions.skills.types.PrepareArrowSkill;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -39,9 +38,9 @@ public class ToxicArrow extends PrepareArrowSkill {
 
         return new String[]{
                 "Your next arrow will poison your target, and give them",
-                "nausea for " + ChatColor.GREEN + (6 + level) + ChatColor.GRAY + " seconds.",
+                "nausea for <val>" + (6 + level) + "</val> seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
 
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
@@ -1,6 +1,9 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
 
 
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,18 +15,12 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Optional;
-
 
 @Singleton
 @BPvPListener
@@ -45,7 +42,7 @@ public class Backstab extends Skill implements PassiveSkill, Listener {
 
         return new String[]{
                 "Hitting an enemy from behind will increased",
-                "your damage dealt by " + ChatColor.GREEN + (2 + level) + "0%"};
+                "your damage dealt by <val>" + (2 + level) + "0%"};
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Recall.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Recall.java
@@ -52,11 +52,11 @@ public class Recall extends Skill implements ToggleSkill, CooldownSkill, Listene
                 "Drop Sword / Axe to Activate",
                 "",
                 "Teleports you back to where you ",
-                "were located " + ChatColor.GREEN + (1.5 + (level)) + ChatColor.GRAY + " seconds ago",
+                "were located <val>" + (1.5 + (level)) + "</val> seconds ago",
                 "Increases health by 1/4 of the health you had",
-                ChatColor.GREEN.toString() + (1.5 + (level)) + ChatColor.GRAY + " seconds ago",
+                "<val>" + (1.5 + (level)) + "</val> seconds ago",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/RepeatedStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/RepeatedStrikes.java
@@ -1,6 +1,10 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
 
 
+import java.util.HashSet;
+import java.util.WeakHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -11,17 +15,11 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.HashSet;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -47,7 +45,7 @@ public class RepeatedStrikes extends Skill implements PassiveSkill, Listener {
         return new String[]{
                 "Each time you attack, your damage",
                 "increases by 1",
-                "You can get up to " + ChatColor.GREEN + level + ChatColor.GRAY + " bonus damage.",
+                "You can get up to <val>" + level + "</val> bonus damage.",
                 "",
                 "Not attacking for 2 seconds clears",
                 "your bonus damage."};

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ShockingStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ShockingStrikes.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -9,16 +11,12 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 @Singleton
 @BPvPListener
@@ -39,7 +37,7 @@ public class ShockingStrikes extends Skill implements PassiveSkill, Listener {
 
         return new String[]{
                 "Your attacks shock targets for",
-                ChatColor.GREEN.toString() + (level) + ChatColor.GRAY + " second, giving them Slow I",
+                "<val>" + (level) + "</val> second, giving them Slow I",
                 "and Screen-Shake."
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SilencingStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SilencingStrikes.java
@@ -1,6 +1,10 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
 
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -13,17 +17,10 @@ import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.List;
-
 
 @Singleton
 @BPvPListener
@@ -47,7 +44,7 @@ public class SilencingStrikes extends Skill implements PassiveSkill, Listener {
 
         return new String[]{
                 "Hit a player 3 times within 2 seconds",
-                "to silence them for " + ChatColor.GREEN + (level) + ChatColor.GRAY + " seconds."
+                "to silence them for <val>" + (level) + "</val> seconds."
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -1,5 +1,11 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
 
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -16,7 +22,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -28,14 +33,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.WeakHashMap;
-
 
 @Singleton
 @BPvPListener
@@ -141,11 +138,11 @@ public class SmokeBomb extends Skill implements ToggleSkill, CooldownSkill, List
 
         return new String[]{
                 "Instantly vanish before your foes for a",
-                "maximum of " + ChatColor.GREEN + (3 + level) + ChatColor.GRAY + " seconds",
+                "maximum of <val>" + (3 + level) + "</val> seconds",
                 "hitting an enemy or using abilities",
                 " will make you reappear",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -1,6 +1,8 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.sword;
 
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequipEvent;
@@ -12,7 +14,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,10 +21,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 
 @Singleton
 @BPvPListener
@@ -47,9 +44,9 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener 
         return new String[]{
                 "Right click with a sword to activate.",
                 "",
-                "Your next hit blinds the target for " + ChatColor.GREEN + (durationPerLevel * level) + ChatColor.GRAY + " seconds.",
+                "Your next hit blinds the target for <val>" + (durationPerLevel * level) + "</val> seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -88,8 +85,8 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener 
         if (active.contains(damager.getUniqueId())) {
             e.setReason("Concussion");
             damagee.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, (int) (level * durationPerLevel) * 20, 0));
-            UtilMessage.message(damager, getName(), "You gave " + ChatColor.GREEN + damagee.getName() + ChatColor.GRAY + " a concussion.");
-            UtilMessage.message(damagee, getName(), ChatColor.GREEN + damager.getName() + ChatColor.GRAY + " gave you a concussion.");
+            UtilMessage.simpleMessage(damager, getName(), "You gave <alt>" + damagee.getName() + "</alt> a concussion.");
+            UtilMessage.simpleMessage(damagee, getName(), "<alt>" + damager.getName() + "</alt> gave you a concussion.");
             active.remove(damager.getUniqueId());
         }
 
@@ -99,7 +96,7 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener 
     @Override
     public boolean canUse(Player player) {
         if (active.contains(player.getUniqueId())) {
-            UtilMessage.message(player, getClassType().getName(), ChatColor.GREEN + getName() + ChatColor.GRAY + " is already active.");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "<alt>" + getName() + "</alt> is already active.");
             return false;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -17,7 +20,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -28,10 +30,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.UUID;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -62,7 +60,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
                 "",
                 "2 second internal cooldown.",
                 "",
-                "Energy / second: " + ChatColor.GREEN + (10 * getEnergy(level))};
+                "Energy / second: <val>" + (10 * getEnergy(level))};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
@@ -1,6 +1,11 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.sword;
 
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,18 +17,11 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -47,12 +45,12 @@ public class ExcessiveForce extends Skill implements InteractSkill, CooldownSkil
         return new String[]{
                 "Right click with a Sword to activate.",
                 "",
-                "For the next " + ChatColor.GREEN + (3 + ((level - 1) * 0.5)) + ChatColor.GRAY + " seconds",
+                "For the next <val>" + (3 + ((level - 1) * 0.5)) + "</val> seconds",
                 "your attacks deal knockback to enemies",
                 "",
                 "Does not ignore anti-knockback abilities.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)};
+                "Cooldown: <val>" + getCooldown(level)};
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.sword;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.roles.events.RoleChangeEvent;
@@ -13,16 +15,12 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.scheduler.BukkitRunnable;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 @Singleton
 @BPvPListener
@@ -44,10 +42,10 @@ public class Sever extends PrepareSkill implements CooldownSkill, Listener {
         return new String[]{
                 "Right click with a sword to activate",
                 "",
-                "Your next hit applies a " + ChatColor.GREEN + (level) + ChatColor.GRAY + " second bleed",
+                "Your next hit applies a <val>" + (level) + "</val> second bleed",
                 "dealing 1 heart per second",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -81,8 +79,8 @@ public class Sever extends PrepareSkill implements CooldownSkill, Listener {
 
         int level = getLevel(player);
         runSever(player, damagee, level);
-        UtilMessage.message(player, getClassType().getName(), "You severed " + ChatColor.GREEN + damagee.getName() + ChatColor.GRAY + ".");
-        UtilMessage.message(damagee, getClassType().getName(), "You have been severed by " + ChatColor.GREEN + player.getName() + ChatColor.GRAY + ".");
+        UtilMessage.simpleMessage(player, getClassType().getName(), "You severed <alt>" + damagee.getName() + "</alt>.");
+        UtilMessage.simpleMessage(damagee, getClassType().getName(), "You have been severed by <alt>" + player.getName() + "</alt>.");
         active.remove(player.getUniqueId());
 
         championsManager.getCooldowns().removeCooldown(player, getName(), true);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SeismicSlam.java
@@ -65,7 +65,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
                 "Jump and slam the ground, knocking up all opponents",
                 "within a small radius",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SpiritOfTheBear.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SpiritOfTheBear.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
@@ -43,10 +42,10 @@ public class SpiritOfTheBear extends Skill implements InteractSkill, CooldownSki
                 "Right click with a axe to activate.",
                 "",
                 "Call upon the spirit of the bear",
-                "granting all allies within " + ChatColor.GREEN + (radius + (level)) + ChatColor.GRAY + " blocks",
+                "granting all allies within <val>" + (radius + (level)) + "</val> blocks",
                 "Resistance II for 5 seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SpiritOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/SpiritOfTheWolf.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
@@ -42,10 +41,10 @@ public class SpiritOfTheWolf extends Skill implements InteractSkill, CooldownSki
                 "Right click with a axe to activate.",
                 "",
                 "Call upon the spirit of the wolf",
-                "granting all allies within " + ChatColor.GREEN + (radius + (level)) + ChatColor.GRAY + " blocks",
-                "Speed II for " + ChatColor.GREEN + duration + ChatColor.GRAY + " seconds.",
+                "granting all allies within <val>" + (radius + (level)) + "</val> blocks",
+                "Speed II for <val>" + duration + "</val> seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/StrengthInNumbers.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/StrengthInNumbers.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
@@ -41,13 +40,13 @@ public class StrengthInNumbers extends Skill implements InteractSkill, CooldownS
         return new String[]{
                 "Right click with a axe to activate.",
                 "",
-                "Grant all allies within " + ChatColor.GREEN + radius + ChatColor.GRAY + " blocks",
-                "Strength I for " + ChatColor.GREEN + (duration + level),
+                "Grant all allies within <val>" + radius + "</val> blocks",
+                "Strength I for <val>" + (duration + level),
                 "seconds.",
                 "",
                 "This does not give you the buff.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
 
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/axe/ThreateningShout.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
@@ -41,11 +40,11 @@ public class ThreateningShout extends Skill implements InteractSkill, CooldownSk
                 "Right click with a axe to activate.",
                 "",
                 "Release a roar, which frightens all enemies",
-                "within " + ChatColor.GREEN + (radius + level) + ChatColor.GRAY + " blocks",
-                "and grants them Vulnerability for " + ChatColor.GREEN + (duration + level),
+                "within <val>" + (radius + level) + "</val> blocks",
+                "and grants them Vulnerability for <val>" + (duration + level),
                 "seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Bloodlust.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Bloodlust.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.gladiator.passiv
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,15 +15,12 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -49,7 +47,7 @@ public class Bloodlust extends Skill implements PassiveSkill {
         return new String[]{
                 "When an enemy dies within 15 blocks,",
                 "you go into a Bloodlust, receiving",
-                "Speed 1 and Strength 1 for " + ChatColor.GREEN + (duration + level) + ChatColor.GRAY + " seconds.",
+                "Speed 1 and Strength 1 for <val>" + (duration + level) + "</val> seconds.",
                 "",
                 "Bloodlust can stack up to 3 times,",
                 "boosting the level of Speed and Strength."};
@@ -78,7 +76,7 @@ public class Bloodlust extends Skill implements PassiveSkill {
                 }
                 championsManager.getEffects().addEffect(target, EffectType.STRENGTH, tempStr, (long) ((duration + level) * 1000L));
                 target.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, (int) ((duration + level) * 20), tempStr));
-                UtilMessage.message(target, getClassType().getName(), "You entered bloodlust at level: " + ChatColor.YELLOW + tempStr + ChatColor.GRAY + ".");
+                UtilMessage.simpleMessage(target, getClassType().getName(), "You entered bloodlust at level: <alt2>" + tempStr + "</alt2>.");
                 target.getWorld().playSound(target.getLocation(), Sound.ENTITY_ZOMBIFIED_PIGLIN_ANGRY, 2.0F, 0.6F);
             }
 
@@ -98,7 +96,7 @@ public class Bloodlust extends Skill implements PassiveSkill {
         if (System.currentTimeMillis() > time.get(player)) {
             int tempStr = str.get(player);
             str.remove(player);
-            UtilMessage.message(player, getClassType().getName(), "Your bloodlust has ended at level: " + ChatColor.YELLOW + tempStr + ChatColor.GRAY + ".");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "Your bloodlust has ended at level: <alt2>" + tempStr + "</alt2>.");
             time.remove(player);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Colossus.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Colossus.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomKnockbackEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -36,7 +35,8 @@ public class Colossus extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "You take " + ChatColor.GREEN + (reductionPerLevel * level) + "% " + ChatColor.GRAY + "reduced knockback."};
+                "You take <val>" + (reductionPerLevel * level) + "%</val> reduced knockback."
+        };
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/CripplingBlow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/CripplingBlow.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -40,7 +39,7 @@ public class CripplingBlow extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Enemies you hit with an axe don't get knocked back and receive",
-                "Slow I for " + ChatColor.GREEN + (slowDuration + (level * 0.5)) + ChatColor.GRAY + " seconds,"
+                "Slow I for <val>" + (slowDuration + (level * 0.5)) + "</val> seconds,"
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Overwhelm.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Overwhelm.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -38,7 +37,7 @@ public class Overwhelm extends Skill implements PassiveSkill {
                 "You deal 1 bonus damage for every",
                 "2 more health you have than your",
                 "target. You can deal a maximum of",
-                ChatColor.GREEN + String.format("%.1f", (0.0 + (level * 0.5))) + ChatColor.GRAY + " bonus damage."
+                "<val>" + String.format("%.1f", (0.0 + (level * 0.5))) + "</val> bonus damage."
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Resistance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Resistance.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -33,8 +32,8 @@ public class Resistance extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "You take " + ChatColor.GREEN + (level * 15) + ChatColor.GRAY + "% less damage",
-                "but you deal " + ChatColor.GREEN + (level * 15) + ChatColor.GRAY + "% less as well"
+                "You take <val>" + (level * 15) + "</val>% less damage",
+                "but you deal <val>" + (level * 15) + "</val>% less as well"
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Stampede.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/passives/Stampede.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.gladiator.passiv
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,7 +15,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,8 +22,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -50,7 +48,7 @@ public class Stampede extends Skill implements PassiveSkill {
         return new String[]{
                 "You slowly build up speed as you",
                 "sprint. You gain a level of Speed",
-                "for every " + ChatColor.GREEN + (7 - level) + ChatColor.GRAY + " seconds, up to a max",
+                "for every <val>" + (7 - level) + "</val> seconds, up to a max",
                 "of Speed II.",
                 "",
                 "Attacking during stampede deals",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/BattleTaunt.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/BattleTaunt.java
@@ -45,10 +45,10 @@ public class BattleTaunt extends ChannelSkill implements InteractSkill, Cooldown
 
         return new String[]{"Hold Block with a sword to Channel.",
                 "",
-                "While channelling, any enemies within " + ChatColor.GREEN + (2 + level) + ChatColor.GRAY + " blocks",
+                "While channelling, any enemies within <val>" + (2 + level) + "</val> blocks",
                 "are slowly pulled in towards you",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)};
+                "Energy / Second: <val>" + getEnergy(level)};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/FleshHook.java
@@ -57,7 +57,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
                 "Fire a hook at an enemy, pulling them towards you",
                 "Higher Charge time = faster hook",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level),
+                "Cooldown: <val>" + getCooldown(level),
         };
     }
 
@@ -93,7 +93,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
                     if (UtilTime.elapsed(data.getLastCharge(), 400L)) {
                         if (data.getCharge() < data.getMaxCharge()) {
                             data.addCharge();
-                            UtilMessage.message(player, getClassType().getName(), getName() + ": " + ChatColor.YELLOW + "+ " + data.getCharge() + "% Strength");
+                            UtilMessage.simpleMessage(player, getClassType().getName(), getName() + ": <alt2>+ " + data.getCharge() + "% Strength");
                             player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.4F, 1.0F + 0.05F * data.getCharge());
                         }
                     }
@@ -120,7 +120,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
                         }
 
 
-                        UtilMessage.message(player, getClassType().getName(), "You used " + ChatColor.GREEN + getName() + ChatColor.GRAY + ".");
+                        UtilMessage.simpleMessage(player, getClassType().getName(), "You used <alt>" + getName() + "</alt>.");
                         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 2.0F, 0.8F);
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/gladiator/sword/Takedown.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.gladiator.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,7 +17,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -22,10 +24,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -50,13 +48,13 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
                 "Right click with a sword to activate.",
                 "",
                 "Hurl yourself towards an opponent.",
-                "If you collide with them, you " + ChatColor.WHITE + "both",
+                "If you collide with them, you <white>both",
                 "take damage and receive Slow 4",
-                "for " + ChatColor.GREEN + (1 + level) + ChatColor.GRAY + " seconds.",
+                "for <val>" + (1 + level) + "</val> seconds.",
                 "",
                 "Cannot be used while grounded.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -126,12 +124,12 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
 
 
     public void doTakedown(Player player, Player target) {
-        UtilMessage.message(player, getClassType().getName(), "You hit " + ChatColor.GREEN + target.getName() + ChatColor.GRAY + " with " + ChatColor.GREEN + getName());
+        UtilMessage.simpleMessage(player, getClassType().getName(), "You hit <alt>" + target.getName() + "</alt> with <alt>" + getName());
 
         UtilDamage.doCustomDamage(new CustomDamageEvent(target, player, null, DamageCause.CUSTOM, 10, false, "Takedown"));
 
 
-        UtilMessage.message(target, getClassType().getName(), ChatColor.GREEN + player.getName() + ChatColor.GRAY + " hit you with " + ChatColor.GREEN + getName());
+        UtilMessage.simpleMessage(target, getClassType().getName(), "<alt>" + player.getName() + "</alt> hit you with <alt>" + getName());
         UtilDamage.doCustomDamage(new CustomDamageEvent(player, target, null, DamageCause.CUSTOM, 10, false, "Takedown Recoil"));
 
         PotionEffect pot = new PotionEffect(PotionEffectType.SLOW, (int) (1 + (getLevel(player) * 0.5)) * 20, 2);
@@ -143,7 +141,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     public boolean canUse(Player p) {
 
         if (UtilBlock.isGrounded(p)) {
-            UtilMessage.message(p, getClassType().getName(), "You cannot use " + ChatColor.GREEN + getName() + ChatColor.GRAY + " while grounded.");
+            UtilMessage.simpleMessage(p, getClassType().getName(), "You cannot use <alt>" + getName() + "</alt> while grounded.");
             return false;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/BreakFall.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/BreakFall.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
@@ -35,7 +34,7 @@ public class BreakFall extends Skill implements PassiveSkill {
         return new String[]{
                 "You roll when you hit the ground.",
                 "",
-                "Fall damage is reduced by " + ChatColor.GREEN + (5 + level)};
+                "Fall damage is reduced by <val>" + (5 + level)};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/FastRecovery.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/FastRecovery.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.champions.energy.events.RegenerateEnergyEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 
@@ -36,7 +35,7 @@ public class FastRecovery extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Increase your energy regeneration speed,",
-                "by " + ChatColor.GREEN + (percentagePerLevel * level) + "%",
+                "by <val>" + (percentagePerLevel * level) + "%",
                 "",
                 "Does not work with legendary items equipped."
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/Swim.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/Swim.java
@@ -14,7 +14,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -42,7 +41,7 @@ public class Swim extends Skill implements PassiveSkill, EnergySkill {
         return new String[]{
                 "Tap crouch to Swim forwards.",
                 "",
-                "Energy: " + ChatColor.GREEN + getEnergy(level)};
+                "Energy: <val>" + getEnergy(level)};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
@@ -1,5 +1,9 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.knight.axe;
 
+import java.util.HashMap;
+import java.util.UUID;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -13,7 +17,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilSound;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
@@ -25,11 +28,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.HashMap;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -57,7 +55,7 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
                 "",
                 "While charging, you take no knockback.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 
@@ -102,8 +100,9 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 1.5F, 0.5F);
 
                 if (event.getDamagee() instanceof Player damaged) {
-                    UtilMessage.message(damaged, getClassType().getName(), ChatColor.YELLOW + damager.getName() + ChatColor.GRAY + " hit you with " + ChatColor.GREEN + getName() + ChatColor.GRAY + ".");
-                    UtilMessage.message(damager, getClassType().getName(), "You hit " + ChatColor.YELLOW + damaged.getName() + ChatColor.GRAY + " with " + ChatColor.GREEN + getName() + ChatColor.GRAY + ".");
+                    UtilMessage.simpleMessage(damaged, getClassType().getName(), "<yellow>" + damager.getName() + "</yellow> hit you with <green>" + getName() + "</green>.");
+                    UtilMessage.simpleMessage(damager, getClassType().getName(), "You hit <yellow>" + damaged.getName() + "</yellow> with <green>" + getName() + "</green>.");
+          
                     running.remove(damager.getUniqueId());
                     return;
                 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/HoldPosition.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/HoldPosition.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -42,9 +41,9 @@ public class HoldPosition extends Skill implements InteractSkill, CooldownSkill,
         return new String[]{
                 "Hold your position, gaining",
                 "Protection II, Slow III and no",
-                "knockback for " + ChatColor.GREEN + (5 + ((level - 1) * 0.5)) + ChatColor.GRAY + " seconds.",
+                "knockback for <val>" + (5 + ((level - 1) * 0.5)) + "</val> seconds.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/PowerChop.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/PowerChop.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -16,16 +17,12 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.WeakHashMap;
-
 
 @Singleton
 @BPvPListener
@@ -52,12 +49,12 @@ public class PowerChop extends PrepareSkill implements CooldownSkill {
         return new String[]{
                 "Put more strength into your",
                 "next axe attack, causing it",
-                "to deal " + ChatColor.GREEN + (Math.max(1, (level + 2))) + ChatColor.GRAY + " bonus damage.",
+                "to deal <val>" + (Math.max(1, (level + 2))) + "</val> bonus damage.",
                 "",
                 "Attack must be made within",
-                ChatColor.GREEN.toString() + timeToHit + ChatColor.GRAY + " seconds of being used.",
+                "<val>" + timeToHit + "</val> seconds of being used.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
@@ -15,7 +15,6 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -43,7 +42,7 @@ public class Cleave extends Skill implements PassiveSkill, Listener {
         return new String[]{
                 "Your axe attacks cleave onto nearby targets and deal damage.",
                 "",
-                "Distance: " + ChatColor.GREEN + (baseDistance + level) + ChatColor.GRAY,
+                "Distance: <val>" + (baseDistance + level),
                 "",
                 "Only applies to axes."
         };

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Deflection.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Deflection.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -15,14 +17,10 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.Optional;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -50,7 +48,7 @@ public class Deflection extends Skill implements PassiveSkill {
         return new String[]{
                 "Prepare to deflect incoming attacks",
                 "You gain 1 charge every 3 seconds.",
-                "You can store a maximum of " + ChatColor.GREEN + (level) + ChatColor.GRAY + " charges",
+                "You can store a maximum of <val>" + (level) + "</val> charges",
                 "",
                 "When attacked, the damage you take is",
                 "reduced by the number of your charges",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Fortitude.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Fortitude.java
@@ -3,6 +3,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,14 +16,10 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-
-import java.util.HashSet;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -46,7 +44,7 @@ public class Fortitude extends Skill implements PassiveSkill, Listener {
 
         return new String[]{
                 "After taking damage, you slowly",
-                "regenerate up to " + ChatColor.GREEN + (3 + (level - 1)) + ChatColor.GRAY + " health, at a",
+                "regenerate up to <val>" + (3 + (level - 1)) + "</val> health, at a",
                 "rate of 1 health per 1 seconds.",
                 "",
                 "This does not stack, and is reset",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Fury.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Fury.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,7 +33,7 @@ public class Fury extends Skill implements PassiveSkill, Listener {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "Your attacks deal a bonus " + ChatColor.GREEN + (level * 0.5) + ChatColor.GRAY + " damage"
+                "Your attacks deal a bonus <val>" + (level * 0.5) + "</val> damage"
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Sacrifice.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Sacrifice.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,9 +33,10 @@ public class Sacrifice extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         double percentage = ((level * 0.08) * 100);
-        return new String[]{"Deal an extra " + ChatColor.GREEN + percentage + "%" + ChatColor.GRAY + " damage",
+        return new String[]{
+                "Deal an extra <val>" + percentage + "%" + "</val> damage",
                 "But you now also take",
-                ChatColor.GREEN.toString() + percentage + "%" + ChatColor.GRAY + " extra damage from melee attacks"
+                "<val>" + percentage + "%" + "</val> extra damage from melee attacks"
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -17,13 +18,10 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -50,7 +48,7 @@ public class Swordsmanship extends Skill implements PassiveSkill {
         return new String[]{
                 "Prepare a powerful sword attack,",
                 "You gain 1 charge every 3 seconds.",
-                "You can store a maximum of " + ChatColor.GREEN + (level) + ChatColor.GRAY + " charges",
+                "You can store a maximum of <val>" + (level) + "</val> charges",
                 "",
                 "When you attack, your damage is",
                 "increased by 0.5 for each charge you have",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Thorns.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Thorns.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,14 +13,11 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -41,7 +39,7 @@ public class Thorns extends Skill implements PassiveSkill, Listener {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "Enemies take " + ChatColor.GREEN + (level) + ChatColor.GRAY + " damage when",
+                "Enemies take <val>" + level + "</val> damage when",
                 "they hit you using a melee attack."
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -20,7 +21,6 @@ import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -28,8 +28,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -60,7 +58,7 @@ public class DefensiveStance extends ChannelSkill implements InteractSkill, Ener
                 "Players who attack you receive damage,",
                 "and get knocked back.",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)};
+                "Energy / Second: <val>" + getEnergy(level)};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
@@ -15,7 +15,6 @@ import me.mykindos.betterpvp.core.components.champions.events.PlayerUseSkillEven
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -24,7 +23,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
-
 
 @Singleton
 @BPvPListener
@@ -46,11 +44,11 @@ public class HiltSmash extends Skill implements CooldownSkill, Listener {
                 "Right click with a sword to activate.",
                 "",
                 "Smash the hilt of your sword into",
-                "your opponent, dealing " + ChatColor.GREEN + (3 + (level)) + ChatColor.GRAY + " damage",
-                "and applying shock for " + ChatColor.GREEN + (level / 2) + ChatColor.GRAY + " seconds.",
-                "Silences enemy for " + ChatColor.GREEN + (level / 2) + ChatColor.GRAY + " seconds",
+                "your opponent, dealing <val>" + (3 + (level)) + "</val> damage",
+                "and applying shock for <val>" + (level / 2) + "</val> seconds.",
+                "Silences enemy for <val>" + (level / 2) + "</val> seconds",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -16,7 +17,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
@@ -28,8 +28,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
 
 @Singleton
 @BPvPListener
@@ -55,10 +53,10 @@ public class Riposte extends PrepareSkill implements CooldownSkill, Listener {
         return new String[]{
                 "Right click with a sword to activate.",
                 "",
-                "Reduce all melee damage by 75% for " + ChatColor.GREEN + (1 + (level * 0.5)) + ChatColor.GRAY + " seconds.",
+                "Reduce all melee damage by 75% for <val>" + (1 + (level * 0.5)) + "</val> seconds.",
                 "Impervious to knockback while active.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/DefensiveAura.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
@@ -40,10 +39,10 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
         return new String[]{
                 "Right click with a axe to Activate",
                 "",
-                "Gives you, and all allies within " + ChatColor.GREEN + (6 + level) + ChatColor.GRAY + " blocks",
+                "Gives you, and all allies within <val>" + (6 + level) + "</val> blocks",
                 "2 bonus hearts",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/LightningOrb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/LightningOrb.java
@@ -18,7 +18,6 @@ import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Item;
@@ -56,10 +55,10 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
 
         return new String[]{
                 "Launch a lightning orb. Directly hitting a player",
-                "will strike all enemies within " + ChatColor.GREEN + (3 + (level * 0.5)) + ChatColor.GRAY + " blocks",
+                "will strike all enemies within <val>" + (3 + (level * 0.5)) + "</val> blocks",
                 "with lightning, giving them Slowness II for 4 seconds.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/MoltenBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/MoltenBlast.java
@@ -3,6 +3,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -15,7 +18,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LargeFireball;
@@ -27,10 +29,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 
 @Singleton
 @BPvPListener
@@ -59,9 +57,9 @@ public class MoltenBlast extends Skill implements InteractSkill, CooldownSkill, 
                 "",
                 "Shoot a large fireball that deals",
                 "area of effect damage, and igniting any players hit",
-                "for " + ChatColor.GREEN + ((level * 0.5)) + ChatColor.GRAY + " seconds",
+                "for <val>" + (level * 0.5) + "</val> seconds",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/Rupture.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/axe/Rupture.java
@@ -1,5 +1,9 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.axe;
 
+import java.util.ArrayList;
+import java.util.WeakHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -13,7 +17,6 @@ import me.mykindos.betterpvp.core.framework.customtypes.CustomArmourStand;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -32,11 +35,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -65,7 +63,7 @@ public class Rupture extends Skill implements Listener, InteractSkill, CooldownS
                 "you are facing, damaging, knocking up",
                 "and slowing any enemies hit.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/ArcticArmour.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/ArcticArmour.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.passives
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.types.ActiveToggleSkill;
@@ -17,7 +20,6 @@ import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -25,10 +27,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -57,12 +55,12 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
                 "Drop Axe/Sword to Toggle.",
                 "",
                 "Create a freezing area around you",
-                "in a " + ChatColor.GREEN + (minRadius + level) + ChatColor.GRAY + " Block radius. Allies inside",
+                "in a <val>" + (minRadius + level) + "</val> Block radius. Allies inside",
                 "this area receive Protection I.",
                 "Enemies inside this area receive",
                 "Slowness I",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)
+                "Energy / Second: <val>" + getEnergy(level)
         };
     }
 
@@ -158,10 +156,10 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
     public void toggle(Player player, int level) {
         if (active.contains(player.getUniqueId())) {
             active.remove(player.getUniqueId());
-            UtilMessage.message(player, getClassType().getName(), "Arctic Armour: " + ChatColor.RED + "Off");
+            UtilMessage.message(player, getClassType().getName(), "Arctic Armour: <red>Off");
         } else {
             active.add(player.getUniqueId());
-            UtilMessage.message(player, getClassType().getName(), "Arctic Armour: " + ChatColor.GREEN + "On");
+            UtilMessage.message(player, getClassType().getName(), "Arctic Armour: <green>On");
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/HolyLight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/HolyLight.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -37,7 +36,7 @@ public class HolyLight extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Create an aura that gives", "yourself and all allies within",
-                ChatColor.GREEN.toString() + (8 + level) + ChatColor.GRAY + " blocks extra regeneration"};
+                "<val>" + (8 + level) + "</val> blocks extra regeneration"};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/Immolate.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/Immolate.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.passives
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.types.ActiveToggleSkill;
@@ -15,7 +17,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Item;
@@ -26,9 +27,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -58,7 +56,7 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill {
                 "You leave a trail of fire, which",
                 "burns players that go near it.",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)
+                "Energy / Second: <val>" + getEnergy(level)
 
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/MagmaBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/MagmaBlade.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -36,7 +35,7 @@ public class MagmaBlade extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Your sword scorches opponents,",
-                "dealing an additional " + ChatColor.GREEN + (level) + ChatColor.GRAY + " damage",
+                "dealing an additional <val>" + (level) + "</val> damage",
                 "to players who are on fire."};
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/NullBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/NullBlade.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
@@ -34,7 +33,7 @@ public class NullBlade extends Skill implements PassiveSkill, EnergySkill {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "Your sword sucks " + ChatColor.GREEN + getEnergy(level) + ChatColor.GRAY + " energy from",
+                "Your sword sucks <val>" + getEnergy(level) + "</val> energy from",
                 "opponents with every attack"
         };
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/RootingAxe.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/RootingAxe.java
@@ -14,7 +14,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -50,7 +49,7 @@ public class RootingAxe extends Skill implements PassiveSkill, CooldownSkill {
                 "the earth disrupting their movement,",
                 "and stops them from jumping for 2 seconds",
                 "",
-                "Internal Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Internal Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/Void.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/passives/Void.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.passives
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.types.ActiveToggleSkill;
@@ -13,16 +15,12 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.Iterator;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -50,7 +48,7 @@ public class Void extends ActiveToggleSkill implements EnergySkill {
                 "Reduces incoming damage by 5, but",
                 "burns 20 of your energy",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)
+                "Energy / Second: <val>" + getEnergy(level)
         };
     }
 
@@ -127,11 +125,11 @@ public class Void extends ActiveToggleSkill implements EnergySkill {
     public void toggle(Player player, int level) {
         if (active.contains(player.getUniqueId())) {
             active.remove(player.getUniqueId());
-            UtilMessage.message(player, getClassType().getName(), "Void: " + ChatColor.RED + "Off");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "Void: <red>Off");
         } else {
             active.add(player.getUniqueId());
             if (championsManager.getEnergy().use(player, "Void", 5, false)) {
-                UtilMessage.message(player, getClassType().getName(), "Void: " + ChatColor.GREEN + "On");
+                UtilMessage.simpleMessage(player, getClassType().getName(), "Void: <green>On");
             }
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Blizzard.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Blizzard.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -17,7 +18,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -27,8 +27,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -56,7 +54,7 @@ public class Blizzard extends ChannelSkill implements InteractSkill, EnergySkill
                 "While channeling, release a blizzard",
                 "that slows anyone hit for 2 seconds.",
                 "",
-                "Energy: " + ChatColor.GREEN + getEnergy(level)
+                "Energy: <val>" + getEnergy(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Cyclone.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Cyclone.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -41,9 +40,9 @@ public class Cyclone extends Skill implements InteractSkill, CooldownSkill {
                 "Right click with a sword to activate.",
                 "",
                 "Pulls all enemies within",
-                ChatColor.GREEN.toString() + (minimumDistance + level) + ChatColor.GRAY + " blocks towards you",
+                "<val>" + (minimumDistance + level) + "</val> blocks towards you",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/GlacialPrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/GlacialPrison.java
@@ -16,7 +16,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Item;
@@ -56,7 +55,7 @@ public class GlacialPrison extends Skill implements InteractSkill, CooldownSkill
                 "Launches an orb, trapping any players",
                 "within 5 blocks of it in a prison of ice for 5 seconds",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Inferno.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Inferno.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -21,7 +22,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.ArmorStand;
@@ -33,8 +33,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -63,7 +61,7 @@ public class Inferno extends ChannelSkill implements InteractSkill, EnergySkill 
                 "You spray fire at high speed,",
                 "igniting anything it hits.",
                 "",
-                "Energy / Second: " + ChatColor.GREEN + getEnergy(level)
+                "Energy / Second: <val>" + getEnergy(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Pestilence.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Pestilence.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.UUID;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -19,7 +21,6 @@ import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -29,9 +30,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.HashMap;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -62,7 +60,7 @@ public class Pestilence extends PrepareSkill implements CooldownSkill {
                 "nearby enemies. While enemies are infected,",
                 "they deal 20% reduced damage",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Polymorph.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Polymorph.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
 import me.libraryaddict.disguise.DisguiseAPI;
 import me.libraryaddict.disguise.disguisetypes.DisguiseType;
 import me.libraryaddict.disguise.disguisetypes.MobDisguise;
@@ -19,7 +22,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -29,10 +31,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -60,12 +58,12 @@ public class Polymorph extends PrepareSkill implements CooldownSkill {
                 "Right click with a sword to prepare.",
                 "",
                 "The next player you hit, is polymorphed",
-                "into a sheep for " + ChatColor.GREEN + polymorphDuration + ChatColor.GRAY + " seconds.",
+                "into a sheep for <val>" + polymorphDuration + "</val> seconds.",
                 "",
                 "While a player is polymorphed, they cannot deal",
                 "or take any damage.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Swarm.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/paladin/sword/Swarm.java
@@ -3,6 +3,11 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.paladin.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.ListIterator;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -23,7 +28,6 @@ import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Bat;
@@ -33,12 +37,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.ListIterator;
-import java.util.Map.Entry;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -69,7 +67,7 @@ public class Swarm extends ChannelSkill implements InteractSkill, EnergySkill, L
                 "which damage, and knockback",
                 "any enemies they come in contact with",
                 "",
-                "Energy: " + ChatColor.GREEN + getEnergy(level)
+                "Energy: <val>" + getEnergy(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -15,7 +18,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -26,10 +28,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -56,11 +54,11 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
                 "Right click with a axe to activate.",
                 "",
                 "Sprint with great agility, gaining",
-                "Speed I for " + ChatColor.GREEN + (baseDuration + level) + ChatColor.GRAY + " seconds.",
+                "Speed I for <val>" + (baseDuration + level) + "</val> seconds.",
                 "You also take 60% reduced damage while active.",
                 "Agility ends if you interact",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,15 +15,12 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -49,10 +47,10 @@ public class WolvesFury extends Skill implements InteractSkill, CooldownSkill, L
                 "Right click with a axe to activate.",
                 "",
                 "Summon the power of the wolf, gaining",
-                "Strength 1 for " + ChatColor.GREEN + (baseDuration + level) + ChatColor.GRAY + " seconds, and giving",
+                "Strength 1 for <val>" + (baseDuration + level) + "</val> seconds, and giving",
                 "no knockback on your attacks.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/IncendiaryShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/IncendiaryShot.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -39,9 +38,9 @@ public class IncendiaryShot extends PrepareArrowSkill {
                 "Left click to activate.",
                 "",
                 "Shoot an ignited arrow",
-                "burning anyone hit for " + ChatColor.GREEN + (level * 1.5) + ChatColor.GRAY + " seconds",
+                "burning anyone hit for <val>" + (level * 1.5) + "</val> seconds",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -41,11 +40,11 @@ public class LevitatingShot extends PrepareArrowSkill {
                 "Left click to activate.",
                 "",
                 "Your next arrow is tipped with mysterious magic,",
-                "causing the next target you hit to receive Levitation for " + ChatColor.GREEN + (3.5 + (level * .5)) + ChatColor.GRAY + " seconds.",
+                "causing the next target you hit to receive Levitation for <val>" + (3.5 + (level * .5)) + "</val> seconds.",
                 "",
                 "Players with levitation are unable to use abilities.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.bow;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.*;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -19,7 +20,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Arrow;
@@ -31,8 +31,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.meta.CrossbowMeta;
-
-import java.util.*;
 
 @Singleton
 @BPvPListener
@@ -60,7 +58,7 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
                 "Draw back harder on your bow, giving",
                 "2 bonus damage per 0.8 seconds",
                 "",
-                "Maximum Damage: " + ChatColor.GREEN + (2 + level)
+                "Maximum Damage: <val>" + (2 + level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/PinDown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/PinDown.java
@@ -38,9 +38,9 @@ public class PinDown extends PrepareArrowSkill {
         return new String[]{
                 "Left click with a bow to instantly fire",
                 "an arrow, which gives anybody hit ",
-                "Slowness IV for " + net.md_5.bungee.api.ChatColor.GREEN + (level * 1.5) + net.md_5.bungee.api.ChatColor.GRAY + " seconds.",
+                "Slowness IV for <val>" + (level * 1.5) + "</val> seconds.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -45,7 +44,7 @@ public class RopedArrow extends PrepareArrowSkill {
                 "Your next arrow will pull you",
                 "in after it hits",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StunningShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StunningShot.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -40,9 +39,9 @@ public class StunningShot extends PrepareArrowSkill {
                 "Left click to activate.",
                 "",
                 "Shoot an arrow",
-                "stunning anyone hit for " + ChatColor.GREEN + String.format("%.2f", (level * 0.40)) + ChatColor.GRAY + " seconds",
+                "stunning anyone hit for <val>" + String.format("%.2f", (level * 0.40)) + "</val> seconds",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Volley.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Volley.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -44,7 +43,7 @@ public class Volley extends PrepareArrowSkill {
                 "Your next shot is instant, and shoots",
                 "a volley of arrows in the direction you are facing",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level)
+                "Cooldown: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Entangle.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Entangle.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -36,9 +35,10 @@ public class Entangle extends Skill implements PassiveSkill {
 
     @Override
     public String[] getDescription(int level) {
-
-        return new String[]{"Your arrows apply Slowness 2",
-                "to any damageable target for " + ChatColor.GREEN + (baseDuration + (level * 0.5)) + ChatColor.GRAY + " seconds"};
+        return new String[] {
+                "Your arrows apply Slowness 2",
+                "to any damageable target for <val>" + (baseDuration + (level * 0.5)) + "</val> seconds"
+        };
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HuntersThrill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HuntersThrill.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,14 +13,11 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -43,10 +41,10 @@ public class HuntersThrill extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "For each consecutive hit within " + ChatColor.GREEN + (maxTimeBetweenShots + level) + ChatColor.GRAY + " seconds of each other",
+                "For each consecutive hit within <val>" + (maxTimeBetweenShots + level) + "</val> seconds of each other",
                 "you gain increased movement speed",
                 "",
-                "Max consecutive hits: " + ChatColor.GREEN + maxConsecutiveHits
+                "Max consecutive hits: <val>" + maxConsecutiveHits
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -15,7 +17,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Arrow;
@@ -24,9 +25,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -54,7 +52,7 @@ public class Longshot extends Skill implements PassiveSkill {
         return new String[]{
                 "Shoot an arrow that gains additional",
                 "damage the further the target hit is",
-                "Caps out at " + ChatColor.GREEN + (baseDamage + level) + ChatColor.GRAY + " damage",
+                "Caps out at <val>" + (baseDamage + level) + "</val> damage",
                 "Cannot be used in own territory"};
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -34,7 +33,9 @@ public class Precision extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
 
-        return new String[]{"Your arrows deal " + ChatColor.GREEN + (level * 0.5) + ChatColor.GRAY + " bonus damage on hit"};
+        return new String[] {
+                "Your arrows deal <val>" + (level * 0.5) + "</val> bonus damage on hit"
+        };
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,12 +13,9 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import net.md_5.bungee.api.ChatColor;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -41,9 +39,9 @@ public class Sharpshooter extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "You deal " +  ChatColor.GREEN.toString() + (level * 0.75) + ChatColor.GRAY + " extra damage for each consecutive hit",
+                "You deal <val>" + (level * 0.75) + "</val> extra damage for each consecutive hit",
                 "",
-                "Maximum consecutive hits: " + ChatColor.GREEN + maxConsecutiveHits
+                "Maximum consecutive hits: <val>" + maxConsecutiveHits
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/VitalitySpores.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/VitalitySpores.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -14,13 +15,10 @@ import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.Optional;
 
 @Singleton
 @BPvPListener
@@ -42,7 +40,7 @@ public class VitalitySpores extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "After " + ChatColor.GREEN + (baseDuration - level) + ChatColor.GRAY + " seconds of not taking damage,",
+                "After <val>" + (baseDuration - level) + "</val> seconds of not taking damage,",
                 "forest spores surround you, giving",
                 "you Regeneration 1 for 6 seconds.",
                 "",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Disengage.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Disengage.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
@@ -15,7 +16,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -24,8 +24,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -53,13 +51,13 @@ public class Disengage extends PrepareSkill implements CooldownSkill {
                 "Right click with a sword to prepare",
                 "",
                 "If you are attacked",
-                "within " + ChatColor.GREEN + ((level * 0.5)) + ChatColor.GRAY + " seconds you successfully disengage",
+                "within <val>" + (level * 0.5) + "</val> seconds you successfully disengage",
                 "",
                 "If successful, you leap backwards",
                 "and your attacker receives Slow 4",
-                "for " + ChatColor.GREEN + (baseSlowDuration + level) + ChatColor.GRAY + " seconds.",
+                "for <val>" + (baseSlowDuration + level) + "</val> seconds.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)};
+                "Recharge: <val>" + getCooldown(level)};
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.UUID;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -18,7 +20,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -28,9 +29,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.PlayerDeathEvent;
-
-import java.util.HashMap;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -57,13 +55,13 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
         return new String[]{
                 "Right click with a axe to activate.",
                 "",
-                "Sacrifice " + ChatColor.GREEN + UtilMath.round(100 - (0.50 + (level * 0.05)) * 100, 2) + "%" + ChatColor.GRAY + " of your health to grant",
+                "Sacrifice <val>" + UtilMath.round(100 - (0.50 + (level * 0.05)) * 100, 2) + "%</val> of your health to grant",
                 "yourself and all nearby allies a barrier which reduces",
                 "the damage of the next 3 incoming attacks by 30%",
                 "",
                 "Barrier lasts up to 1 minute total, and does not stack.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -42,10 +41,10 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, Li
         return new String[]{
                 "Right click with a axe to activate.",
                 "",
-                "Sacrifice " + ChatColor.GREEN + UtilMath.round(100 - ((0.50 + (level * 0.05)) * 100), 2) + "%" + ChatColor.GRAY + " of your health to grant",
-                "yourself Speed III for " + ChatColor.GREEN + duration + ChatColor.GRAY + " seconds.",
+                "Sacrifice <val>" + UtilMath.round(100 - ((0.50 + (level * 0.05)) * 100), 2) + "%" + "</val> of your health to grant",
+                "yourself Speed III for <val>" + duration + "</val> seconds.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -17,7 +17,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -45,13 +44,13 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
         return new String[]{
                 "Right click with a axe to activate.",
                 "",
-                "Sacrifice " + ChatColor.GREEN + UtilMath.round(100 - ((0.50 + (level * 0.05)) * 100), 2) + "%" + ChatColor.GRAY + " of your health to purge",
-                "all negative effects from yourself and allies within " + ChatColor.GREEN + (distance + level) + ChatColor.GRAY + " blocks.",
+                "Sacrifice <val>" + UtilMath.round(100 - ((0.50 + (level * 0.05)) * 100), 2) + "%" + "</val> of your health to purge",
+                "all negative effects from yourself and allies within <val>" + (distance + level) + "</val> blocks.",
                 "",
                 "You and your allies also receive an immunity against",
-                "negative effects for " + ChatColor.GREEN + (duration + (level / 2)) + ChatColor.GRAY + " seconds.",
+                "negative effects for <val>" + (duration + (level / 2)) + "</val> seconds.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 
@@ -97,7 +96,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
 
         for (Player ally : UtilPlayer.getNearbyAllies(player, player.getLocation(), (distance + level))) {
             championsManager.getEffects().addEffect(ally, EffectType.IMMUNETOEFFECTS, (long) ((duration + (level / 2)) * 1000L));
-            UtilMessage.message(ally, "Cleanse", "You were cleansed of negative by " + ChatColor.GREEN + player.getName());
+            UtilMessage.simpleMessage(ally, "Cleanse", "You were cleansed of negative by <alt>" + player.getName());
 
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -17,7 +20,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -26,10 +28,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ListIterator;
 
 @Singleton
 @BPvPListener
@@ -57,11 +55,11 @@ public class TormentedSoil extends Skill implements InteractSkill, CooldownSkill
                 "Right click with a axe to activate.",
                 "",
                 "Corrupt the earth around you, creating a ring that",
-                "debuffs enemies within it for " + ChatColor.GREEN + duration + ChatColor.GRAY + " seconds.",
+                "debuffs enemies within it for <val>" + duration + "</val> seconds.",
                 "Player within the ring take 33% more damage.",
                 "",
-                "Range: " + ChatColor.GREEN + (radius + (level / 2)) + ChatColor.GRAY + " blocks.",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Range: <val>" + (radius + (level / 2)) + "</val> blocks.",
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Bloodthirst.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Bloodthirst.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilSound;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -37,7 +36,7 @@ public class Bloodthirst extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
         return new String[]{
                 "Your senses are heightened, ",
-                "allowing you to detect nearby enemies below " + ChatColor.GREEN + (25 + (5 * level)) + "% " + ChatColor.GRAY + "health.",
+                "allowing you to detect nearby enemies below <val>" + (25 + (5 * level)) + "%</val> health.",
                 "",
                 "While running towards weak enemies, you receive Speed I."
         };

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Frailty.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Frailty.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.passives
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequipEvent;
@@ -16,17 +19,12 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -47,8 +45,8 @@ public class Frailty extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "Nearby enemies that fall below " + ChatColor.GREEN + (40 + ((level - 1) * 10)) + "%" + ChatColor.GRAY + " health",
-                "take " + ChatColor.GREEN + (20 + ((level - 1) * 5)) + "%" + ChatColor.GRAY + " more damage from your melee attacks."
+                "Nearby enemies that fall below <val>" + (40 + ((level - 1) * 10)) + "%" + "</val> health",
+                "take <val>" + (20 + ((level - 1) * 5)) + "%" + "</val> more damage from your melee attacks."
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Impotence.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Impotence.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -33,7 +32,7 @@ public class Impotence extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "For each enemy within " + ChatColor.GREEN + (3 + level) + ChatColor.GRAY + " blocks",
+                "For each enemy within <val>" + (3 + level) + "</val> blocks",
                 "you take reduced damage from all sources, at a maximum of 3 players.",
                 "",
                 "Damage Reduction:",

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Siphon.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Siphon.java
@@ -14,7 +14,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
@@ -40,10 +39,10 @@ public class Siphon extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "Siphon energy from all enemies within " + ChatColor.GREEN + (4 + level) + ChatColor.GRAY + " blocks,",
+                "Siphon energy from all enemies within <val>" + (4 + level) + "</val> blocks,",
                 "Granting you Speed II and sometimes a small amount of health.",
                 "",
-                "Energy siphoned per second: " + ChatColor.GREEN + 5
+                "Energy siphoned per second: <val>" + 5
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/SoulHarvest.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/SoulHarvest.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.passives
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -12,7 +15,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
@@ -20,10 +22,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -49,7 +47,7 @@ public class SoulHarvest extends Skill implements PassiveSkill {
                 "Collected souls give bursts of speed and regeneration.",
                 "Souls are visible by Warlocks only",
                 "",
-                "Buff duration: " + ChatColor.GREEN + ((40 + (level * 20)) / 20) + ChatColor.GRAY + " seconds."
+                "Buff duration: <val>" + ((40 + (level * 20)) / 20) + "</val> seconds."
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Grasp.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Grasp.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.*;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -15,7 +16,6 @@ import me.mykindos.betterpvp.core.framework.customtypes.CustomArmourStand;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -32,8 +32,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
-
-import java.util.*;
 
 @Singleton
 @BPvPListener
@@ -61,9 +59,9 @@ public class Grasp extends Skill implements InteractSkill, CooldownSkill, Listen
                 "Create a wall of skulls that closes in on you from a distance",
                 "and drags all enemies with it.",
                 "",
-                "Cooldown: " + ChatColor.GREEN + getCooldown(level),
-                "Max range: " + ChatColor.GREEN + (10 + ((level * 10) / 2)),
-                "Damage: " + ChatColor.GREEN + (1 + (level - 1))
+                "Cooldown: <val>" + getCooldown(level),
+                "Max range: <val>" + (10 + ((level * 10) / 2)),
+                "Damage: <val>" + (1 + (level - 1))
 
         };
     }
@@ -217,7 +215,7 @@ public class Grasp extends Skill implements InteractSkill, CooldownSkill, Listen
         int level = getLevel(player);
         Block block = player.getTargetBlock(null, (20 + (level * 10) / 2));
         if (block.getLocation().distance(player.getLocation()) < 3) {
-            UtilMessage.message(player, getClassType().getName(), "You cannot use " + ChatColor.GREEN + getName() + ChatColor.GRAY + " this close.");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "You cannot use <alt>" + getName() + "</alt> this close.");
             return false;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Leech.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Leech.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -19,7 +21,6 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.LivingEntity;
@@ -30,9 +31,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Singleton
 @BPvPListener
@@ -62,7 +60,7 @@ public class Leech extends PrepareSkill implements CooldownSkill {
                 "Linked targets have 1 health leeched per second.",
                 "All leeched health is given to the caster.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Wreath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Wreath.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.warlock.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequipEvent;
@@ -14,7 +15,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -33,8 +33,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -59,9 +57,9 @@ public class Wreath extends PrepareSkill implements CooldownSkill {
                 "Right click with a sword to prepare.",
                 "",
                 "Your next 3 attacks will release a barrage of teeth",
-                "that deal " + ChatColor.GREEN + String.format("%.2f", (2 + (level / 1.5))) + ChatColor.GRAY + " damage and slow their target.",
+                "that deal <val>" + String.format("%.2f", (2 + (level / 1.5))) + "</val> damage and slow their target.",
                 "",
-                "Recharge: " + ChatColor.GREEN + getCooldown(level)
+                "Recharge: <val>" + getCooldown(level)
         };
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
@@ -1,5 +1,9 @@
 package me.mykindos.betterpvp.champions.champions.skills.types;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
@@ -9,7 +13,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
@@ -19,11 +22,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
 
 public abstract class PrepareArrowSkill extends PrepareSkill implements CooldownSkill {
 
@@ -108,8 +106,7 @@ public abstract class PrepareArrowSkill extends PrepareSkill implements Cooldown
                 if (cooldown != null) {
                     if (cooldown.isCancellable()) {
                         championsManager.getCooldowns().removeCooldown(player, getName(), true);
-                        UtilMessage.message(player, getClassType().getName(), "%s was cancelled.",
-                                ChatColor.GREEN + getName() + " " + level + ChatColor.GRAY);
+                        UtilMessage.simpleMessage(player, getClassType().getName(), "<alt>%s</alt> was cancelled.", getName() + " " + level);
                         it.remove();
                     }
                 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareSkill.java
@@ -1,19 +1,16 @@
 package me.mykindos.betterpvp.champions.champions.skills.types;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequipEvent;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-
 
 public abstract class PrepareSkill extends Skill implements InteractSkill, Listener {
 
@@ -33,8 +30,7 @@ public abstract class PrepareSkill extends Skill implements InteractSkill, Liste
     @Override
     public boolean canUse(Player player) {
         if (active.contains(player.getUniqueId())) {
-            UtilMessage.message(player, getClassType().getName(), "You have already prepared %s.",
-                    ChatColor.GREEN + getName() + ChatColor.GRAY);
+            UtilMessage.simpleMessage(player, getClassType().getName(), "You have already prepared <alt>%s</alt>.", getName());
             return false;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/energy/EnergyHandler.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/energy/EnergyHandler.java
@@ -7,7 +7,6 @@ import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
@@ -39,7 +38,7 @@ public class EnergyHandler {
 
         if (amount > getEnergy(player)) {
             if (inform) {
-                UtilMessage.message(player, "Energy", "You are too exhausted to use " + ChatColor.GREEN + ability + ChatColor.GRAY + ".");
+                UtilMessage.simpleMessage(player, "Energy", "You are too exhausted to use <green>" + ability + "</green>.");
                 player.getWorld().playEffect(player.getLocation(), Effect.SMOKE, 1);
             }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.clans.clans;
 
+import java.util.*;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.clans.events.ClanPropertyUpdateEvent;
@@ -16,13 +17,12 @@ import me.mykindos.betterpvp.core.properties.PropertyContainer;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.*;
 
 @Slf4j
 @Data
@@ -169,7 +169,7 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
         return "";
     }
 
-    public String getSimpleDominanceString(IClan clan) {
+    public Component getSimpleDominanceString(IClan clan) {
         Optional<ClanEnemy> enemyOptional = getEnemy(clan);
         Optional<ClanEnemy> theirEnemyOptional = clan.getEnemy(this);
         if (enemyOptional.isPresent() && theirEnemyOptional.isPresent()) {
@@ -178,16 +178,16 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
             ClanEnemy theirEnemy = theirEnemyOptional.get();
 
             if (theirEnemy.getDominance() == 0 && enemy.getDominance() == 0) {
-                return ChatColor.WHITE + " 0";
+                return Component.text(" 0", NamedTextColor.WHITE);
             }
             if (theirEnemy.getDominance() > 0) {
-                return ChatColor.GREEN + " " + theirEnemy.getDominance() + "%";
+                return Component.text(" " + theirEnemy.getDominance() + "%", NamedTextColor.GREEN);
             } else {
-                return ChatColor.DARK_RED + " " + enemy.getDominance() + "%";
+                return Component.text(" " + enemy.getDominance() + "%", NamedTextColor.RED);
             }
 
         }
-        return "";
+        return Component.empty();
     }
 
     /**

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.clans.clans;
 
 import lombok.Getter;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.minecraft.world.level.material.MapColor;
 import org.bukkit.ChatColor;
 
@@ -27,8 +29,12 @@ public enum ClanRelation {
     }
 
 
-    public String getPrimary(boolean bold) {
-        return primary.toString() + ChatColor.BOLD;
+    public Style getPrimary(boolean bold) {
+        final Style style = Style.style(primary);
+        if (bold) {
+            style.decorate(TextDecoration.BOLD);
+        }
+        return style;
     }
 
     public ChatColor getPrimaryAsChatColor(){

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
@@ -30,9 +30,9 @@ public enum ClanRelation {
 
 
     public Style getPrimary(boolean bold) {
-        final Style style = Style.style(primary);
+        Style style = Style.style(primary);
         if (bold) {
-            style.decorate(TextDecoration.BOLD);
+            style = style.decorate(TextDecoration.BOLD);
         }
         return style;
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/chatcommands/AllyChatCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/chatcommands/AllyChatCommand.java
@@ -2,16 +2,16 @@ package me.mykindos.betterpvp.clans.clans.commands.chatcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 public class AllyChatCommand extends Command {
@@ -48,8 +48,9 @@ public class AllyChatCommand extends Command {
 
             gamer.saveProperty(GamerProperty.ALLY_CHAT, allyChatEnabled);
             gamer.saveProperty(GamerProperty.CLAN_CHAT, false);
-            UtilMessage.message(player, "Command", "Ally Chat: "
-                    + (allyChatEnabled ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled"));
+
+            Component result = Component.text((allyChatEnabled ? "enabled" : "disabled"), (allyChatEnabled ? NamedTextColor.GREEN : NamedTextColor.RED));
+            UtilMessage.simpleMessage(player, "Command", Component.text("Ally Chat: ").append(result));
         }
     }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/chatcommands/ClanChatCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/chatcommands/ClanChatCommand.java
@@ -2,16 +2,16 @@ package me.mykindos.betterpvp.clans.clans.commands.chatcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 public class ClanChatCommand extends Command {
@@ -48,8 +48,9 @@ public class ClanChatCommand extends Command {
 
             gamer.saveProperty(GamerProperty.CLAN_CHAT, clanChatEnabled);
             gamer.saveProperty(GamerProperty.ALLY_CHAT, false);
-            UtilMessage.message(player, "Command", "Clan Chat: "
-                    + (clanChatEnabled ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled"));
+
+            Component result = Component.text((clanChatEnabled ? "enabled" : "disabled"), (clanChatEnabled ? NamedTextColor.GREEN : NamedTextColor.RED));
+            UtilMessage.simpleMessage(player, "Command", Component.text("Clan Chat: ").append(result));
         }
     }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
@@ -14,13 +15,10 @@ import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 @SubCommand(ClanCommand.class)
@@ -74,8 +72,7 @@ public class ClaimSubCommand extends ClanSubCommand {
             if (locationClan.equals(clan)) {
                 UtilMessage.message(player, "Clans", "Your clan already owns this territory");
             } else {
-                UtilMessage.message(player, "Clans", "This territory is owned by " + ChatColor.YELLOW + "Clan "
-                        + locationClan.getName() + ChatColor.GRAY + ".");
+                UtilMessage.message(player, "Clans", "This territory is owned by <alt2>Clan " + locationClan.getName() + "</alt2>.");
             }
             return;
         }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/DisbandClanSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/DisbandClanSubCommand.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
@@ -15,11 +16,8 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.slf4j.MDC;
-
-import java.util.Optional;
 
 @Slf4j
 @Singleton
@@ -60,8 +58,7 @@ public class DisbandClanSubCommand extends ClanSubCommand {
             }
 
             if (System.currentTimeMillis() < clan.getLastTntedTime()) {
-                UtilMessage.message(player, "Clans", "You cannot disband your clan for "
-                        + ChatColor.GREEN + UtilTime.getTime(clan.getLastTntedTime() - System.currentTimeMillis(), UtilTime.TimeUnit.BEST, 1));
+                UtilMessage.simpleMessage(player, "Clans", "You cannot disband your clan for <alt>" + UtilTime.getTime(clan.getLastTntedTime() - System.currentTimeMillis(), UtilTime.TimeUnit.BEST, 1));
                 return;
             }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/InviteSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/InviteSubCommand.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
@@ -15,10 +16,7 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 @SubCommand(ClanCommand.class)
@@ -70,8 +68,7 @@ public class InviteSubCommand extends ClanSubCommand {
 
         Optional<Clan> targetClan = clanManager.getClanByPlayer(target);
         if(targetClan.isPresent()) {
-            UtilMessage.message(player, "Clans", ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " is apart of "
-                    + ChatColor.YELLOW + "Clan " + targetClan.get().getName() + ChatColor.GRAY + ".");
+            UtilMessage.simpleMessage(player, "Clans", "<alt2>" + target.getName() + "</alt2> is apart of <alt2>Clan " + targetClan.get().getName() + "</alt2>.");
             return;
         }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/KickSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/KickSubCommand.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
@@ -15,10 +16,7 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 @SubCommand(ClanCommand.class)
@@ -91,7 +89,7 @@ public class KickSubCommand extends ClanSubCommand {
                 UtilServer.callEvent(new ClanKickMemberEvent(player, clan, target));
 
             } else {
-                UtilMessage.message(player, "Clans", ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " is not in your clan");
+                UtilMessage.simpleMessage(player, "Clans", "<alt2>" + target.getName() + "</alt2> is not in your clan");
             }
 
         }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/LeaveSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/LeaveSubCommand.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
@@ -15,10 +16,7 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-
-import java.util.Optional;
 
 @Singleton
 @SubCommand(ClanCommand.class)
@@ -59,7 +57,7 @@ public class LeaveSubCommand extends ClanSubCommand {
                 ClanMember leader = leaderOptional.get();
                 if (leader.getUuid().equals(player.getUniqueId().toString())) {
                     if (clan.getMembers().size() > 1) {
-                        UtilMessage.message(player, "Clans", "You must pass on " + ChatColor.GREEN + "Leadership" + ChatColor.GRAY + " before leaving.");
+                        UtilMessage.message(player, "Clans", "You must pass on <alt>Leadership</alt> before leaving.");
                         return;
                     } else if (clan.getMembers().size() == 1) {
                         UtilServer.callEvent(new ClanDisbandEvent(player, clan));
@@ -71,8 +69,7 @@ public class LeaveSubCommand extends ClanSubCommand {
         }
 
         if (System.currentTimeMillis() < clan.getLastTntedTime()) {
-            UtilMessage.message(player, "Clans", "You cannot leave your clan for "
-                    + ChatColor.GREEN + UtilTime.getTime(clan.getLastTntedTime() - System.currentTimeMillis(), UtilTime.TimeUnit.BEST, 1));
+            UtilMessage.message(player, "Clans", "You cannot leave your clan for <alt>" + UtilTime.getTime(clan.getLastTntedTime() - System.currentTimeMillis(), UtilTime.TimeUnit.BEST, 1));
             return;
         }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
@@ -1,6 +1,8 @@
 package me.mykindos.betterpvp.clans.clans.listeners;
 
 import com.google.inject.Inject;
+import java.util.Optional;
+import java.util.UUID;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
@@ -26,15 +28,13 @@ import me.mykindos.betterpvp.core.utilities.UtilWorld;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @BPvPListener
 public class ClanEventListener extends ClanListener {
@@ -78,8 +78,7 @@ public class ClanEventListener extends ClanListener {
         clan.getTerritory().add(new ClanTerritory(chunkString));
         clanManager.getRepository().saveClanTerritory(clan, chunkString);
 
-        UtilMessage.message(player, "Clans", "You claimed Territory " + ChatColor.YELLOW
-                + UtilWorld.chunkToPrettyString(chunk) + ChatColor.GRAY + ".");
+        UtilMessage.simpleMessage(player, "Clans", "You claimed Territory <yellow>" + UtilWorld.chunkToPrettyString(chunk) + "</yellow>.");
 
         clan.messageClan(String.format("<yellow>%s<gray> claimed territory <yellow>%s<gray>.", player.getName(),
                 UtilWorld.chunkToPrettyString(chunk)), player.getUniqueId(), true);
@@ -97,8 +96,7 @@ public class ClanEventListener extends ClanListener {
 
         String chunkString = UtilWorld.chunkToFile(chunk);
 
-        UtilMessage.message(player, "Clans", "You unclaimed territory " + ChatColor.YELLOW
-                + UtilWorld.chunkToPrettyString(chunk) + ChatColor.GRAY + ".");
+        UtilMessage.simpleMessage(player, "Clans", "You unclaimed territory <alt2>" + UtilWorld.chunkToPrettyString(chunk) + "</alt2>.");
 
         targetClan.messageClan(String.format("<yellow>%s<gray> unclaimed territory <yellow>%s<gray>.", player.getName(),
                         UtilWorld.chunkToPrettyString(chunk)), player.getUniqueId(), true);
@@ -154,8 +152,8 @@ public class ClanEventListener extends ClanListener {
         clanManager.getRepository().delete(clan);
         clanManager.getObjects().remove(clan.getName());
 
-        UtilMessage.broadcast("Clans", ChatColor.YELLOW + event.getPlayer().getName() + ChatColor.GRAY + " disbanded "
-                + ChatColor.YELLOW + "Clan " + clan.getName() + ChatColor.GRAY + ".");
+        UtilMessage.broadcast("Clans", "<alt2>" + event.getPlayer().getName() + "</alt2> disbanded <alt2>Clan " + clan.getName() + "</alt2>.");
+        UtilMessage.broadcast("Clans", "<alt2>Clan " + clan.getName() + "</alt2> has been disbanded.");
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -167,18 +165,16 @@ public class ClanEventListener extends ClanListener {
         Player target = event.getTarget();
 
 
-        UtilMessage.message(player, "Clans", "You invited " + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " to join your Clan.");
-        clan.messageClan(String.format("<yellow>%s<gray> invited <yellow>%s<gray> to join your Clan.", player.getName(), target.getName()),
-                player.getUniqueId(), true);
+        UtilMessage.simpleMessage(player, "Clans", "You invited <alt2>" + target.getName() + "</alt2> to join your Clan.");
+        
+        clan.messageClan(String.format("<yellow>%s<gray> invited <yellow>%s<gray> to join your Clan.", player.getName(), target.getName()), player.getUniqueId(), true);
 
-        UtilMessage.message(target, "Clans", ChatColor.YELLOW + player.getName() + ChatColor.GRAY + " invited you to join " + ChatColor.YELLOW
-                + "Clan " + clan.getName() + ChatColor.GRAY + ".");
+        UtilMessage.simpleMessage(target, "Clans", "<alt2>" + player.getName() + "</alt2> invited you to join <alt2>Clan " + clan.getName() + "</alt2>.");
 
-        Component inviteMessage = Component.text(ChatColor.GOLD.toString() + ChatColor.UNDERLINE + "Click Here")
+        Component inviteMessage = Component.text("Click Here", NamedTextColor.GOLD, TextDecoration.UNDERLINED)
                 .clickEvent(ClickEvent.runCommand("/c join " + clan.getName()))
-                .append(Component.text(ChatColor.GRAY + " or type '"
-                        + ChatColor.YELLOW + "/c join " + clan.getName() + ChatColor.GRAY + "'" + ChatColor.GRAY + " to accept!"));
-        UtilMessage.message(target, "Clans", inviteMessage);
+                .append(UtilMessage.deserialize(" or type '<alt2>/c join" + clan.getName() + "</alt2>' to accept!"));
+        UtilMessage.simpleMessage(target, "Clans", inviteMessage);
 
         Gamer targetGamer = gamerManager.getObject(target.getUniqueId().toString()).orElseThrow(() -> new NoSuchGamerException(target.getName()));
         inviteHandler.createInvite(clan, targetGamer, "Invite", 20);
@@ -195,13 +191,12 @@ public class ClanEventListener extends ClanListener {
 
         if (!targetGamer.getClient().isAdministrating()) {
             if (!inviteHandler.isInvited(targetGamer, clan, "Invite")) {
-                UtilMessage.message(player, "Clans", "You are not invited to " + ChatColor.YELLOW + "Clan "
-                        + clan.getName() + ChatColor.GRAY + ".");
+                UtilMessage.simpleMessage(player, "Clans", "You are not invited to <alt2>Clan " + clan.getName() + "</alt2>.");
                 return;
             }
 
             if (clan.getSquadCount() >= maxClanMembers) {
-                UtilMessage.message(player, "Clans", ChatColor.YELLOW + "Clan " + clan.getName() + ChatColor.GRAY + " has too many members or allies");
+                UtilMessage.simpleMessage(player, "Clans", "<alt2>Clan " + clan.getName() + "</alt2> has too many members or allies");
                 return;
             }
         }
@@ -215,7 +210,7 @@ public class ClanEventListener extends ClanListener {
         inviteHandler.removeInvite(targetGamer, clan, "Invite");
 
         clan.messageClan(String.format("<yellow>%s<gray> has joined your Clan.", player.getName()), player.getUniqueId(), true);
-        UtilMessage.message(player, "Clans", "You joined " + ChatColor.YELLOW + "Clan " + clan.getName() + ChatColor.GRAY + ".");
+        UtilMessage.simpleMessage(player, "Clans", "You joined <alt2>Clan " + clan.getName() + "</alt2>.");
 
     }
 
@@ -233,7 +228,7 @@ public class ClanEventListener extends ClanListener {
             clanManager.getRepository().deleteClanMember(clan, clanMember);
             clan.getMembers().remove(clanMember);
 
-            UtilMessage.message(player, "Clans", "You left " + ChatColor.YELLOW + "Clan " + clan.getName() + ChatColor.GRAY + ".");
+            UtilMessage.simpleMessage(player, "Clans", "You left <alt2>Clan " + clan.getName() + "</alt2>.");
             clan.messageClan(String.format("<yellow>%s<gray> left your Clan.", player.getName()), player.getUniqueId(), true);
         }
 
@@ -254,12 +249,12 @@ public class ClanEventListener extends ClanListener {
             clanManager.getRepository().deleteClanMember(clan, clanMember);
             clan.getMembers().remove(clanMember);
 
-            UtilMessage.message(player, "Clans", "You kicked " + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + ".");
+            UtilMessage.simpleMessage(player, "Clans", "You kicked <alt2>" + target.getName() + "</alt2>.");
             clan.messageClan(String.format("<yellow>%s<gray> was kicked from your Clan.", player.getName()), player.getUniqueId(), true);
 
             Player targetPlayer = Bukkit.getPlayer(target.getName());
             if (targetPlayer != null) {
-                UtilMessage.message(targetPlayer, "Clans", "You were kicked from " + ChatColor.YELLOW + clan.getName());
+                UtilMessage.simpleMessage(targetPlayer, "Clans", "You were kicked from <alt2>" + clan.getName());
             }
         }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansChatListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansChatListener.java
@@ -82,7 +82,7 @@ public class ClansChatListener extends ClanListener {
             if (allyChat) {
                 event.cancel("Player has ally chat enabled");
 
-                String message = "dark_green" + playerName + " <green>" + PlainTextComponentSerializer.plainText().serialize(event.getMessage());
+                String message = "<dark_green>" + playerName + " <green>" + PlainTextComponentSerializer.plainText().serialize(event.getMessage());
 
                 clan.getAlliances().forEach(alliance -> {
                     alliance.getClan().messageClan(message, null, false);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/map/listeners/MapListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/map/listeners/MapListener.java
@@ -1,6 +1,10 @@
 package me.mykindos.betterpvp.clans.clans.map.listeners;
 
 import com.google.inject.Inject;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
@@ -21,9 +25,10 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilWorld;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.world.level.material.MapColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -43,11 +48,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 @BPvPListener
 public class MapListener implements Listener {
@@ -443,8 +443,9 @@ public class MapListener implements Listener {
 
     }
 
-    private String createZoomBar(MapSettings.Scale scale) {
-        return ChatColor.WHITE + "Zoom: " + ChatColor.GREEN + (1 << scale.getValue()) + "x";
+    private Component createZoomBar(MapSettings.Scale scale) {
+        return Component.text("Zoom: ", NamedTextColor.WHITE)
+                .append(Component.text((1 << scale.getValue()) + "x", NamedTextColor.GREEN));
     }
 
     private MapColor getColourForClan(Clan playerClan, Clan otherClan) {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/scoreboards/ClansNameScoreboardListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/scoreboards/ClansNameScoreboardListener.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.clans.scoreboards;
 
 import com.google.inject.Inject;
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.ClanRelation;
@@ -9,14 +10,11 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
-
-import java.util.Optional;
 
 @BPvPListener
 public class ClansNameScoreboardListener implements Listener {
@@ -62,7 +60,7 @@ public class ClansNameScoreboardListener implements Listener {
         if (noTeam == null) {
             noTeam = scoreboard.registerNewTeam("None");
             noTeam.color(NamedTextColor.YELLOW);
-            noTeam.prefix(Component.text(ChatColor.YELLOW.toString()));
+            noTeam.prefix(Component.text("", NamedTextColor.YELLOW));
         }
         if (!noTeam.hasEntry(name)) {
             noTeam.addEntry(name);
@@ -109,36 +107,36 @@ public class ClansNameScoreboardListener implements Listener {
             ClanRelation relation = clanManager.getRelation(playerClan, targetClan);
             String prefix = targetClan.getName();
             if (relation == ClanRelation.ALLY) {
-                team.prefix(Component.text(ChatColor.DARK_GREEN + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.DARK_GREEN));
                 team.color(NamedTextColor.GREEN);
                 team.suffix(Component.text(""));
             } else if (relation == ClanRelation.ALLY_TRUST) {
-                team.prefix(Component.text(ChatColor.DARK_GREEN + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.DARK_GREEN));
                 team.color(NamedTextColor.DARK_GREEN);
                 team.suffix(Component.text(""));
             } else if (relation == ClanRelation.ENEMY) {
-                team.prefix(Component.text(ChatColor.DARK_RED + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.DARK_RED));
                 team.color(NamedTextColor.RED);
-                team.suffix(Component.text(targetClan.getSimpleDominanceString(playerClan)));
+                team.suffix(targetClan.getSimpleDominanceString(playerClan));
             } else if (relation == ClanRelation.PILLAGE) {
-                team.prefix(Component.text(ChatColor.DARK_PURPLE + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.DARK_PURPLE));
                 team.color(NamedTextColor.LIGHT_PURPLE);
                 team.suffix(Component.text(""));
             } else if (relation == ClanRelation.SELF) {
-                team.prefix(Component.text(ChatColor.DARK_AQUA + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.DARK_AQUA));
                 team.color(NamedTextColor.AQUA);
                 team.suffix(Component.text(""));
             } else {
-                team.prefix(Component.text(ChatColor.GOLD + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.GOLD));
                 team.color(NamedTextColor.YELLOW);
                 team.suffix(Component.text(""));
             }
         } else {
             if (playerClan == null && targetClan != null) {
                 String prefix = targetClan.getName();
-                team.prefix(Component.text(ChatColor.GOLD + prefix + " "));
+                team.prefix(Component.text(prefix + " ", NamedTextColor.GOLD));
             } else {
-                team.prefix(Component.text(ChatColor.YELLOW + ""));
+                team.prefix(Component.text("", NamedTextColor.YELLOW));
             }
             team.color(NamedTextColor.YELLOW);
             team.suffix(Component.text(""));

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/settings/buttons/ClansCategoryButton.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/settings/buttons/ClansCategoryButton.java
@@ -1,27 +1,30 @@
 package me.mykindos.betterpvp.clans.settings.buttons;
 
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.settings.menus.ClansSettingsMenu;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.menu.Button;
 import me.mykindos.betterpvp.core.menu.MenuManager;
 import me.mykindos.betterpvp.core.utilities.UtilSound;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Optional;
-
 public class ClansCategoryButton extends Button {
 
     private final GamerManager gamerManager;
 
     public ClansCategoryButton(GamerManager gamerManager) {
-        super(1, new ItemStack(Material.DIAMOND_HELMET), ChatColor.GREEN.toString() + ChatColor.BOLD + "Clans Settings",
-                ChatColor.GRAY + "View generic settings related to the clans gamemode");
+        super(1,
+                new ItemStack(Material.DIAMOND_HELMET),
+                Component.text("Clans Settings", NamedTextColor.GREEN, TextDecoration.BOLD),
+                Component.text("View generic settings related to the clans gamemode", NamedTextColor.GRAY));
         this.gamerManager = gamerManager;
     }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/settings/buttons/ClansSettingButton.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/settings/buttons/ClansSettingButton.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.clans.settings.buttons;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.settings.menus.buttons.SettingsButton;
 import me.mykindos.betterpvp.core.utilities.UtilSound;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -12,7 +13,7 @@ public class ClansSettingButton extends SettingsButton {
 
     private final Gamer gamer;
 
-    public ClansSettingButton(Gamer gamer, Enum<?> setting, boolean settingEnabled, int slot, ItemStack item, String name, String... lore) {
+    public ClansSettingButton(Gamer gamer, Enum<?> setting, boolean settingEnabled, int slot, ItemStack item, String name, Component... lore) {
         super(setting, settingEnabled, slot, item, name, lore);
         this.gamer = gamer;
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/settings/menus/ClansSettingsMenu.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/settings/menus/ClansSettingsMenu.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.clans.settings.menus;
 
+import java.util.Optional;
 import me.mykindos.betterpvp.clans.settings.buttons.ClansSettingButton;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
@@ -8,12 +9,9 @@ import me.mykindos.betterpvp.core.settings.menus.SettingSubMenu;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Optional;
 
 public class ClansSettingsMenu extends SettingSubMenu implements IRefreshingMenu {
 
@@ -31,8 +29,13 @@ public class ClansSettingsMenu extends SettingSubMenu implements IRefreshingMenu
 
         Optional<Boolean> sidebarSettingOptional = gamer.getProperty(GamerProperty.SIDEBAR_ENABLED);
         sidebarSettingOptional.ifPresent(sidebarSetting -> {
-            addButton(new ClansSettingButton(gamer, GamerProperty.SIDEBAR_ENABLED, sidebarSetting,
-                    0, new ItemStack(Material.IRON_BARS), "Sidebar", ChatColor.GRAY + "Whether to display the sidebar or not"));
+            addButton(new ClansSettingButton(gamer,
+                    GamerProperty.SIDEBAR_ENABLED,
+                    sidebarSetting,
+                    0,
+                    new ItemStack(Material.IRON_BARS),
+                    "Sidebar",
+                    Component.text("Whether to display the sidebar or not", NamedTextColor.GRAY)));
         });
 
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/WorldListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/WorldListener.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.clans.world;
 
 import com.google.inject.Inject;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.framework.ModuleLoadedEvent;
@@ -12,7 +13,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.*;
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -32,8 +32,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
-
-import java.util.*;
 
 @Slf4j
 @BPvPListener
@@ -72,7 +70,7 @@ public class WorldListener implements Listener {
     @EventHandler
     public void handleBucket(PlayerBucketFillEvent event) {
         event.setCancelled(true);
-        UtilMessage.message(event.getPlayer(), "Game", "Your " + ChatColor.YELLOW + "Bucket" + ChatColor.GRAY + " broke!");
+        UtilMessage.simpleMessage(event.getPlayer(), "Game", "Your <alt2>>Bucket</alt2> broke!");
         ItemStack replacement = new ItemStack(Material.IRON_INGOT, event.getPlayer().getInventory().getItemInMainHand().getAmount() * 3);
         event.getPlayer().getInventory().setItemInMainHand(replacement);
     }
@@ -152,9 +150,7 @@ public class WorldListener implements Listener {
                     || event.getInventory().getType() == InventoryType.STONECUTTER
                     || event.getInventory().getType() == InventoryType.SMITHING
                     || event.getInventory().getType() == InventoryType.BEACON) {
-                UtilMessage.message(player, "Game",
-                        ChatColor.YELLOW + UtilFormat.cleanString(event.getInventory().getType().toString())
-                                + ChatColor.GRAY + " is disabled.");
+                UtilMessage.simpleMessage(player, "Game", "<alt2>" + UtilFormat.cleanString(event.getInventory().getType().toString()) + "</alt2> is disabled.");
                 event.setCancelled(true);
             }
 
@@ -231,8 +227,7 @@ public class WorldListener implements Listener {
                 if (block.getType().name().contains("OBSIDIAN") || block.getType() == Material.BEDROCK || block.getType() == Material.WATER_BUCKET
                         || block.getType() == Material.SPAWNER || block.getType() == Material.COBWEB
                         || block.getType() == Material.BREWING_STAND || block.getType().name().contains("_BED")) {
-                    UtilMessage.message(player, "Server", "You cannot place " + ChatColor.YELLOW
-                            + WordUtils.capitalizeFully(block.getType().toString()) + ChatColor.GRAY + ".");
+                    UtilMessage.simpleMessage(player, "Server", "You cannot place <alt2>" + WordUtils.capitalizeFully(block.getType().toString()) + "</alt2>.");
                     event.setCancelled(true);
                 }
             }

--- a/core/src/main/java/me/mykindos/betterpvp/core/chat/ChatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/chat/ChatListener.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.core.chat;
 
 import com.google.inject.Inject;
 import io.papermc.paper.event.player.AsyncChatEvent;
+import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.chat.events.ChatReceivedEvent;
 import me.mykindos.betterpvp.core.chat.events.ChatSentEvent;
@@ -16,15 +18,13 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-
-import java.util.Optional;
 
 @Slf4j
 @BPvPListener
@@ -49,9 +49,9 @@ public class ChatListener implements Listener {
         Player player = event.getPlayer();
 
         Component message = event.message().color(NamedTextColor.WHITE);
+        message = message.decorations(Set.of(TextDecoration.values()), false);
 
-
-        ChatSentEvent chatSent = new ChatSentEvent(player, Bukkit.getOnlinePlayers(), Component.text(UtilFormat.spoofNameForLunar(player.getName()) + ": " + ChatColor.RESET), message);
+        ChatSentEvent chatSent = new ChatSentEvent(player, Bukkit.getOnlinePlayers(), Component.text(UtilFormat.spoofNameForLunar(player.getName()) + ": "), message);
         Bukkit.getPluginManager().callEvent(chatSent);
         if (chatSent.isCancelled()) {
             log.info("ChatSentEvent cancelled for {} - {}", chatSent.getPlayer().getName(), chatSent.getCancelReason());
@@ -91,13 +91,13 @@ public class ChatListener implements Listener {
 
         Rank rank = event.getClient().getRank();
         if(rank.isDisplayPrefix()) {
-            Component rankPrefix = Component.text(ChatColor.BOLD + rank.getName() + " ", rank.getColor());
+            Component rankPrefix = Component.text(rank.getName() + " ", rank.getColor(), TextDecoration.BOLD);
             event.setPrefix(rankPrefix.append(event.getPrefix()));
         }
 
         Optional<Boolean> lunarClientOptional = event.getClient().getProperty(ClientProperty.LUNAR);
         if(lunarClientOptional.isPresent()) {
-            event.setPrefix(Component.text(ChatColor.GREEN + "* ").append(event.getPrefix()));
+            event.setPrefix(Component.text("* ", NamedTextColor.GREEN).append(event.getPrefix()));
         }
 
         Component finalMessage = event.getPrefix().append(event.getMessage());

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/Rank.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/Rank.java
@@ -2,8 +2,9 @@ package me.mykindos.betterpvp.core.client;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.format.TextDecoration;
 
 @AllArgsConstructor
 public enum Rank {
@@ -28,20 +29,12 @@ public enum Rank {
     private final int id;
 
 
-    public String getTag(boolean bold) {
-        String tag = this.name;
+    public Component getTag(boolean bold) {
+        Component tag = Component.text(this.name, color);
         if (bold) {
-            return getChatColor().toString() + ChatColor.BOLD + fixColors(tag);
+            tag = tag.decorate(TextDecoration.BOLD);
         }
-        return getChatColor().toString() + fixColors(tag);
-    }
-
-    private String fixColors(String s) {
-        return ChatColor.translateAlternateColorCodes('&', s);
-    }
-
-    private ChatColor getChatColor(){
-        return ChatColor.valueOf(color.toString().toUpperCase());
+        return tag;
     }
 
     public static Rank getRank(int id) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/commands/ClientCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/commands/ClientCommand.java
@@ -2,18 +2,18 @@ package me.mykindos.betterpvp.core.client.commands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.ClientManager;
 import me.mykindos.betterpvp.core.client.Rank;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Singleton
 public class ClientCommand extends Command {
@@ -50,8 +50,9 @@ public class ClientCommand extends Command {
         @Override
         public void execute(Player player, Client client, String[] args) {
             client.setAdministrating(!client.isAdministrating());
-            UtilMessage.message(player, "Command", "Client admin: "
-                    + (client.isAdministrating() ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled"));
+            
+            Component status = client.isAdministrating() ? Component.text("enabled", NamedTextColor.GREEN) : Component.text("disabled", NamedTextColor.RED);
+            UtilMessage.simpleMessage(player, "Command", Component.text("Client admin: ").append(status));
         }
 
         @Override
@@ -88,8 +89,8 @@ public class ClientCommand extends Command {
 
             Optional<Client> clientOptional = clientManager.getClientByName(name);
             clientOptional.ifPresentOrElse(target -> {
-                List<String> result = new ArrayList<>();
-                result.add(ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " Client Details:");
+                List<Component> result = new ArrayList<>();
+                result.add(UtilMessage.deserialize("<alt2>%s</alt2> Client Details", target.getName()));
                 //event.getResult().add(ChatColor.YELLOW + "IP Address: "
                 //        + (client.hasRank(Rank.ADMIN, false) ? ChatColor.GRAY + target.getIP() : ChatColor.RED + "N/A"));
                 //event.getResult().add(ChatColor.YELLOW + "Previous Name: " + ChatColor.GRAY + target.getOldName());
@@ -141,15 +142,15 @@ public class ClientCommand extends Command {
                 if(targetRank != null) {
                     if (client.getRank().getId() < targetRank.getId() || player.isOp()) {
                         targetClient.setRank(targetRank);
-                        UtilMessage.message(player, "Client", "%s has been promoted to %s",
-                                ChatColor.YELLOW + targetClient.getName() + ChatColor.GRAY, targetRank.getTag(true));
+
+                        final Component msg = UtilMessage.deserialize("<alt2>%s</alt2> has been promoted to ", targetClient.getName()).append(targetRank.getTag(true));
+                        UtilMessage.simpleMessage(player, "Client", msg);
                         clientManager.getRepository().save(targetClient);
                     }else{
                         UtilMessage.message(player, "Client", "You cannot promote someone to your current rank or higher.");
                     }
                 }else{
-                    UtilMessage.message(player, "Client", "%s already has the highest rank.",
-                            ChatColor.YELLOW + targetClient.getName() + ChatColor.GRAY);
+                    UtilMessage.simpleMessage(player, "Client", "<alt2>%s</alt2> already has the highest rank.", targetClient.getName());
                 }
             }
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/events/ClientQuitEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/events/ClientQuitEvent.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 
 @EqualsAndHashCode(callSuper = true)
@@ -13,6 +14,6 @@ public class ClientQuitEvent extends CustomCancellableEvent {
 
     private final Client client;
     private final Player player;
-    private String quitMessage;
+    private Component quitMessage;
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/KickCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/KickCommand.java
@@ -6,9 +6,7 @@ import me.mykindos.betterpvp.core.client.Rank;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.IConsoleCommand;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -37,9 +35,8 @@ public class KickCommand extends Command implements IConsoleCommand {
             Player target = Bukkit.getPlayer(args[0]);
             if (target != null) {
                 String reason = args[1];
-                target.kick(Component.text(ChatColor.RED + "[Kick] " + ChatColor.GRAY + reason));
-                UtilMessage.broadcast("Kick", ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + " kicked " + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " for "
-                        + ChatColor.GREEN + reason);
+                target.kick(UtilMessage.deserialize("<red>[Kick] <gray>" + reason));
+                UtilMessage.simpleBroadcast("Kick", "<alt2>%s</alt2> kicked <alt2>%s</alt2> for <alt>%s</alt>", sender.getName(), target.getName(), reason);
             }
         } else {
             UtilMessage.message(sender, "Command", "You must specify a player and a reason");

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/general/ListCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/general/ListCommand.java
@@ -1,15 +1,16 @@
 package me.mykindos.betterpvp.core.command.commands.general;
 
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Singleton
 public class ListCommand extends Command {
@@ -28,13 +29,14 @@ public class ListCommand extends Command {
     public void execute(Player player, Client client, String... args) {
         int size = Bukkit.getOnlinePlayers().size();
 
-        List<String> players = new ArrayList<>();
+        List<Component> players = new ArrayList<>();
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            players.add(ChatColor.GRAY + " " + onlinePlayer.getName() + ChatColor.YELLOW);
+            players.add(Component.text(onlinePlayer.getName(), NamedTextColor.YELLOW));
         }
 
-        UtilMessage.message(player, "List", "There are currently " + ChatColor.YELLOW + size + ChatColor.GRAY + " players online.");
-        UtilMessage.message(player, "List", ChatColor.YELLOW + players.toString());
+        Component list = Component.join(JoinConfiguration.separator(Component.text(", ", NamedTextColor.YELLOW)), players.toArray(new Component[0]));
+        UtilMessage.message(player, "List", "There are currently <alt2>" + size + "</alt2> players online.");
+        UtilMessage.message(player, "List", list);
 
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/cooldowns/CooldownListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/cooldowns/CooldownListener.java
@@ -10,8 +10,10 @@ import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -72,21 +74,14 @@ public class CooldownListener implements Listener {
                 green = 10;
             }
 
-            StringBuilder msg = new StringBuilder();
-
-            for (int i = 0; i < green; i++) {
-                msg.append(ChatColor.GREEN).append(ChatColor.BOLD).append("\u2588");
-            }
-
+            String msg = "<green><bold>" + "\u2588".repeat(Math.max(0, green));
             if (green != 10) {
-
-                for (int i = 0; i < red; i++) {
-                    msg.append(ChatColor.RED).append(ChatColor.BOLD).append("\u2588");
-                }
+                msg += "<red><bold>" + "\u2588".repeat(Math.max(0, red));
             }
 
-            UtilPlayer.sendActionBar(event.getPlayer(), ChatColor.GOLD.toString() + ChatColor.BOLD + event.getCooldownName() + " "
-                    + ChatColor.YELLOW + ChatColor.BOLD + "[" + msg + ChatColor.YELLOW + ChatColor.BOLD + "]");
+            final Component bar = MiniMessage.miniMessage().deserialize(msg);
+            final Component actionBar = MiniMessage.miniMessage().deserialize("<gold><bold>" + event.getCooldownName() + " <yellow><bold>[<bar>]", Placeholder.component("bar", bar));
+            UtilPlayer.sendActionBar(event.getPlayer(), actionBar);
         }
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/cooldowns/CooldownManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/cooldowns/CooldownManager.java
@@ -2,17 +2,16 @@ package me.mykindos.betterpvp.core.cooldowns;
 
 
 import com.google.inject.Singleton;
-import lombok.Synchronized;
-import lombok.extern.slf4j.Slf4j;
-import me.mykindos.betterpvp.core.framework.manager.Manager;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.GameMode;
-import org.bukkit.entity.Player;
-
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.Synchronized;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.framework.manager.Manager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
 
 @Slf4j
 @Singleton
@@ -46,8 +45,7 @@ public class CooldownManager extends Manager<ConcurrentHashMap<String, Cooldown>
             if (isCooling(player, ability)) {
 
                 if (inform) {
-                    player.sendMessage(ChatColor.BLUE + "Cooldown> " + ChatColor.GRAY + "You cannot use " + ChatColor.GREEN + ability + ChatColor.GRAY + " for "
-                            + ChatColor.GREEN + "" + Math.max(0, getAbilityRecharge(player, ability).getRemaining()) + " seconds" + ChatColor.GRAY + ".");
+                    UtilMessage.simpleMessage(player, "Cooldown", "You cannot use <alt>%s</alt> for <alt>%s</alt> seconds.", ability, Math.max(0, getAbilityRecharge(player, ability).getRemaining()));
                 }
 
                 return false;
@@ -89,7 +87,7 @@ public class CooldownManager extends Manager<ConcurrentHashMap<String, Cooldown>
             if (cooldowns.containsKey(ability)) {
                 cooldowns.remove(ability);
                 if (!silent) {
-                    player.sendMessage(ChatColor.BLUE + "Recharge> " + ChatColor.GREEN + ability + ChatColor.GRAY + " has been recharged.");
+                    UtilMessage.simpleMessage(player, "Recharge", "<alt>%s</alt> has been recharged.", ability);
                 }
             }
 
@@ -105,7 +103,7 @@ public class CooldownManager extends Manager<ConcurrentHashMap<String, Cooldown>
                     if (cd.isInform()) {
                         Player player = Bukkit.getPlayer(UUID.fromString(key));
                         if (player != null) {
-                            player.sendMessage(ChatColor.BLUE + "Cooldown> " + ChatColor.GREEN + entry.getKey() + ChatColor.GRAY + " has been recharged.");
+                            UtilMessage.simpleMessage(player, "Cooldown", "<alt>%s</alt> has been recharged.", entry.getKey());
                         }
                     }
                     return true;

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
@@ -1,6 +1,10 @@
 package me.mykindos.betterpvp.core.effects.listeners;
 
 import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.effects.Effect;
 import me.mykindos.betterpvp.core.effects.EffectManager;
@@ -11,7 +15,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.EntityEffect;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -24,11 +27,6 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @BPvPListener
 public class EffectListener implements Listener {
@@ -64,8 +62,7 @@ public class EffectListener implements Listener {
             }
             if (effect.getEffectType() == EffectType.SILENCE) {
                 player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1.5F);
-                UtilMessage.message(player, "Silence", "You have been silenced for %s seconds.",
-                        ChatColor.GREEN.toString() + (effect.getRawLength() / 1000) + ChatColor.GRAY);
+                UtilMessage.simpleMessage(player, "Silence", "You have been silenced for <alt>%s</alt> seconds.", effect.getRawLength() / 1000);
             }
 
             if (effect.getEffectType() == EffectType.VULNERABILITY) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/delayedactions/DelayedActionListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/delayedactions/DelayedActionListener.java
@@ -1,6 +1,8 @@
 package me.mykindos.betterpvp.core.framework.delayedactions;
 
 import com.google.inject.Inject;
+import java.time.Duration;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.framework.delayedactions.events.PlayerDelayedActionEvent;
@@ -11,16 +13,13 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
-
-import java.time.Duration;
-import java.util.WeakHashMap;
 
 @BPvPListener
 public class DelayedActionListener implements Listener {
@@ -67,11 +66,14 @@ public class DelayedActionListener implements Listener {
         delayedActionMap.forEach((player, delayedAction) -> {
             if (delayedAction.isCountdown() && delayedAction.getCountdownText() != null) {
 
-                String remainingTime = String.format(ChatColor.YELLOW + delayedAction.getCountdownText() + ChatColor.GREEN + " %.1f %s",
+                Component remainingTime = UtilMessage.deserialize("<alt2>%s</alt2> <alt>%.1f</alt> <alt2>%s</alt2>",
+                        delayedAction.getCountdownText(),
                         UtilTime.convert((delayedAction.getTime() - System.currentTimeMillis()), UtilTime.TimeUnit.BEST, 1),
-                        ChatColor.YELLOW + UtilTime.getTimeUnit2(delayedAction.getTime() - System.currentTimeMillis()).toLowerCase());
+                        UtilTime.getTimeUnit2(delayedAction.getTime() - System.currentTimeMillis()).toLowerCase()
+                );
+                
                 var times = Title.Times.times(Duration.ofMillis(0), Duration.ofMillis(1000), Duration.ofMillis(1000));
-                player.showTitle(Title.title(Component.text(remainingTime), Component.empty(), times));
+                player.showTitle(Title.title(remainingTime, Component.empty(), times));
             }
 
         });
@@ -85,8 +87,8 @@ public class DelayedActionListener implements Listener {
 
                 var times = Title.Times.times(Duration.ofMillis(0), Duration.ofMillis(1000), Duration.ofMillis(1000));
                 player.showTitle(Title.title(
-                        Component.text(ChatColor.RED + delayedAction.getTitleText() + " cancelled"),
-                        Component.text(ChatColor.GRAY + "You took damage while " + delayedAction.getSubtitleText()),
+                        Component.text(delayedAction.getTitleText() + " cancelled", NamedTextColor.RED),
+                        Component.text("You took damage while " + delayedAction.getSubtitleText(), NamedTextColor.GRAY),
                         times));
             }
         }
@@ -101,8 +103,8 @@ public class DelayedActionListener implements Listener {
 
                 var times = Title.Times.times(Duration.ofMillis(0), Duration.ofMillis(1000), Duration.ofMillis(1000));
                 event.getPlayer().showTitle(Title.title(
-                        Component.text(ChatColor.RED + delayedAction.getTitleText() + " cancelled"),
-                        Component.text(ChatColor.GRAY + "You moved while " + delayedAction.getSubtitleText()),
+                        Component.text(delayedAction.getTitleText() + " cancelled", NamedTextColor.RED),
+                        Component.text("You moved while " + delayedAction.getSubtitleText(), NamedTextColor.GRAY),
                         times));
             }
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/Button.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/Button.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.core.menu;
 
 import lombok.Data;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
@@ -13,21 +15,26 @@ public class Button {
 
     private final int slot;
     private final ItemStack itemStack;
-    private final String name;
-    private final String[] lore;
+    private final Component name;
+    private final Component[] lore;
 
     public Button(int slot, ItemStack item, String name, String... lore){
-        this.slot = slot;
-        this.lore = lore;
-        this.name = name;
-        this.itemStack = UtilItem.removeAttributes(UtilItem.setItemNameAndLore(item, name, lore));
+        this(slot, item, name, List.of(lore));
     }
 
     public Button(int slot, ItemStack item, String name, List<String> lore) {
-        this.lore = lore.toArray(new String[0]);
+        this(slot, item, Component.text(name), lore.stream().map(Component::text).toArray(Component[]::new));
+    }
+
+    public Button(int slot, ItemStack item, Component name, Component... lore) {
+        this(slot, item, name, List.of(lore));
+    }
+
+    public Button(int slot, ItemStack item, Component name, List<Component> lore) {
+        this.lore = lore.stream().map(line -> line.decoration(TextDecoration.ITALIC, false)).toArray(Component[]::new);
         this.slot = slot;
-        this.name = name;
-        this.itemStack = UtilItem.removeAttributes(UtilItem.setItemNameAndLore(item, name, lore));
+        this.name = name.decoration(TextDecoration.ITALIC, false);
+        this.itemStack = UtilItem.removeAttributes(UtilItem.setItemNameAndLore(item, this.name, List.of(this.lore)));
     }
 
     public void onClick(Player player, ClickType clickType) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/settings/commands/SettingsCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/settings/commands/SettingsCommand.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.core.settings.commands;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
@@ -9,7 +8,6 @@ import me.mykindos.betterpvp.core.settings.menus.SettingsMenu;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 @Singleton

--- a/core/src/main/java/me/mykindos/betterpvp/core/settings/menus/buttons/SettingsButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/settings/menus/buttons/SettingsButton.java
@@ -2,7 +2,8 @@ package me.mykindos.betterpvp.core.settings.menus.buttons;
 
 import lombok.Getter;
 import me.mykindos.betterpvp.core.menu.Button;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.inventory.ItemStack;
 
 public abstract class SettingsButton extends Button {
@@ -10,12 +11,12 @@ public abstract class SettingsButton extends Button {
     @Getter
     protected final String setting;
 
-    public SettingsButton(Enum<?> key, boolean settingEnabled, int slot, ItemStack item, String name, String... lore) {
+    public SettingsButton(Enum<?> key, boolean settingEnabled, int slot, ItemStack item, String name, Component... lore) {
         this(key.name(), settingEnabled, slot, item, name, lore);
     }
 
-    public SettingsButton(String setting, boolean settingEnabled, int slot, ItemStack item, String name, String... lore) {
-        super(slot, item, settingEnabled ? ChatColor.GREEN + name : ChatColor.RED + name, lore);
+    public SettingsButton(String setting, boolean settingEnabled, int slot, ItemStack item, String name, Component... lore) {
+        super(slot, item, Component.text(name, settingEnabled ? NamedTextColor.GREEN : NamedTextColor.RED), lore);
         this.setting = setting;
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
@@ -59,6 +59,27 @@ public class UtilItem {
     }
 
     /**
+     * Updates an ItemStack, giving it a custom name and lore
+     *
+     * @param item ItemStack to modify
+     * @param name Name to give the ItemStack
+     * @param lore Lore to give the ItemStack
+     * @return Returns the ItemStack with the newly adjusted name and lore
+     */
+    public static ItemStack setItemNameAndLore(ItemStack item, Component name, List<Component> lore) {
+        ItemMeta im = item.getItemMeta();
+        im.displayName(name);
+        if (lore != null) {
+            im.lore(lore);
+        }
+
+        im.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_POTION_EFFECTS);
+
+        item.setItemMeta(im);
+        return item;
+    }
+
+    /**
      * Removes attributes from an ItemStack (e.g. the +7 damage that is visible
      * on a diamond sword under the lore)
      *

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
@@ -2,28 +2,36 @@ package me.mykindos.betterpvp.core.utilities;
 
 import me.mykindos.betterpvp.core.client.Rank;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public class UtilMessage {
 
+    private static final TagResolver tagResolver = TagResolver.resolver(
+            TagResolver.resolver("alt", Tag.styling(NamedTextColor.GREEN)),
+            TagResolver.resolver("alt2", Tag.styling(NamedTextColor.YELLOW))
+    );
+
+
     /**
      * Sends a message to a player with appropriate formatting
      *
-     * @param player  The player
+     * @param sender  The player
      * @param prefix  The message
      * @param message Message to send to a player
      */
-    public static void message(Player player, String prefix, Component message) {
-        Component prefixComponent = MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ");
-        player.sendMessage(prefixComponent.append(message));
+    public static void message(CommandSender sender, String prefix, Component message) {
+        sender.sendMessage(getPrefix(prefix).append(normalize(message)));
     }
 
     /**
@@ -35,7 +43,7 @@ public class UtilMessage {
      * @param message Message to send to the CommandSender
      */
     public static void message(CommandSender sender, String prefix, String message) {
-        sender.sendMessage((!prefix.equals("") ? (ChatColor.BLUE + prefix + "> ") : "") + ChatColor.GRAY + message);
+       message(sender, prefix, MiniMessage.miniMessage().deserialize(message, tagResolver));
     }
 
     /**
@@ -48,7 +56,7 @@ public class UtilMessage {
      * @param args    The args to interpolate in the string
      */
     public static void message(CommandSender sender, String prefix, String message, Object... args) {
-        sender.sendMessage(String.format(ChatColor.BLUE + prefix + "> " + ChatColor.GRAY + message, args));
+        message(sender, prefix, String.format(message, args));
     }
 
     /**
@@ -65,7 +73,7 @@ public class UtilMessage {
             player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0F, 1.0F);
         }
 
-        player.sendMessage(ChatColor.BLUE + prefix + "> " + ChatColor.GRAY + message);
+        message(player, prefix, message);
     }
 
     /**
@@ -75,6 +83,16 @@ public class UtilMessage {
      * @param message The message to be sent
      */
     public static void message(Player player, String message) {
+        player.sendMessage(Component.text(message));
+    }
+
+    /**
+     * Sends a message to a player, does not format the message
+     *
+     * @param player  The player receiving the message
+     * @param message The message to be sent
+     */
+    public static void message(Player player, Component message) {
         player.sendMessage(message);
     }
 
@@ -88,7 +106,10 @@ public class UtilMessage {
      * @param rank    The rank required to use this command
      */
     public static void message(Player player, String command, String message, Rank rank) {
-        player.sendMessage(rank.getColor() + command + " " + ChatColor.GRAY + message + rank.getColor() + " " + rank.getTag(false));
+        final TextComponent prefixCmpt = Component.text(command, rank.getColor());
+        final TextComponent messageCmpt = Component.text(message, NamedTextColor.GRAY);
+        final Component rankCmpt = rank.getTag(false);
+        player.sendMessage(Component.join(JoinConfiguration.separator(Component.space()), prefixCmpt, messageCmpt, rankCmpt));
     }
 
     /**
@@ -99,6 +120,18 @@ public class UtilMessage {
      */
     public static void message(Player player, String[] message) {
         for (String string : message) {
+            message(player, string);
+        }
+    }
+
+    /**
+     * Sends an array of strings to a player, does not format the strings
+     *
+     * @param player  The player receiving the message
+     * @param message The strings to be sent
+     */
+    public static void message(Player player, Component[] message) {
+        for (Component string : message) {
             player.sendMessage(string);
         }
     }
@@ -112,7 +145,7 @@ public class UtilMessage {
      */
     public static void message(Player player, String prefix, String[] message) {
         for (String string : message) {
-            player.sendMessage(ChatColor.BLUE + prefix + "> " + ChatColor.GRAY + string);
+            message(player, prefix, string);
         }
     }
 
@@ -123,7 +156,7 @@ public class UtilMessage {
      * @param message The message to send
      */
     public static void simpleMessage(CommandSender sender, String message) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<gray>" + message));
+        sender.sendMessage(deserialize(message));
     }
 
     /**
@@ -134,8 +167,7 @@ public class UtilMessage {
      * @param message Message to send to the CommandSender
      */
     public static void simpleMessage(CommandSender sender, String prefix, String message) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ")
-                .append(MiniMessage.miniMessage().deserialize("<gray>" + message)));
+        sender.sendMessage(getPrefix(prefix).append(deserialize(message)));
     }
 
     /**
@@ -147,9 +179,7 @@ public class UtilMessage {
      * @param hover   Hover event to add to the message
      */
     public static void simpleMessage(CommandSender sender, String prefix, String message, Component hover) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ")
-                .hoverEvent(HoverEvent.showText(hover))
-                .append(MiniMessage.miniMessage().deserialize("<gray>" + message)));
+        simpleMessage(sender, prefix, Component.text(message), hover);
     }
 
     /**
@@ -161,9 +191,7 @@ public class UtilMessage {
      * @param hover   Hover event to add to the message
      */
     public static void simpleMessage(CommandSender sender, String prefix, Component message, Component hover) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ")
-                .hoverEvent(HoverEvent.showText(hover))
-                .append(message));
+        sender.sendMessage(getPrefix(prefix).hoverEvent(HoverEvent.showText(hover)).append(normalize(message)));
     }
 
     /**
@@ -175,8 +203,7 @@ public class UtilMessage {
      * @param args    The args to interpolate in the string
      */
     public static void simpleMessage(CommandSender sender, String prefix, String message, Object... args) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ")
-                .append(MiniMessage.miniMessage().deserialize("<gray>" + String.format(message, args))));
+        simpleMessage(sender, prefix, String.format(message, args));
     }
 
     /**
@@ -187,9 +214,8 @@ public class UtilMessage {
      * @param component Message to send to the CommandSender
      */
     public static void simpleMessage(CommandSender sender, String prefix, Component component) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ").append(component));
+        sender.sendMessage(getPrefix(prefix).append(normalize(component)));
     }
-
 
     /**
      * Sends a message utilizing <a href="https://docs.adventure.kyori.net/minimessage">MiniMessage</a> from Adventure API
@@ -199,21 +225,39 @@ public class UtilMessage {
      * @param args    The args to interpolate in the string
      */
     public static void simpleMessage(CommandSender sender, String message, Object... args) {
-        sender.sendMessage(MiniMessage.miniMessage().deserialize("<gray>" + String.format(message, args)));
+        sender.sendMessage(deserialize(String.format(message, args)));
     }
 
 
     public static void simpleBroadcast(String prefix, String message, Object... args) {
-        Bukkit.getServer().broadcast(Component.text(NamedTextColor.BLUE + prefix + "> ")
-                .append(MiniMessage.miniMessage().deserialize("<gray>" + String.format(message, args))));
+        Bukkit.getServer().broadcast(getPrefix(prefix).append(deserialize(String.format(message, args))));
     }
 
     public static Component getMiniMessage(String message, Object... args) {
-        return MiniMessage.miniMessage().deserialize(String.format(message, args)).decoration(TextDecoration.ITALIC, false);
+        return deserialize(String.format(message, args)).decoration(TextDecoration.ITALIC, false);
     }
 
     public static Component getMiniMessage(String message) {
-        return MiniMessage.miniMessage().deserialize(message).decoration(TextDecoration.ITALIC, false);
+        return deserialize(message).decoration(TextDecoration.ITALIC, false);
+    }
+
+    public static Component deserialize(String message) {
+        return normalize(MiniMessage.miniMessage().deserialize(message, tagResolver));
+    }
+
+    public static Component deserialize(String message, Object... args) {
+        return deserialize(String.format(message, args));
+    }
+
+    public static Component normalize(Component component) {
+        return component.applyFallbackStyle(NamedTextColor.GRAY);
+    }
+
+    public static Component getPrefix(String prefix) {
+        if (prefix.isEmpty()) {
+            return Component.empty();
+        }
+        return MiniMessage.miniMessage().deserialize("<blue>" + prefix + "> ");
     }
 
     /**
@@ -223,7 +267,7 @@ public class UtilMessage {
      * @param message The message to be broadcasted
      */
     public static void broadcast(String prefix, String message) {
-        Bukkit.getServer().broadcast(Component.text(ChatColor.BLUE + prefix + "> " + ChatColor.GRAY + message));
+        Bukkit.getServer().broadcast(getPrefix(prefix).append(deserialize(message)));
     }
 
     /**
@@ -232,7 +276,7 @@ public class UtilMessage {
      * @param message The message to be broadcasted
      */
     public static void broadcast(String message) {
-        Bukkit.getServer().broadcast(Component.text(ChatColor.GRAY + message));
+        Bukkit.getServer().broadcast(deserialize(message));
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
@@ -87,8 +87,8 @@ public class UtilPlayer {
         return Arrays.stream(items).anyMatch(item -> item == player.getInventory().getItemInMainHand().getType());
     }
 
-    public static void sendActionBar(Player player, String msg) {
-        player.sendActionBar(Component.text(msg));
+    public static void sendActionBar(Player player, Component msg) {
+        player.sendActionBar(msg);
     }
 
     /**

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/commands/ShopsCommand.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/commands/ShopsCommand.java
@@ -12,9 +12,6 @@ import me.mykindos.betterpvp.shops.Shops;
 import me.mykindos.betterpvp.shops.commands.loader.ShopsCommandLoader;
 import me.mykindos.betterpvp.shops.listener.ShopsListenerLoader;
 import me.mykindos.betterpvp.shops.shops.shopkeepers.ShopkeeperManager;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -76,8 +73,8 @@ public class ShopsCommand extends Command implements IConsoleCommand {
                 UtilMessage.message(player, "Shops", "Usage: /shop spawn <entityType> <shop name>");
                 return;
             }
-
-            shopkeeperManager.saveShopkeeper(args[0], Component.text(args[1], NamedTextColor.GREEN, TextDecoration.BOLD), player.getLocation());
+            
+            shopkeeperManager.saveShopkeeper(args[0], args[1], player.getLocation());
             shopkeeperManager.loadShopsFromConfig();
         }
     }

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/commands/ShopsCommand.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/commands/ShopsCommand.java
@@ -12,7 +12,9 @@ import me.mykindos.betterpvp.shops.Shops;
 import me.mykindos.betterpvp.shops.commands.loader.ShopsCommandLoader;
 import me.mykindos.betterpvp.shops.listener.ShopsListenerLoader;
 import me.mykindos.betterpvp.shops.shops.shopkeepers.ShopkeeperManager;
-import net.md_5.bungee.api.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -75,7 +77,7 @@ public class ShopsCommand extends Command implements IConsoleCommand {
                 return;
             }
 
-            shopkeeperManager.saveShopkeeper(args[0], ChatColor.BOLD.toString() + ChatColor.GREEN + args[1], player.getLocation());
+            shopkeeperManager.saveShopkeeper(args[0], Component.text(args[1], NamedTextColor.GREEN, TextDecoration.BOLD), player.getLocation());
             shopkeeperManager.loadShopsFromConfig();
         }
     }

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/ShopkeeperManager.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/ShopkeeperManager.java
@@ -2,17 +2,17 @@ package me.mykindos.betterpvp.shops.shops.shopkeepers;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Objects;
+import java.util.UUID;
 import me.mykindos.betterpvp.core.framework.manager.Manager;
 import me.mykindos.betterpvp.shops.Shops;
 import me.mykindos.betterpvp.shops.shops.shopkeepers.types.*;
-import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.LivingEntity;
-
-import java.util.Objects;
-import java.util.UUID;
 
 @Singleton
 public class ShopkeeperManager extends Manager<IShopkeeper> {
@@ -34,12 +34,13 @@ public class ShopkeeperManager extends Manager<IShopkeeper> {
 
         configSection.getKeys(false).forEach(key -> {
             String type = shops.getConfig().getString("shopkeepers." + key + ".type");
-            String name = shops.getConfig().getString("shopkeepers." + key + ".name");
+            String rawName = shops.getConfig().getString("shopkeepers." + key + ".name", "");
+            TextComponent name = LegacyComponentSerializer.legacyAmpersand().deserialize(rawName);
             World world = Bukkit.getWorld(Objects.requireNonNull(shops.getConfig().getString("shopkeepers." + key + ".world")));
             double x = shops.getConfig().getDouble("shopkeepers." + key + ".x");
             double y = shops.getConfig().getDouble("shopkeepers." + key + ".y");
             double z = shops.getConfig().getDouble("shopkeepers." + key + ".z");
-
+            
             if(type == null) return;
 
             switch (type.toUpperCase()) {
@@ -63,10 +64,10 @@ public class ShopkeeperManager extends Manager<IShopkeeper> {
         });
     }
 
-    public void saveShopkeeper(String type, Component name, Location location) {
+    public void saveShopkeeper(String type, String rawName, Location location) {
         String tag = UUID.randomUUID().toString();
         shops.getConfig().set("shopkeepers." + tag + ".type", type);
-        shops.getConfig().set("shopkeepers." + tag + ".name", name);
+        shops.getConfig().set("shopkeepers." + tag + ".name", rawName);
         shops.getConfig().set("shopkeepers." + tag + ".world", location.getWorld().getName());
         shops.getConfig().set("shopkeepers." + tag + ".x", location.getX());
         shops.getConfig().set("shopkeepers." + tag + ".y", location.getY());

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/ShopkeeperManager.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/ShopkeeperManager.java
@@ -5,6 +5,7 @@ import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.framework.manager.Manager;
 import me.mykindos.betterpvp.shops.Shops;
 import me.mykindos.betterpvp.shops.shops.shopkeepers.types.*;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -62,7 +63,7 @@ public class ShopkeeperManager extends Manager<IShopkeeper> {
         });
     }
 
-    public void saveShopkeeper(String type, String name, Location location) {
+    public void saveShopkeeper(String type, Component name, Location location) {
         String tag = UUID.randomUUID().toString();
         shops.getConfig().set("shopkeepers." + tag + ".type", type);
         shops.getConfig().set("shopkeepers." + tag + ".name", name);

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/ParrotShopkeeper.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/ParrotShopkeeper.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.shops.shops.shopkeepers.types;
 
 import lombok.Getter;
+import net.kyori.adventure.text.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
@@ -25,11 +26,11 @@ public class ParrotShopkeeper extends Parrot implements IShopkeeper {
     @Getter
     private final CraftEntity entity;
 
-    public ParrotShopkeeper(Location location, String name) {
+    public ParrotShopkeeper(Location location, Component name) {
         this(EntityType.PARROT, location, name);
     }
 
-    public ParrotShopkeeper(EntityType<? extends Parrot> type, Location location, String name) {
+    public ParrotShopkeeper(EntityType<? extends Parrot> type, Location location, Component name) {
         super(type, ((CraftWorld) location.getWorld()).getHandle());
 
         goalSelector.removeAllGoals(Objects::nonNull);
@@ -37,7 +38,7 @@ public class ParrotShopkeeper extends Parrot implements IShopkeeper {
 
         entity = spawn(location);
 
-        entity.setCustomName(name);
+        entity.customName(name);
         entity.setCustomNameVisible(true);
 
         if(entity instanceof LivingEntity livingEntity) {

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/SkeletonShopkeeper.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/SkeletonShopkeeper.java
@@ -1,15 +1,16 @@
 package me.mykindos.betterpvp.shops.shops.shopkeepers.types;
 
+import net.kyori.adventure.text.Component;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.AbstractSkeleton;
 import org.bukkit.Location;
 
 public class SkeletonShopkeeper extends StandardShopkeeper {
-    public SkeletonShopkeeper(Location location, String name) {
+    public SkeletonShopkeeper(Location location, Component name) {
         super(EntityType.SKELETON, location, name);
     }
 
-    public SkeletonShopkeeper(EntityType<? extends AbstractSkeleton> type, Location location, String name) {
+    public SkeletonShopkeeper(EntityType<? extends AbstractSkeleton> type, Location location, Component name) {
         super(type, location, name);
     }
 }

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/StandardShopkeeper.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/StandardShopkeeper.java
@@ -1,6 +1,8 @@
 package me.mykindos.betterpvp.shops.shops.shopkeepers.types;
 
+import java.util.Objects;
 import lombok.Getter;
+import net.kyori.adventure.text.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
@@ -19,14 +21,12 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-
 public class StandardShopkeeper extends Mob implements IShopkeeper{
 
     @Getter
     private final CraftEntity entity;
 
-    public StandardShopkeeper(EntityType<? extends Mob> type, Location location, String name) {
+    public StandardShopkeeper(EntityType<? extends Mob> type, Location location, Component name) {
         super(type, ((CraftWorld) location.getWorld()).getHandle());
 
         goalSelector.removeAllGoals(Objects::nonNull);
@@ -34,7 +34,7 @@ public class StandardShopkeeper extends Mob implements IShopkeeper{
 
         entity = spawn(location);
 
-        entity.setCustomName(name);
+        entity.customName(name);
         entity.setCustomNameVisible(true);
 
         if(entity instanceof LivingEntity livingEntity) {

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/VillagerShopkeeper.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/VillagerShopkeeper.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.shops.shops.shopkeepers.types;
 
+import javax.annotation.Nullable;
+import net.kyori.adventure.text.Component;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.EntityType;
@@ -10,14 +12,12 @@ import net.minecraft.world.level.ServerLevelAccessor;
 import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nullable;
-
 public class VillagerShopkeeper extends StandardShopkeeper {
-    public VillagerShopkeeper(Location location, String name) {
+    public VillagerShopkeeper(Location location, Component name) {
         super(EntityType.VILLAGER, location, name);
     }
 
-    public VillagerShopkeeper(EntityType<? extends AbstractVillager> type, Location location, String name) {
+    public VillagerShopkeeper(EntityType<? extends AbstractVillager> type, Location location, Component name) {
         super(type, location, name);
     }
 

--- a/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/ZombieShopkeeper.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/shops/shopkeepers/types/ZombieShopkeeper.java
@@ -1,16 +1,17 @@
 package me.mykindos.betterpvp.shops.shops.shopkeepers.types;
 
+import net.kyori.adventure.text.Component;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Zombie;
 import org.bukkit.Location;
 
 
 public class ZombieShopkeeper extends StandardShopkeeper {
-    public ZombieShopkeeper(Location location, String name) {
+    public ZombieShopkeeper(Location location, Component name) {
         super(EntityType.ZOMBIE, location, name);
     }
 
-    public ZombieShopkeeper(EntityType<? extends Zombie> type, Location location, String name) {
+    public ZombieShopkeeper(EntityType<? extends Zombie> type, Location location, Component name) {
         super(type, location, name);
     }
 


### PR DESCRIPTION
Changes:
- Migrate _most_ of Bukkit's ChatColor use cases to Adventure Components. The remaining ChatColor imports are in classes that make use of incompatible APIs, like the Scoreboard API.
- All messages in UtilMessage are now parsed using MiniMessage.
- Added default MiniMessage format tag `<alt>` and `<alt2>` that represent green and yellow, respectively. Both of these should be used in all instances of user-bound chat messages so as to have a good control of chat style format and have maintainable chat coloring.
- Added MiniMessage format tag `<val>` **specifically in skill descriptions**. This tag is currently only set to format text as green, though it can serve as a dynamic coloring tag in the future in the case that number values change color depending on a condition, like skill selection status, etc. This tag should be used in all instances in which a number or any raw value is input in a skill description within the champions module.