### PR TITLE
Add a warning for low energy.

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
@@ -211,16 +211,6 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
         });
     }
 
-    /**
-     * Send a title to all online clan members
-     * @param message
-     * @return
-     */
-
-    public void sendTitleClan(String title, String subtitle) {
-
-    }
-
     public String getEnergyTimeRemaining() {
 
         if (getTerritory().isEmpty()) {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
@@ -211,13 +211,27 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
         });
     }
 
+    /**
+     * Send a title to all online clan members
+     * @param message
+     * @return
+     */
+
+    public void sendTitleClan(String title, String subtitle) {
+
+    }
+
     public String getEnergyTimeRemaining() {
 
         if (getTerritory().isEmpty()) {
             return "\u221E";
         }
-        return UtilTime.getTime((getEnergy() / (float) (getTerritory().size() * 25)) * 3600000, UtilTime.TimeUnit.BEST, 2);
+        return UtilTime.getTime(getEnergyRatio() * 3600000, UtilTime.TimeUnit.BEST, 2);
 
+    }
+
+    public double getEnergyRatio() {
+        return getEnergy() / (float) (getTerritory().size() * 25);
     }
 
     @Override

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/EnergyCheckEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/EnergyCheckEvent.java
@@ -1,0 +1,14 @@
+package me.mykindos.betterpvp.clans.clans.events;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.core.components.clans.events.ClanEvent;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+@Getter
+public class EnergyCheckEvent extends ClanEvent<Clan> {
+    public EnergyCheckEvent(Player player, Clan clan) {
+        super(player, clan, false);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
@@ -38,7 +38,7 @@ public class ClanEnergyListener extends ClanListener{
         this.clans = clans;
     }
 
-    @UpdateEvent(delay = 30 * 1000, isAsync = true)
+    @UpdateEvent(delay = 300 * 1000, isAsync = true)
     public void checkEnergy() {
         Bukkit.getOnlinePlayers().forEach(player -> {
             Optional<Clan> clanOptional = clanManager.getClanByPlayer(player);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
@@ -29,7 +29,7 @@ public class ClanEnergyListener extends ClanListener{
 
 
     @Inject
-    @Config(path="clans.energy.energyWarnLevel", defaultValue = "4.0")
+    @Config(path="clans.energy.energyWarnLevel", defaultValue = "1.0")
     private double energyWarnLevel;
 
     @Inject
@@ -54,7 +54,7 @@ public class ClanEnergyListener extends ClanListener{
         if (event.isCancelled()) return;
         Player player = event.getPlayer();
         Clan clan = event.getClan();
-        if (clan.getEnergyRatio() < 36.0) {
+        if (clan.getEnergyRatio() < energyWarnLevel) {
             Component title = Component.text("CLAN ENERGY LOW", NamedTextColor.RED);
             Component subTitle = Component.text("Time Remaining: ", NamedTextColor.YELLOW).append(Component.text(clan.getEnergyTimeRemaining(), NamedTextColor.GREEN));
             player.showTitle(Title.title( title, subTitle));

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
@@ -1,0 +1,43 @@
+package me.mykindos.betterpvp.clans.clans.listeners;
+
+import com.google.inject.Inject;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.display.TitleComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Bukkit;
+
+import java.util.Optional;
+
+public class ClanEnergyListener extends ClanListener{
+    @Inject
+    @Config(path="clans.energy.energyWarnLevel", defaultValue = "0.1")
+    private double energyWarnLevel;
+    ClanEnergyListener(ClanManager clanManager, GamerManager gamerManager) {
+        super(clanManager, gamerManager);
+    }
+
+    @UpdateEvent(delay = 30 * 1000, isAsync = true)
+    public void checkEnergy() {
+        Bukkit.getOnlinePlayers().forEach(player -> {
+            Optional<Clan> clanOptional = clanManager.getClanByPlayer(player);
+            if (clanOptional.isPresent()) {
+                Clan clan = clanOptional.get();
+                if (clan.getEnergyRatio() < 1.0) {
+                    Component title = Component.text("CLAN ENERGY LOW", NamedTextColor.RED);
+                    Component subTitle = Component.text("Time Remaining: ", NamedTextColor.YELLOW).append(Component.text(clan.getEnergyTimeRemaining(), NamedTextColor.GREEN));
+                    player.showTitle(Title.title( title, subTitle));
+                    UtilMessage.message(player, "Clans", title);
+                    UtilMessage.message(player, "Clans", subTitle);
+                }
+            }
+        });
+    }
+}
+

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEnergyListener.java
@@ -1,26 +1,41 @@
 package me.mykindos.betterpvp.clans.clans.listeners;
 
 import com.google.inject.Inject;
+import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.events.EnergyCheckEvent;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.display.TitleComponent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 
 import java.util.Optional;
 
+@BPvPListener
 public class ClanEnergyListener extends ClanListener{
+
+    private final Clans clans;
+
+
     @Inject
-    @Config(path="clans.energy.energyWarnLevel", defaultValue = "0.1")
+    @Config(path="clans.energy.energyWarnLevel", defaultValue = "4.0")
     private double energyWarnLevel;
-    ClanEnergyListener(ClanManager clanManager, GamerManager gamerManager) {
+
+    @Inject
+    ClanEnergyListener(Clans clans, ClanManager clanManager, GamerManager gamerManager) {
         super(clanManager, gamerManager);
+        this.clans = clans;
     }
 
     @UpdateEvent(delay = 30 * 1000, isAsync = true)
@@ -29,15 +44,23 @@ public class ClanEnergyListener extends ClanListener{
             Optional<Clan> clanOptional = clanManager.getClanByPlayer(player);
             if (clanOptional.isPresent()) {
                 Clan clan = clanOptional.get();
-                if (clan.getEnergyRatio() < 1.0) {
-                    Component title = Component.text("CLAN ENERGY LOW", NamedTextColor.RED);
-                    Component subTitle = Component.text("Time Remaining: ", NamedTextColor.YELLOW).append(Component.text(clan.getEnergyTimeRemaining(), NamedTextColor.GREEN));
-                    player.showTitle(Title.title( title, subTitle));
-                    UtilMessage.message(player, "Clans", title);
-                    UtilMessage.message(player, "Clans", subTitle);
-                }
+                UtilServer.runTaskLater(clans, () -> {UtilServer.callEvent(new EnergyCheckEvent(player, clan));}, 5);
             }
         });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEnergyCheck(EnergyCheckEvent event) {
+        if (event.isCancelled()) return;
+        Player player = event.getPlayer();
+        Clan clan = event.getClan();
+        if (clan.getEnergyRatio() < 36.0) {
+            Component title = Component.text("CLAN ENERGY LOW", NamedTextColor.RED);
+            Component subTitle = Component.text("Time Remaining: ", NamedTextColor.YELLOW).append(Component.text(clan.getEnergyTimeRemaining(), NamedTextColor.GREEN));
+            player.showTitle(Title.title( title, subTitle));
+            UtilMessage.message(player, "Clans", title);
+            UtilMessage.message(player, "Clans", subTitle);
+        }
     }
 }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanPropertyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanPropertyListener.java
@@ -26,4 +26,5 @@ public class ClanPropertyListener extends ClanListener{
     public void processStatUpdates(){
         clanManager.getRepository().processPropertyUpdates(true);
     }
+
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
@@ -65,9 +65,9 @@ public class UtilTime {
             return "Seconds";
         } else if (d >= 60000L && d <= 3600000L) {
             return "Minutes";
-        } else if (d >= 3600000L && d <= 86400000L) {
+        } else if (d >= 3600000L && d < 86400000L) {
             return "Hours";
-        } else if (d >= 86400000L && d <= 31536000000L) {
+        } else if (d >= 86400000L && d < 31536000000L) {
             return "Days";
         }
         return "Years";


### PR DESCRIPTION
Add a title/chat warning for low energy, which is checked every 5 minutes. If your clan has less than `1.0` hours, receive a warning through title and chat.

Also fixes a bug in UtilTime.getTIme chain.