### PR TITLE
Create Fields & new utility events and classes

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
@@ -40,6 +40,7 @@ public class Clans extends BPvPPlugin {
 
     @Inject
     @Config(path = "clans.database.prefix", defaultValue = "clans_")
+    @Getter
     private String databasePrefix;
 
     private ClanManager clanManager;

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/TerritoryInteractEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/TerritoryInteractEvent.java
@@ -1,0 +1,39 @@
+package me.mykindos.betterpvp.clans.clans.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+/**
+ * Called when a player interacts with a territory, such as breaking, placing or interacting with a block.
+ */
+@Getter
+@Setter
+public class TerritoryInteractEvent extends CustomEvent {
+
+    private final Player player;
+    private final Clan territoryOwner;
+    private final Block block;
+    private final InteractionType interactionType;
+    private Result result;
+    private boolean inform; // If the player should be informed of the result
+
+    public TerritoryInteractEvent(Player player, Clan territoryOwner, Block block, Result result, InteractionType interactionType) {
+        this.player = player;
+        this.territoryOwner = territoryOwner;
+        this.block = block;
+        this.interactionType = interactionType;
+        this.result = result;
+        this.inform = true;
+    }
+
+    public enum InteractionType {
+        BREAK,
+        PLACE,
+        INTERACT
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -70,7 +69,7 @@ public class ClansMovementListener extends ClanListener {
             clan = clanOptional.get();
         }
 
-        String append = "";
+        Component append = Component.empty();
 
         if (locationClan != null) {
             ClanRelation relation = clanManager.getRelation(clan, locationClan);
@@ -79,32 +78,25 @@ public class ClansMovementListener extends ClanListener {
             if (locationClan.isAdmin()) {
                 if (locationClan.isSafe()) {
                     component = Component.text(NamedTextColor.WHITE + locationClan.getName());
-                    append = NamedTextColor.WHITE + " (" + NamedTextColor.AQUA + "Safe" + NamedTextColor.WHITE + ")";
+                    append = UtilMessage.deserialize("<white>(<aqua>Safe</aqua>)</white>");
                 }
             } else if (relation == ClanRelation.ALLY_TRUST) {
-                append = NamedTextColor.GRAY + " (" + NamedTextColor.YELLOW + "Trusted" + NamedTextColor.GRAY + ")";
-
+                append = UtilMessage.deserialize("<gray>(<yellow>Safe</yellow>)</gray>");
             } else if (relation == ClanRelation.ENEMY) {
                 if (clan != null) {
-                    append = clan.getDominanceString(locationClan);
+                    append = UtilMessage.deserialize(clan.getDominanceString(locationClan));
                 }
-
             }
         }
 
         if (locationClan != null) {
             if (locationClan.getName().equals("Fields") || locationClan.getName().equals("Lake")) {
-                append = NamedTextColor.RED.toString() + TextDecoration.BOLD + "                    Warning! "
-                        + NamedTextColor.GRAY + TextDecoration.BOLD + "PvP Hotspot";
+                append = UtilMessage.deserialize("<red><bold>                    Warning! <gray> PvP Hotspot</gray></bold></red>");
             }
 
-            UtilMessage.simpleMessage(player, "Territory",
-                    component.append(Component.text(append)),
-                    clanManager.getClanTooltip(player, locationClan)
-            );
-
+            UtilMessage.simpleMessage(player, "Territory", component.append(append), clanManager.getClanTooltip(player, locationClan));
         } else {
-            UtilMessage.message(player, "Territory", component.append(Component.text(append)));
+            UtilMessage.message(player, "Territory", component.append(append));
         }
 
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/commands/commands/ClansCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/commands/commands/ClansCommand.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.commands.ClansCommandLoader;
+import me.mykindos.betterpvp.clans.fields.Fields;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.Rank;
@@ -55,6 +56,8 @@ public class ClansCommand extends Command implements IConsoleCommand {
         @Inject
         private ClansListenerLoader listenerLoader;
 
+        @Inject
+        private Fields fields;
 
         @Override
         public String getName() {
@@ -77,6 +80,7 @@ public class ClansCommand extends Command implements IConsoleCommand {
 
             commandLoader.reload(clans.getClass().getPackageName());
             listenerLoader.reload(clans.getClass().getPackageName());
+            fields.reload(clans);
 
             UtilMessage.message(sender, "Clans", "Successfully reloaded clans");
         }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/Fields.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/Fields.java
@@ -1,0 +1,166 @@
+package me.mykindos.betterpvp.clans.fields;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.clans.fields.repository.FieldsBlockEntry;
+import me.mykindos.betterpvp.clans.fields.repository.FieldsRepository;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * Stores all data for the Fields zone.
+ */
+@Singleton
+@Slf4j
+public class Fields {
+
+    private final SetMultimap<FieldsInteractable, FieldsBlock> blocks = HashMultimap.create();
+
+    private final @NotNull FieldsRepository repository;
+    private final Map<Integer, Double> playerCountSpeeds = new HashMap<>();
+    private final Clans clans;
+
+    @Inject
+    public Fields(@NotNull final FieldsRepository repository, @NotNull Clans clans) {
+        this.repository = repository;
+        this.clans = clans;
+        populate();
+    }
+
+    public Set<FieldsInteractable> getBlockTypes() {
+        return repository.getTypes();
+    }
+
+    private void populate() {
+        repository.getAll().forEach(ore -> blocks.put(ore.getType(), new FieldsBlock(ore.getWorld(),
+                ore.getX(),
+                ore.getY(),
+                ore.getZ())));
+        log.info("Loaded {} fields blocks", blocks.size());
+        reload(clans);
+    }
+
+    public void reload(@NotNull Clans clans) {
+        for (FieldsInteractable type : blocks.keySet()) {
+            final String name = type.getName().toLowerCase().replace(" ", "");
+            final Double delay = clans.getConfig().getOrSaveObject("fields.blocks." + name + ".respawn", 60.0, Double.class);
+            Objects.requireNonNull(delay, "Delay must be present");
+            type.setRespawnDelay(delay);
+
+            type.loadConfig(clans.getConfig());
+        }
+
+        playerCountSpeeds.clear();
+        final Set<String> keys = clans.getConfig().getConfigurationSection("fields.playerCountSpeeds").getKeys(false);
+        for (String key : keys) {
+            final int playerCount = Integer.parseInt(key);
+            Preconditions.checkArgument(playerCount >= 0, "Player count speed buff must be greater than or equal to 0");
+            final double speed = clans.getConfig().getDouble("fields.playerCountSpeeds." + key);
+            playerCountSpeeds.put(playerCount, speed);
+        }
+
+        repository.reload();
+    }
+
+    /**
+     * Adds a block to the Fields zone.
+     * @param type the type of block
+     * @param block the block
+     */
+    public void addBlock(@NotNull FieldsInteractable type, @NotNull Block block) {
+        blocks.put(type, new FieldsBlock(block.getWorld().getName(), block.getX(), block.getY(), block.getZ()));
+        repository.save(new FieldsBlockEntry(type, block.getWorld().getName(), block.getX(), block.getY(), block.getZ()));
+    }
+
+    /**
+     * Adds multiple blocks to the Fields zone.
+     * @param blocksIn the blocks. The key is the block, the value is the type of block. The type can be null if it
+     *             was deleted.
+     */
+    protected void addBlocks(@NotNull Map<@NotNull Block, @Nullable FieldsInteractable> blocksIn) {
+        final List<FieldsBlockEntry> entries = blocksIn.entrySet().stream()
+                .map(o -> new FieldsBlockEntry(o.getValue(), o.getKey().getWorld().getName(), o.getKey().getX(), o.getKey().getY(), o.getKey().getZ()))
+                .toList();
+
+        repository.saveBatch(entries);
+        blocksIn.forEach((block, type) -> {
+            final FieldsBlock ore = new FieldsBlock(block.getWorld().getName(), block.getX(), block.getY(), block.getZ());
+            if (type == null) {
+                blocks.values().remove(ore);
+            } else {
+                blocks.put(type, ore);
+            }
+        });
+    }
+
+    /**
+     * Deletes a block from the Fields zone.
+     * @param block the block.
+     */
+    public void deleteBlock(Block block) {
+        blocks.values().remove(new FieldsBlock(block.getWorld().getName(), block.getX(), block.getY(), block.getZ()));
+        repository.delete(block.getWorld().getName(), block.getX(), block.getY(), block.getZ());
+    }
+
+    /**
+     * Gets the fields block from a specific block in the Fields zone.
+     * @param block the block
+     * @return The block, if present
+     */
+    public Optional<Pair<FieldsInteractable, FieldsBlock>> getBlock(Block block) {
+        return blocks.entries().stream()
+                .filter(e -> e.getValue().equals(new FieldsBlock(block.getWorld().getName(), block.getX(), block.getY(), block.getZ())))
+                .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
+                .findFirst();
+    }
+
+    /**
+     * Gets all blocks from a specific type in the Fields zone.
+     * @param type the type of block
+     * @return An unmodifiable collection of blocks
+     */
+    public Collection<FieldsBlock> getBlocks(FieldsInteractable type) {
+        return Collections.unmodifiableSet(blocks.get(type));
+    }
+
+    /**
+     * Gets all blocks in the Fields zone.
+     *
+     * @return An unmodifiable collection of blocks
+     */
+    public HashMultimap<FieldsInteractable, FieldsBlock> getBlocks() {
+        return HashMultimap.create(blocks);
+    }
+
+    public Optional<FieldsInteractable> getTypeFromBlock(Block block) {
+        return getBlockTypes().stream()
+                .filter(type -> type.matches(block))
+                .findFirst();
+    }
+
+    /**
+     * Gets the respawn delay speed buff for ores. This depends on player count and other factors. Base is 1.
+     * @return The respawn delay speed
+     */
+    public double getSpeedBuff() {
+        final int players = Bukkit.getOnlinePlayers().size();
+        return playerCountSpeeds.keySet().stream()
+                .filter(required -> players >= required) // Skip if the player count is less than the required
+                .max(Comparator.comparingInt(a -> a)) // Get the highest required player count we can reach
+                .map(playerCountSpeeds::get) // Get the modifier for the one we reached
+                .orElse(1.0); // If there's no modifier, default to 1.0
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
@@ -1,0 +1,168 @@
+package me.mykindos.betterpvp.clans.fields;
+
+import com.google.inject.Inject;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.events.TerritoryInteractEvent;
+import me.mykindos.betterpvp.clans.clans.listeners.ClanListener;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.core.client.events.ClientAdministrateEvent;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.gamer.Gamer;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.gamer.exceptions.NoSuchGamerException;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.WeakHashMap;
+
+@BPvPListener
+public class FieldsListener extends ClanListener {
+
+    private final WeakHashMap<Player, Map<Block, FieldsInteractable>> profiles = new WeakHashMap<>();
+
+    private Fields fields;
+
+    @Inject
+    public FieldsListener(ClanManager clanManager, GamerManager gamerManager, Fields fields) {
+        super(clanManager, gamerManager);
+        this.fields = fields;
+    }
+
+    private boolean isFields(Block block) {
+        return clanManager.getClanByLocation(block.getLocation())
+                .map(c -> c.getName().equalsIgnoreCase("Fields"))
+                .orElse(false);
+    }
+
+    @EventHandler
+    public void onAdministrate(ClientAdministrateEvent event) {
+        if (event.isAdministrating()) {
+            return;
+        }
+
+        // If they stop administrating, save their profiles
+        final Map<Block, FieldsInteractable> toSave = profiles.remove(event.getPlayer());
+        if (toSave == null || toSave.isEmpty()) {
+            return; // If they didn't edit any interactables, ignore
+        }
+
+        fields.addBlocks(toSave);
+        UtilMessage.message(event.getPlayer(), "Fields", "Saved <alt2>%s</alt2> interactables change(s) to the database.", toSave.size());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onAdminBreak(BlockBreakEvent event) {
+         processBlockEvent(event.getPlayer(), event, event.getBlock());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onAdminPlace(BlockPlaceEvent event) {
+        processBlockEvent(event.getPlayer(), event, event.getBlockPlaced());
+    }
+
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onOreMine(TerritoryInteractEvent event) {
+        if (event.getResult() != TerritoryInteractEvent.Result.DENY) {
+            return; // If they're allowed to edit the claim, this means we should not interfere with that
+        }
+
+        if (!event.getTerritoryOwner().getName().equalsIgnoreCase("Fields")) {
+            return; // If they're not in the Fields zone, ignore
+        }
+
+        // Attempt to find the block they're mining
+        final Optional<Pair<FieldsInteractable, FieldsBlock>> interactOpt = fields.getBlock(event.getBlock());
+        if (interactOpt.isEmpty()) {
+            return; // If they're not interacting with a block, ignore
+        }
+
+        // If they're interacting with a block
+        final FieldsInteractable type = interactOpt.get().getLeft();
+        final FieldsBlock block = interactOpt.get().getRight();
+        if (!block.isActive()) {
+            return; // If the block isn't active yet, ignore
+        }
+
+        final boolean allow = type.processInteraction(event, block);
+
+        if (allow) {
+            event.setInform(false); // Block the message that they cant break
+            event.getBlock().setType(type.getReplacement().getMaterial()); // Then replace the block
+            event.getBlock().setBlockData(type.getReplacement());
+            block.setLastUsed(System.currentTimeMillis());
+            block.setActive(false);
+        }
+    }
+
+    private void processBlockEvent(Player player, BlockEvent event, Block block) {
+        if (!isFields(event.getBlock())) {
+            return; // ignore if it's not fields
+        }
+
+        Gamer gamer = gamerManager.getObject(player.getUniqueId().toString()).orElseThrow(() -> new NoSuchGamerException(player.getName()));
+        if (!gamer.getClient().isAdministrating()) {
+            return; // if they're not admin, skip
+        }
+
+        // If they're admin
+        final FieldsInteractable blockType;
+        if (event instanceof BlockPlaceEvent) {
+            Optional<FieldsInteractable> typeOpt = fields.getTypeFromBlock(block);
+            if (typeOpt.isEmpty()) {
+                return; // Cancel if what they placed isn't an interactable
+            }
+
+            blockType = typeOpt.get();
+        } else {
+            final Optional<Pair<FieldsInteractable, FieldsBlock>> interactable = fields.getBlock(event.getBlock());
+            if (interactable.isEmpty() && profiles.values().stream().noneMatch(map -> map.containsKey(block))) {
+                // They didn't break a registered interactable
+                // If they didn't break an interactable, and they're not editing one in an edit profile, ignore
+                return;
+            }
+            blockType = null; // Set the interactable type to null because they broke it
+        }
+
+        // If they're admin, and they placed an interactable, then save it
+        profiles.computeIfAbsent(player, p -> {
+            UtilMessage.message(player, "Fields", "<red>You are now editing interactables in Fields. <u>Your changes will be saved when you stop administrating.</u></red>");
+            return new HashMap<>();
+        }).put(block, blockType);
+    }
+
+    @UpdateEvent(delay = 100)
+    public void respawnOres() {
+        final double modifier = fields.getSpeedBuff();
+        fields.getBlocks().entries()
+                .forEach(entry -> {
+                    final FieldsBlock interactable = entry.getValue();
+                    final FieldsInteractable type = entry.getKey();
+                    if (!UtilTime.elapsed(interactable.getLastUsed(), (long) (type.getRespawnDelay() * 1_000 / modifier))) {
+                        return;
+                    }
+
+                    if (interactable.isActive()) {
+                        return; // The block is already the interactable, ignore
+                    }
+
+                    final Block block = interactable.toLocation().getBlock();
+                    block.setType(type.getType().getMaterial());
+                    block.setBlockData(type.getType());
+                    interactable.setActive(true);
+                });
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/GoldChunkOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/GoldChunkOre.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.clans.fields.block;
 import com.google.inject.Inject;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.fields.model.CustomOre;
+import me.mykindos.betterpvp.clans.utilities.ClansNamespacedKeys;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
@@ -83,8 +84,7 @@ public class GoldChunkOre extends CustomOre implements Listener {
         final ItemStack itemStack = new ItemStack(material, 1);
         final ItemMeta meta = itemStack.getItemMeta();
         final PersistentDataContainer pdc = meta.getPersistentDataContainer();
-        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
-        pdc.set(key, PersistentDataType.INTEGER, gold);
+        pdc.set(ClansNamespacedKeys.FIELDS_GOLD_CHUNK, PersistentDataType.INTEGER, gold);
         itemStack.setItemMeta(meta);
         return itemStack;
     }
@@ -92,7 +92,7 @@ public class GoldChunkOre extends CustomOre implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockPickup(InventoryPickupItemEvent event) {
         final PersistentDataContainer pdc = event.getItem().getItemStack().getItemMeta().getPersistentDataContainer();
-        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
+        final NamespacedKey key = ClansNamespacedKeys.FIELDS_GOLD_CHUNK;
         if (!pdc.has(key, PersistentDataType.INTEGER)) {
             return; // Not a gold chunk
         }
@@ -104,7 +104,7 @@ public class GoldChunkOre extends CustomOre implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onItemPick(EntityPickupItemEvent event) {
         final PersistentDataContainer pdc = event.getItem().getItemStack().getItemMeta().getPersistentDataContainer();
-        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
+        final NamespacedKey key = ClansNamespacedKeys.FIELDS_GOLD_CHUNK;
         if (!pdc.has(key, PersistentDataType.INTEGER)) {
             return; // Not a gold chunk
         }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/GoldChunkOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/GoldChunkOre.java
@@ -1,0 +1,139 @@
+package me.mykindos.betterpvp.clans.fields.block;
+
+import com.google.inject.Inject;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.fields.model.CustomOre;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.gamer.Gamer;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+
+/**
+ * Handles gold chunks.
+ *
+ * Gold chunks give a random amount of gold when picked up.
+ */
+@BPvPListener
+public class GoldChunkOre extends CustomOre implements Listener {
+
+    private static final Random random = new Random();
+
+    @Inject
+    @Config(path = "fields.blocks.goldchunk.minCoins", defaultValue = "50")
+    private int minCoins;
+
+    @Inject
+    @Config(path = "fields.blocks.goldchunk.maxCoins", defaultValue = "150")
+    private int maxCoins;
+
+    @Inject
+    public GoldChunkOre(Clans clans, GamerManager gamerManager) {
+        super(clans, gamerManager);
+    }
+
+    @Override
+    public String getName() {
+        return "Gold Chunk";
+    }
+
+    @Override
+    public @NotNull BlockData getType() {
+        return Material.RAW_GOLD_BLOCK.createBlockData();
+    }
+
+    @Override
+    public @NotNull BlockData getReplacement() {
+        return Material.RAW_IRON_BLOCK.createBlockData();
+    }
+
+    @Override
+    public ItemStack @NotNull [] generateDrops() {
+        return new ItemStack[] { getGoldChunk(minCoins, maxCoins) };
+    }
+
+    private ItemStack getGoldChunk(int minCoinsIn, int maxCoinsIn) {
+        int gold = random.ints(minCoinsIn, maxCoinsIn + 1).findAny().orElse(minCoinsIn);
+        Material material = gold - minCoinsIn > (maxCoinsIn - minCoinsIn) / 2 ? Material.GOLD_INGOT : Material.GOLD_NUGGET;
+
+        final ItemStack itemStack = new ItemStack(material, 1);
+        final ItemMeta meta = itemStack.getItemMeta();
+        final PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
+        pdc.set(key, PersistentDataType.INTEGER, gold);
+        itemStack.setItemMeta(meta);
+        return itemStack;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockPickup(InventoryPickupItemEvent event) {
+        final PersistentDataContainer pdc = event.getItem().getItemStack().getItemMeta().getPersistentDataContainer();
+        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
+        if (!pdc.has(key, PersistentDataType.INTEGER)) {
+            return; // Not a gold chunk
+        }
+
+        // Remove gold chunks from being picked up by blocks
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onItemPick(EntityPickupItemEvent event) {
+        final PersistentDataContainer pdc = event.getItem().getItemStack().getItemMeta().getPersistentDataContainer();
+        final NamespacedKey key = new NamespacedKey("clans", "gold-chunk");
+        if (!pdc.has(key, PersistentDataType.INTEGER)) {
+            return; // Not a gold chunk
+        }
+
+        final LivingEntity entity = event.getEntity();
+        if (!(entity instanceof Player player)) {
+            event.setCancelled(true); // Only players can pick up gold chunks
+            return;
+        }
+
+        final int gold = Objects.requireNonNullElse(pdc.get(key, PersistentDataType.INTEGER), 0);
+        final Optional<Gamer> gamerOpt = gamerManager.getObject(player.getUniqueId());
+        if (gamerOpt.isEmpty()) {
+            event.setCancelled(true);
+            return; // Broken ?
+        }
+
+        // Success
+        event.getItem().remove();
+        event.setCancelled(true);
+        final Gamer gamer = gamerOpt.get();
+        gamer.saveProperty(GamerProperty.BALANCE, gamer.getBalance() + gold);
+
+        // Cues
+        final Component titleMsg = UtilMessage.deserialize("<yellow>+%s Coins", gold);
+        final Title.Times times = Title.Times.times(Duration.ofSeconds(0), Duration.ofSeconds(1), Duration.ofSeconds(0));
+        final Title title = Title.title(Component.empty(), titleMsg, times);
+        player.showTitle(title);
+        player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 2f);
+        UtilMessage.message(player, "Fields", "You picked up <alt2>%s</alt2> coins!", gold);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/LootChest.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/LootChest.java
@@ -1,0 +1,116 @@
+package me.mykindos.betterpvp.clans.fields.block;
+
+import com.google.common.base.Preconditions;
+import me.mykindos.betterpvp.clans.clans.events.TerritoryInteractEvent;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.WeighedList;
+import org.apache.commons.lang.math.IntRange;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Random;
+import java.util.Set;
+
+@BPvPListener
+public class LootChest implements FieldsInteractable, Listener {
+
+    private static final Random random = new Random();
+
+    private double respawnDelay = 0;
+    private final WeighedList<Pair<Material, IntRange>> drops = new WeighedList<>();
+    private int dropCount = 1;
+
+    @Override
+    public String getName() {
+        return "Loot Chest";
+    }
+
+    @Override
+    public boolean processInteraction(TerritoryInteractEvent event, FieldsBlock block) {
+        if (!event.getInteractionType().equals(TerritoryInteractEvent.InteractionType.INTERACT)) {
+            return false; // They didn't right-click the chest
+        }
+
+        // Drop the items
+        for (int i = 0; i < dropCount; i++) {
+            final Pair<Material, IntRange> randomDrop = drops.random();
+            if (randomDrop == null) {
+                UtilMessage.message(event.getPlayer(), "Fields", "<red>There are no drops configured for this chest.");
+                return false; // No drops loaded
+            }
+
+            final Material material = randomDrop.getLeft();
+            final IntRange amtRange = randomDrop.getRight();
+            final int randomAmount = random.ints(amtRange.getMinimumInteger(), amtRange.getMaximumInteger() + 1).findAny().orElse(1);
+
+            final ItemStack drop = new ItemStack(material, randomAmount);
+            event.getBlock().getWorld().dropItem(event.getBlock().getLocation(), drop);
+        }
+
+        // Block break particles
+        event.getBlock().getWorld().playEffect(event.getBlock().getLocation(), Effect.STEP_SOUND, event.getBlock().getType().createBlockData());
+        return true;
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        dropCount = config.getOrSaveInt("fields.blocks.lootchest.dropCount", 1);
+        ConfigurationSection section = config.getConfigurationSection("fields.blocks.lootchest.drops");
+        if (section == null) {
+            section = config.createSection("fields.blocks.lootchest.drops");
+        }
+
+        final Set<String> keys = section.getKeys(false);
+        for (String key : keys) {
+            final Material material = Material.getMaterial(key);
+            if (material == null) {
+                throw new IllegalArgumentException("Invalid material: " + key);
+            }
+
+            final int categoryWeight = section.getInt("." + key + ".categoryWeight");
+            final int weight = section.getInt("." + key + ".weight");
+            final int min = section.getInt("." + key + ".min", 1);
+            final int max = section.getInt("." + key + ".max", 1);
+
+            Preconditions.checkArgument(categoryWeight > 0, "Category weight must be greater than 0");
+            Preconditions.checkArgument(weight > 0, "Weight must be greater than 0");
+            Preconditions.checkArgument(min > 0, "Min must be greater than 0");
+            Preconditions.checkArgument(max > 0, "Max must be greater than 0");
+            Preconditions.checkArgument(min <= max, "Min must be less than or equal to max");
+
+            final IntRange range = new IntRange(min, max);
+            drops.add(categoryWeight, weight, Pair.of(material, range));
+        }
+    }
+
+    @Override
+    public @NotNull BlockData getType() {
+        return Material.ENDER_CHEST.createBlockData();
+    }
+
+    @Override
+    public @NotNull BlockData getReplacement() {
+        return Material.AIR.createBlockData();
+    }
+
+    @Override
+    public double getRespawnDelay() {
+        return respawnDelay;
+    }
+
+    @Override
+    public void setRespawnDelay(double delay) {
+        this.respawnDelay = delay;
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/SimpleOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/SimpleOre.java
@@ -1,0 +1,84 @@
+package me.mykindos.betterpvp.clans.fields.block;
+
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.clans.fields.model.FieldsOre;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Random;
+
+@Getter
+public enum SimpleOre implements FieldsOre {
+
+    // Stone
+    GOLD("Gold Ore", Material.GOLD_ORE, Material.STONE, Material.GOLD_INGOT, 3),
+    IRON("Iron Ore", Material.IRON_ORE, Material.STONE, Material.IRON_INGOT, 3),
+    COAL("Coal Ore", Material.COAL_ORE, Material.STONE, Material.COAL, 4),
+    COPPER("Leather Ore", Material.COPPER_ORE, Material.STONE, Material.LEATHER, 3),
+    DIAMOND("Diamond Ore", Material.DIAMOND_ORE, Material.STONE, Material.DIAMOND, 3),
+    EMERALD("Emerald Ore", Material.EMERALD_ORE, Material.STONE, Material.EMERALD, 2),
+    LAPIS("Lapis Ore", Material.LAPIS_ORE, Material.STONE, Material.LAPIS_LAZULI, 5),
+    REDSTONE("Redstone Ore", Material.REDSTONE_ORE, Material.STONE, Material.REDSTONE, 1),
+
+    // Deepslate
+    GOLD_DEEPSLATE("Condensed Gold Ore", Material.DEEPSLATE_GOLD_ORE, Material.DEEPSLATE, Material.GOLD_INGOT, 3),
+    IRON_DEEPSLATE("Condensed Iron Ore", Material.DEEPSLATE_IRON_ORE, Material.DEEPSLATE, Material.IRON_INGOT, 3),
+    COAL_DEEPSLATE("Condensed Coal Ore", Material.DEEPSLATE_COAL_ORE, Material.DEEPSLATE, Material.COAL, 4),
+    COPPER_DEEPSLATE("Condensed Leather Ore", Material.DEEPSLATE_COPPER_ORE, Material.DEEPSLATE, Material.LEATHER, 3),
+    DIAMOND_DEEPSLATE("Condensed Diamond Ore", Material.DEEPSLATE_DIAMOND_ORE, Material.DEEPSLATE, Material.DIAMOND, 3),
+    EMERALD_DEEPSLATE("Condensed Emerald Ore", Material.DEEPSLATE_EMERALD_ORE, Material.DEEPSLATE, Material.EMERALD, 2),
+    LAPIS_DEEPSLATE("Condensed Lapis Ore", Material.DEEPSLATE_LAPIS_ORE, Material.DEEPSLATE, Material.LAPIS_LAZULI, 5),
+    REDSTONE_DEEPSLATE("Condensed Redstone Ore", Material.DEEPSLATE_REDSTONE_ORE, Material.DEEPSLATE, Material.REDSTONE, 1),
+
+    // Netherrack
+    GOLD_NETHER("Gold Ore", Material.NETHER_GOLD_ORE, Material.NETHERRACK, Material.GOLD_INGOT, 3),
+    QUARTZ("Quartz Ore", Material.NETHER_QUARTZ_ORE, Material.NETHERRACK, Material.QUARTZ, 5),
+    ;
+
+    private static final Random RANDOM = new Random();
+
+    private final @NotNull BlockData type;
+
+    private final @NotNull BlockData replacement;
+
+    private final @NotNull Material drop;
+
+    @Setter
+    private double respawnDelay = 60; // All default to 60 seconds
+
+    private final String name;
+
+    private int min;
+    private int max;
+
+    SimpleOre(@NotNull String name, Material type, Material replacement, Material drop, int max) {
+        this.type = type.createBlockData();
+        this.replacement = replacement.createBlockData();
+        this.drop = drop;
+        this.name = name;
+        this.max = max;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public ItemStack @NotNull [] generateDrops() {
+        return new ItemStack[] {
+                new ItemStack(drop, RANDOM.ints(min, max + 1).findAny().orElse(1))
+        };
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        final String key = "fields.blocks." + getName().toLowerCase().replace(" ", "");
+        min = config.getOrSaveInt(key + ".min", 1);
+        max = config.getOrSaveInt(key + ".max", 1);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/SimpleOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/block/SimpleOre.java
@@ -77,8 +77,8 @@ public enum SimpleOre implements FieldsOre {
     @Override
     public void loadConfig(ExtendedYamlConfiguration config) {
         final String key = "fields.blocks." + getName().toLowerCase().replace(" ", "");
-        min = config.getOrSaveInt(key + ".min", 1);
-        max = config.getOrSaveInt(key + ".max", 1);
+        min = config.getOrSaveInt(key + ".min", min);
+        max = config.getOrSaveInt(key + ".max", max);
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/FieldsCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/FieldsCommand.java
@@ -1,0 +1,46 @@
+package me.mykindos.betterpvp.clans.fields.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.framework.annotations.WithReflection;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class FieldsCommand extends Command {
+
+    private final ClanManager clanManager;
+    private final GamerManager gamerManager;
+
+    @WithReflection
+    @Inject
+    public FieldsCommand(ClanManager clanManager, GamerManager gamerManager) {
+        this.clanManager = clanManager;
+        this.gamerManager = gamerManager;
+    }
+
+    @Override
+    public String getName() {
+        return "fields";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fields administration command";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        if (args.length != 0) return;
+
+        UtilMessage.simpleMessage(player, "Fields", "Fields administration commands:");
+        UtilMessage.simpleMessage(player, "Fields", "/fields claim [borderSize] - Claim land for fields");
+        UtilMessage.simpleMessage(player, "Fields", "/fields respawn - Respawn all ores in fields");
+        UtilMessage.simpleMessage(player, "Fields", "/fields info - Get current information for fields");
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsClaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsClaimSubCommand.java
@@ -1,0 +1,79 @@
+package me.mykindos.betterpvp.clans.fields.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.events.ChunkClaimEvent;
+import me.mykindos.betterpvp.clans.fields.commands.FieldsCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.components.clans.data.ClanTerritory;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+
+@Singleton
+@SubCommand(FieldsCommand.class)
+public class FieldsClaimSubCommand extends Command {
+
+    @Inject
+    private ClanManager clanManager;
+
+    @Override
+    public String getName() {
+        return "claim";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Claim land for fields";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        int borderSize = 1;
+        if (args.length > 0) {
+            borderSize = Integer.parseInt(args[0]);
+        }
+
+        Optional<Clan> fieldsOptional = clanManager.getClanByName("Fields");
+        if (fieldsOptional.isEmpty()) {
+            UtilMessage.message(player, "Clans", "Fields clan does not exist, create it first.");
+            return;
+        }
+
+        Clan clan = clanManager.getClanByPlayer(player).orElseThrow();
+        Clan outskirts = fieldsOptional.get();
+
+        int claims = 0;
+        for (ClanTerritory territory : clan.getTerritory()) {
+            Chunk chunk = territory.getWorldChunk();
+            if (chunk == null) {
+                continue;
+            }
+
+            for (int x = -borderSize; x <= borderSize; x++) {
+                for (int z = -borderSize; z <= borderSize; z++) {
+                    if (x == 0 && z == 0) {
+                        continue;
+                    }
+
+                    Chunk wildernessChunk = chunk.getWorld().getChunkAt(chunk.getX() + x, chunk.getZ() + z);
+                    Optional<Clan> locationClanOptional = clanManager.getClanByChunk(wildernessChunk);
+                    if (locationClanOptional.isEmpty()) {
+                        UtilServer.callEvent(new ChunkClaimEvent(player, outskirts, wildernessChunk));
+                        claims++;
+                    }
+                }
+            }
+        }
+
+        UtilMessage.simpleMessage(player, "Clans", "Added <yellow>%s<gray> claims to the Fields clan.", claims);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsInfoSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsInfoSubCommand.java
@@ -1,0 +1,71 @@
+package me.mykindos.betterpvp.clans.fields.commands.subcommands;
+
+import com.google.common.collect.HashMultimap;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.fields.Fields;
+import me.mykindos.betterpvp.clans.fields.commands.FieldsCommand;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.Set;
+
+@Singleton
+@SubCommand(FieldsCommand.class)
+public class FieldsInfoSubCommand extends Command {
+
+    @Inject
+    private ClanManager clanManager;
+
+    @Inject
+    private Fields fields;
+
+    @Override
+    public String getName() {
+        return "info";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display information on Fields.";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final Set<FieldsInteractable> types = fields.getBlockTypes();
+        final HashMultimap<FieldsInteractable, FieldsBlock> blocks = fields.getBlocks();
+        final long activeOres = blocks.values().stream().filter(FieldsBlock::isActive).count();
+        final long inactiveOres = blocks.values().size() - activeOres;
+        final double modifier = fields.getSpeedBuff();
+
+        UtilMessage.simpleMessage(player, "Fields", "Fields information:");
+        UtilMessage.simpleMessage(player, "Fields", "Active blocks: <alt2>%s",activeOres);
+        UtilMessage.simpleMessage(player, "Fields", "Inactive blocks: <alt2>%s",inactiveOres);
+        UtilMessage.simpleMessage(player, "Fields", "Player count buff: <alt2>%sx",modifier);
+        UtilMessage.simpleMessage(player, "Fields", "");
+        UtilMessage.simpleMessage(player, "Fields", "Blocks:");
+
+        for (FieldsInteractable type : types) {
+            final Collection<FieldsBlock> typeOres = fields.getBlocks(type);
+            final long total = typeOres.size();
+            final long active = typeOres.stream().filter(FieldsBlock::isActive).count();
+
+            UtilMessage.simpleMessage(player,
+                    "Fields",
+                    "- <alt2>%s</alt2> (<alt>%s</alt>/<alt>%s</alt>) (<alt>%s</alt>s)",
+                    type.getName(),
+                    active,
+                    total,
+                    type.getRespawnDelay() / modifier
+            );
+        }
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsRespawnSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/commands/subcommands/FieldsRespawnSubCommand.java
@@ -1,0 +1,41 @@
+package me.mykindos.betterpvp.clans.fields.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.fields.Fields;
+import me.mykindos.betterpvp.clans.fields.commands.FieldsCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.Player;
+
+@Singleton
+@SubCommand(FieldsCommand.class)
+public class FieldsRespawnSubCommand extends Command {
+
+    @Inject
+    private ClanManager clanManager;
+
+    @Inject
+    private Fields fields;
+
+    @Override
+    public String getName() {
+        return "respawn";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Respawn all ores in Fields.";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        fields.getBlocks().forEach((type, ore) -> ore.setLastUsed(0));
+
+        UtilMessage.simpleMessage(player, "Clans", "Successfully respawned all ores in Fields.");
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/CustomOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/CustomOre.java
@@ -1,0 +1,32 @@
+package me.mykindos.betterpvp.clans.fields.model;
+
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+
+public abstract class CustomOre implements FieldsOre {
+
+    protected final Clans clans;
+    protected final GamerManager gamerManager;
+    private double respawnDelay = 0;
+
+    protected CustomOre(Clans clans, GamerManager gamerManager) {
+        this.clans = clans;
+        this.gamerManager = gamerManager;
+    }
+
+    @Override
+    public final double getRespawnDelay() {
+        return respawnDelay;
+    }
+
+    @Override
+    public final void setRespawnDelay(double delay) {
+        this.respawnDelay = delay;
+    }
+
+    protected <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+        final String key = "fields.blocks." + getName().toLowerCase().replace(" ", "") + "." + name;
+        return clans.getConfig().getOrSaveObject(key, defaultValue, type);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsBlock.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsBlock.java
@@ -1,0 +1,31 @@
+package me.mykindos.betterpvp.clans.fields.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+
+/**
+ * Represents an ore in the Fields zone.
+ */
+@Data
+@EqualsAndHashCode(of = {"world", "x", "y", "z"})
+public class FieldsBlock {
+
+    private final String world;
+    private final int x;
+    private final int y;
+    private final int z;
+    private long lastUsed; // when it was last mined, used for regeneration
+    private boolean active; // if it is active or not
+
+    public World getWorld() {
+        return Bukkit.getWorld(world);
+    }
+
+    public Location toLocation() {
+        return new Location(getWorld(), x, y, z);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsInteractable.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsInteractable.java
@@ -1,0 +1,65 @@
+package me.mykindos.betterpvp.clans.fields.model;
+
+import me.mykindos.betterpvp.clans.clans.events.TerritoryInteractEvent;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a block on fields you can interact with. Place, break, or click.
+ */
+public interface FieldsInteractable {
+
+    /**
+     * The name of the ore.
+     * @return the name
+     */
+    String getName();
+
+    /**
+     * Processes an interaction with the block.
+     * @param event the event
+     * @param block the block
+     */
+    boolean processInteraction(TerritoryInteractEvent event, FieldsBlock block);
+
+    /**
+     * The ore type.
+     */
+    @NotNull BlockData getType();
+
+    /**
+     * Checks if the block data matches the block type.
+     * @param data the block data
+     * @return true if it matches
+     */
+    default boolean matches(Block block) {
+        return block.getType().equals(getType().getMaterial());
+    }
+
+    /**
+     * The replacement block when the ore is mined.
+     */
+    @NotNull BlockData getReplacement();
+
+
+    /**
+     * The delay before the ore respawns, in seconds.
+     */
+    double getRespawnDelay();
+
+    /**
+     * Sets the respawn delay.
+     * @param delay the delay
+     */
+    void setRespawnDelay(double delay);
+
+    /**
+     * Reloads the ore from the config.
+     */
+    default void loadConfig(ExtendedYamlConfiguration config) {
+
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsOre.java
@@ -1,0 +1,32 @@
+package me.mykindos.betterpvp.clans.fields.model;
+
+import me.mykindos.betterpvp.clans.clans.events.TerritoryInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The different types of ores that can be found in the Fields clan.
+ * These are the main ore families that can be found.
+ */
+public interface FieldsOre extends FieldsInteractable {
+
+    /**
+     * The drops to give when the ore is mined.
+     * If the field is null, the default drops will be given.
+     */
+    @NotNull ItemStack @NotNull [] generateDrops();
+
+    @Override
+    default boolean processInteraction(TerritoryInteractEvent event, FieldsBlock block) {
+        if (!event.getInteractionType().equals(TerritoryInteractEvent.InteractionType.BREAK)) {
+            return false; // They didn't break the ore
+        }
+
+        // Drop the items
+        final ItemStack[] itemStacks = generateDrops();
+        for (ItemStack itemStack : itemStacks) {
+            event.getBlock().getWorld().dropItemNaturally(event.getBlock().getLocation(), itemStack);
+        }
+        return true;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/repository/FieldsBlockEntry.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/repository/FieldsBlockEntry.java
@@ -1,0 +1,28 @@
+package me.mykindos.betterpvp.clans.fields.repository;
+
+import com.google.common.base.Preconditions;
+import lombok.Value;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a database entry for a Fields ore.
+ */
+@Value
+public class FieldsBlockEntry {
+
+    @Nullable
+    FieldsInteractable type; // null if deleted
+    String world;
+    int x;
+    int y;
+    int z;
+
+    public FieldsBlock toFieldsOre() {
+        Preconditions.checkNotNull(type, "type");
+        return new FieldsBlock(world, x, y, z);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/repository/FieldsRepository.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/repository/FieldsRepository.java
@@ -1,0 +1,129 @@
+package me.mykindos.betterpvp.clans.fields.repository;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.fields.Fields;
+import me.mykindos.betterpvp.clans.fields.block.SimpleOre;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.core.database.Database;
+import me.mykindos.betterpvp.core.database.query.Statement;
+import me.mykindos.betterpvp.core.database.query.values.IntegerStatementValue;
+import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
+import me.mykindos.betterpvp.core.database.repository.IRepository;
+import org.jetbrains.annotations.NotNull;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Modifier;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+@Singleton
+@Slf4j
+public class FieldsRepository implements IRepository<FieldsBlockEntry> {
+
+    private final Set<FieldsInteractable> types = new HashSet<>();
+    private Database database;
+    private Clans clans;
+
+    @Inject
+    public FieldsRepository(Clans clans, Database database) {
+        this.clans = clans;
+        this.database = database;
+
+        Reflections reflections = new Reflections(Fields.class.getPackageName());
+        Set<Class<? extends FieldsInteractable>> classes = reflections.getSubTypesOf(FieldsInteractable.class);
+        for (var clazz : classes) {
+            if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers()) || clazz.isEnum()) continue;
+            if (clazz.isAnnotationPresent(Deprecated.class)) continue;
+            FieldsInteractable interactable = clans.getInjector().getInstance(clazz);
+            clans.getInjector().injectMembers(interactable);
+            types.add(interactable);
+        }
+        types.addAll(List.of(SimpleOre.values()));
+        log.info("Loaded " + types.size() + " ore types");
+    }
+
+    public void reload() {
+        types.forEach(type -> clans.getInjector().injectMembers(type));
+    }
+
+    public Set<FieldsInteractable> getTypes() {
+        return types;
+    }
+
+    @Override
+    public List<FieldsBlockEntry> getAll() {
+        List<FieldsBlockEntry> ores = new ArrayList<>();
+        String query = "SELECT * FROM " + clans.getDatabasePrefix() + "fields_ores";
+        ResultSet result = database.executeQuery(new Statement(query));
+        try {
+            while (result.next()) {
+                final String world = result.getString("world");
+                final int x = result.getInt("x");
+                final int y = result.getInt("y");
+                final int z = result.getInt("z");
+                final String typeName = result.getString("type");
+                FieldsInteractable type = types.stream()
+                        .filter(t -> t.getName().equalsIgnoreCase(typeName))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("Unknown block type: " + typeName));
+
+                ores.add(new FieldsBlockEntry(type, world, x, y, z));
+            }
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+
+        return ores;
+    }
+
+    public void delete(String world, int x, int y, int z) {
+        String stmt = "DELETE FROM " + clans.getDatabasePrefix() + "fields_ores WHERE world = ? AND x = ? AND y = ? AND z = ?;";
+        database.executeUpdate(new Statement(stmt,
+                new StringStatementValue(world),
+                new IntegerStatementValue(x),
+                new IntegerStatementValue(y),
+                new IntegerStatementValue(z)));
+    }
+
+    @Override
+    public void save(@NotNull FieldsBlockEntry ore) {
+        if (ore.getType() == null) {
+            delete(ore.getWorld(), ore.getX(), ore.getY(), ore.getZ());
+            return;
+        }
+
+        String stmt = "INSERT INTO " + clans.getDatabasePrefix() + "fields_ores (world, x, y, z, type) VALUES (?, ?, ?, ?, ?);";
+        database.executeUpdate(new Statement(stmt,
+                new StringStatementValue(ore.getWorld()),
+                new IntegerStatementValue(ore.getX()),
+                new IntegerStatementValue(ore.getY()),
+                new IntegerStatementValue(ore.getZ()),
+                new StringStatementValue(ore.getType().getName())));
+    }
+
+    @SneakyThrows
+    public void saveBatch(@NotNull Collection<@NotNull FieldsBlockEntry> ores) {
+        String stmt = "INSERT INTO " + clans.getDatabasePrefix() + "fields_ores (world, x, y, z, type) VALUES (?, ?, ?, ?, ?);";
+        List<Statement> statements = new ArrayList<>();
+        for (FieldsBlockEntry ore : ores) {
+            if (ore.getType() == null) {
+                delete(ore.getWorld(), ore.getX(), ore.getY(), ore.getZ());
+                continue;
+            }
+
+            Statement statement = new Statement(stmt,
+                    new StringStatementValue(ore.getWorld()),
+                    new IntegerStatementValue(ore.getX()),
+                    new IntegerStatementValue(ore.getY()),
+                    new IntegerStatementValue(ore.getZ()),
+                    new StringStatementValue(ore.getType().getName()));
+            statements.add(statement);
+        }
+        database.executeBatch(statements, true);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/utilities/ClansNamespacedKeys.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/utilities/ClansNamespacedKeys.java
@@ -1,0 +1,9 @@
+package me.mykindos.betterpvp.clans.utilities;
+
+import org.bukkit.NamespacedKey;
+
+public class ClansNamespacedKeys {
+
+    public static final NamespacedKey FIELDS_GOLD_CHUNK = new NamespacedKey("clans", "fields-gold-chunk");
+
+}

--- a/clans/src/main/resources/clans-migrations/V1_2__fields.sql
+++ b/clans/src/main/resources/clans-migrations/V1_2__fields.sql
@@ -1,0 +1,9 @@
+create table if not exists ${tablePrefix}fields_ores
+(
+    world varchar(32) not null,
+    x int not null,
+    y int not null,
+    z int not null,
+    type varchar(32) not null,
+    primary key (world, x, y, z)
+);

--- a/clans/src/main/resources/config.yml
+++ b/clans/src/main/resources/config.yml
@@ -128,3 +128,91 @@ command:
     reload:
       enabled: true
       requiredRank: ADMIN
+fields:
+  blocks:
+    goldchunk:
+      maxCoins: 150
+      minCoins: 50
+      respawn: 1800.0
+    condensedgoldore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedironore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    emeraldore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    lootchest:
+      respawn: 1800.0
+      dropCount: 1
+      drops:
+        DIAMOND:
+          categoryWeight: 1
+          weight: 1
+          min: 1
+          max: 5
+    diamondore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedcoalore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    goldore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    redstoneore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    coalore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condenseddiamondore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedredstoneore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    lapisore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    quartzore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedlapisore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedemeraldore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    ironore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    leatherore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+    condensedleatherore:
+      respawn: 1800.0
+      min: 1
+      max: 1
+  playerCountSpeeds:
+    '25': 1.5
+    '50': 2
+    '75': 2.5
+    '100': 3

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/commands/ClientCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/commands/ClientCommand.java
@@ -2,18 +2,20 @@ package me.mykindos.betterpvp.core.client.commands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.ClientManager;
 import me.mykindos.betterpvp.core.client.Rank;
+import me.mykindos.betterpvp.core.client.events.ClientAdministrateEvent;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Singleton
 public class ClientCommand extends Command {
@@ -50,7 +52,8 @@ public class ClientCommand extends Command {
         @Override
         public void execute(Player player, Client client, String[] args) {
             client.setAdministrating(!client.isAdministrating());
-            
+            new ClientAdministrateEvent(client, player, client.isAdministrating()).callEvent();
+
             Component status = client.isAdministrating() ? Component.text("enabled", NamedTextColor.GREEN) : Component.text("disabled", NamedTextColor.RED);
             UtilMessage.simpleMessage(player, "Command", Component.text("Client admin: ").append(status));
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/events/ClientAdministrateEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/events/ClientAdministrateEvent.java
@@ -1,0 +1,17 @@
+package me.mykindos.betterpvp.core.client.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class ClientAdministrateEvent extends CustomEvent {
+
+    Client client;
+    Player player;
+    boolean administrating;
+
+}


### PR DESCRIPTION
Changes:
- Implementation Fields clans zone 
- Create `TerritoryInteractEvent` to listen for whenever a user interacts with a claimed territory, whether it be placing, breaking or clicking blocks.
- Fix colored messaging when walking to Fields territory.
- Create `ClientAdministrateEvent` to listen for whenever an admin uses the `/client admin` command
- Creat `/fields` command and subcommand

Behavior:
- Fields:
    - Configurable values for all interactables.
    - Condition-based respawn delay modifiers, configurable per player-count. 
    - `FieldsInteractable` represents all interactable blocks within fields, which include ores and clickable blocks. A default implementation of this is `LootChest`
    - `SimpleOre` is an interactable that represents all default minecraft ores that drop a single `Material` with a min and max range.
    - `CustomOre` is an interactable that represents ores with custom implementations like `GoldChunkOre`, which drops gold nuggets/ingots that give the player coins.
- Fields commands:
    - `/fields` displays the help message
    - `/fields respawn` respawns all the interactable blocks
    - `/fields info` displays information on all interactable blocks and player buffs
    - `/fields claim <radius>` claims an area with a radius for fields
    
Changes were tested.