### PR TITLE
Added the following c subcommands: setenergy, list, stuck

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
@@ -87,6 +87,10 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
         putProperty(ClanProperty.BALANCE, balance);
     }
 
+    public void setEnergy(int energy) {
+        putProperty(ClanProperty.ENERGY, energy);
+    }
+
     public Optional<ClanMember> getLeader() {
         return members.stream().filter(clanMember -> clanMember.getRank() == ClanMember.MemberRank.LEADER).findFirst();
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -161,20 +161,13 @@ public class ClanManager extends Manager<Clan> {
         Chunk playerChunk = player.getChunk();
         World world = player.getWorld();
 
-        boolean end = false;
-
-        for (int i = 1; i < maxChunksRadiusToScan; i++) {
-            int[] offset = {-i, 0, i};
-            for (int x : offset) {
-                for (int z: offset) {
-                    Chunk chunk = world.getChunkAt(playerChunk.getX() + x, playerChunk.getZ() + z);
-                    if (getClanByChunk(chunk).isEmpty()) {
-                        chunks.add(chunk);
-                        end = true;
-                    }
+        for (int i = -maxChunksRadiusToScan; i < maxChunksRadiusToScan; i++) {
+            for (int j = -maxChunksRadiusToScan; j < maxChunksRadiusToScan; j++) {
+                Chunk chunk = world.getChunkAt(playerChunk.getX() + i, playerChunk.getZ() + j);
+                if (getClanByChunk(chunk).isEmpty()) {
+                    chunks.add(chunk);
                 }
             }
-            if (end) break;
         }
 
         if (!chunks.isEmpty()) {
@@ -182,7 +175,6 @@ public class ClanManager extends Manager<Clan> {
 
             //this should not ever happen
             if (chunk == null) return null;
-
 
             List<Location> locations = new ArrayList<>();
 
@@ -194,7 +186,9 @@ public class ClanManager extends Manager<Clan> {
             }
 
             locations.sort(Comparator.comparingInt(a -> (int) player.getLocation().distanceSquared(a)));
-            return locations.get(0);
+
+            //to prevent getting stuck in a block, add 1 to Y
+            return locations.get(0).add(0, 1, 0);
         }
         return null;
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -23,6 +23,7 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.*;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.core.Direction;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -152,6 +153,37 @@ public class ClanManager extends Manager<Clan> {
         return relation == ClanRelation.SELF || relation == ClanRelation.ALLY_TRUST;
     }
 
+    public Location closestWilderness(Player player) {
+        List<Location> locations = new ArrayList<>();
+        //worst case scenario, we are stuck in the exact center of a 3x3 claim
+        for (int i = 0; i < ((16 + 8) + 1); i++) {
+            for (int d = 0; d < 4; d++) {
+                Location location = player.getLocation().toBlockLocation();
+                switch (d) {
+                    case 0:
+                        location.add(i, 0, 0);
+                        break;
+                    case 1:
+                        location.add(0, 0, i);
+                        break;
+                    case 2:
+                        location.add(-i, 0, 0);
+                        break;
+                    case 3:
+                        location.add(0, 0, -i);
+                }
+                Optional<Clan> clanOptional = getClanByLocation(location);
+                if (clanOptional.isEmpty()) {
+                    locations.add(location);
+                }
+            }
+        }
+        if (!locations.isEmpty()) {
+            locations.sort(Comparator.comparingInt(a -> (int) player.getLocation().distance(a)));
+            return locations.get(0);
+        }
+        return null;
+    }
     public Location closestWildernessBackwards(Player player) {
         List<Location> locations = new ArrayList<>();
         for (int i = 0; i < 64; i++) {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -155,33 +155,41 @@ public class ClanManager extends Manager<Clan> {
     }
 
     public Location closestWilderness(Player player) {
-        int maxChunksToScan = 3;
+        int maxChunksRadiusToScan = 3;
         List<Chunk> chunks = new ArrayList<>();
 
         Chunk playerChunk = player.getChunk();
         World world = player.getWorld();
 
-        for (int i = 1; i < maxChunksToScan; i++) {
+        boolean end = false;
+
+        for (int i = 1; i < maxChunksRadiusToScan; i++) {
             int[] offset = {-i, 0, i};
             for (int x : offset) {
                 for (int z: offset) {
                     Chunk chunk = world.getChunkAt(playerChunk.getX() + x, playerChunk.getZ() + z);
                     if (getClanByChunk(chunk).isEmpty()) {
                         chunks.add(chunk);
-                        break;
+                        end = true;
                     }
                 }
             }
+            if (end) break;
         }
 
         if (!chunks.isEmpty()) {
-            Chunk chunk = chunks.get(0);
+            Chunk chunk = UtilWorld.closestChunkToPlayer(chunks, player);
+
+            //this should not ever happen
+            if (chunk == null) return null;
+
+
             List<Location> locations = new ArrayList<>();
 
             int y = (int) player.getY();
             for (int i = 0; i < 16; i++) {
                 for (int j = 0; j < 16; j++) {
-                    locations.add(chunk.getBlock(i, y, j).getLocation());
+                    locations.add(chunk.getBlock(i, y, j).getLocation().toHighestLocation());
                 }
             }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ListSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ListSubCommand.java
@@ -29,8 +29,6 @@ public class ListSubCommand extends ClanSubCommand {
     @Inject
     public ListSubCommand(ClanManager clanManager, GamerManager gamerManager) {
         super(clanManager, gamerManager);
-        aliases.addAll(List.of("?", "h"));
-
     }
 
     @Override
@@ -61,8 +59,7 @@ public class ListSubCommand extends ClanSubCommand {
             }
         }
 
-        Collection<Clan> clansCollection = clanManager.getObjects().values();
-        List<Clan> clansList = new ArrayList<Clan>(clansCollection.stream().toList());
+        List<Clan> clansList = new ArrayList<>(clanManager.getObjects().values());
         Collections.sort(clansList, Comparator.comparing(Clan::getName));
 
         Component component = Component.text("Clans Page: ", NamedTextColor.YELLOW);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ListSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ListSubCommand.java
@@ -1,0 +1,113 @@
+package me.mykindos.betterpvp.clans.clans.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
+import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.components.clans.data.ClanMember;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import javax.inject.Named;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Singleton
+@SubCommand(ClanCommand.class)
+public class ListSubCommand extends ClanSubCommand {
+
+    @Inject
+    public ListSubCommand(ClanManager clanManager, GamerManager gamerManager) {
+        super(clanManager, gamerManager);
+        aliases.addAll(List.of("?", "h"));
+
+    }
+
+    @Override
+    public String getName() {
+        return "list";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List all clans.";
+    }
+
+    @Override public String getUsage() {
+        return super.getUsage() + " [pageNumber]";
+    }
+
+
+    @Override
+    public void execute(Player player, Client client, String... args) {;
+        int numPerPage = 10;
+        int pageNumber = 1;
+
+        if (args.length >= 1) {
+            try {
+                pageNumber = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+                //pass
+            }
+        }
+
+        List<Clan> clansList = clanManager.getRepository().getAll();
+
+        Collections.sort(clansList, Comparator.comparing(Clan::getName));
+
+        Component component = Component.text("Clans Page: ", NamedTextColor.YELLOW);
+
+        int count = 0;
+        int start = (pageNumber - 1) * numPerPage;
+        int end = start + numPerPage;
+        int size = clansList.size();
+
+        component = component.append(Component.text(pageNumber, NamedTextColor.WHITE));
+
+        if (start <= size) {
+            if (end > size) end = size;
+            for (Clan clan : clansList.subList(start, end)) {
+                if (count == numPerPage) break;
+                component = component.append(addClanComponent(clan));
+                count++;
+            }
+        }
+        UtilMessage.message(player, "Clans", component);
+    }
+
+
+
+    private Component addClanComponent(Clan clan) {
+        Component component = Component.empty().appendNewline();
+
+        List<ClanMember> clanMembers = clan.getMembers();
+
+        int onlineMembers = (int) clanMembers.stream().filter(member -> Bukkit.getPlayer(member.getUuid()) != null).count();
+
+        NamedTextColor color = onlineMembers > 0 ? NamedTextColor.GREEN : NamedTextColor.RED;
+
+        component = component.append(Component.text(clan.getName(), color))
+                .append(Component.text(" (", NamedTextColor.YELLOW))
+                .append(Component.text(onlineMembers, NamedTextColor.WHITE))
+                .append(Component.text("|", NamedTextColor.YELLOW))
+                .append(Component.text(clanMembers.size(), NamedTextColor.WHITE))
+                .append(Component.text(")", NamedTextColor.YELLOW));
+
+        return component;
+    }
+
+    @Override
+    public boolean canExecuteWithoutClan() {
+        return true;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
@@ -1,0 +1,71 @@
+package me.mykindos.betterpvp.clans.clans.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
+import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.components.clans.data.ClanEnemy;
+import me.mykindos.betterpvp.core.framework.events.scoreboard.ScoreboardUpdateEvent;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+
+@Singleton
+@SubCommand(ClanCommand.class)
+public class SetEnergySubCommand extends ClanSubCommand {
+
+    @Inject
+    public SetEnergySubCommand(ClanManager clanManager, GamerManager gamerManager) {
+        super(clanManager, gamerManager);
+    }
+
+    @Override
+    public String getName() {
+        return "setenergy";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Force set the energy for your current clan";
+    }
+
+    @Override
+    public String getUsage() {
+        return super.getUsage() + " <energy>";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+
+        int energy = Integer.parseInt(args[0]);
+
+        Clan playerClan = clanManager.getClanByPlayer(player).orElseThrow();
+
+        int oldEnergy = playerClan.getEnergy();
+        playerClan.setEnergy(energy);
+
+        Component component = Component.text("Energy set to: ", NamedTextColor.GRAY).append(Component.text(playerClan.getEnergy() + " - (", NamedTextColor.YELLOW)
+                .append(Component.text(playerClan.getEnergyTimeRemaining(), NamedTextColor.GOLD).append(Component.text(")", NamedTextColor.YELLOW))))
+            .append(Component.text(" Previous: ", NamedTextColor.GRAY)).append(Component.text(oldEnergy, NamedTextColor.YELLOW));
+
+        playerClan.getMembersAsPlayers().forEach(player1 -> {
+            UtilServer.callEvent(new ScoreboardUpdateEvent(player1));
+        });
+
+        UtilMessage.message(player, "Clans", component);
+    }
+
+    @Override
+    public boolean requiresServerAdmin() {
+        return true;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
@@ -46,7 +46,14 @@ public class SetEnergySubCommand extends ClanSubCommand {
     @Override
     public void execute(Player player, Client client, String... args) {
 
-        int energy = Integer.parseInt(args[0]);
+        int energy;
+        try {
+            energy = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            UtilMessage.message(player, "Clans", Component.text(args[0] + " is not a valid input. Input must be an integer."));
+            return;
+        }
+
 
         Clan playerClan = clanManager.getClanByPlayer(player).orElseThrow();
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/SetEnergySubCommand.java
@@ -45,7 +45,10 @@ public class SetEnergySubCommand extends ClanSubCommand {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-
+        if (args.length != 1) {
+            UtilMessage.message(player, "Clans", Component.text("This command requires 1 argument as input."));
+            return;
+        }
         int energy;
         try {
             energy = Integer.parseInt(args[0]);
@@ -54,6 +57,7 @@ public class SetEnergySubCommand extends ClanSubCommand {
             return;
         }
 
+        if (energy < 0) energy = 0;
 
         Clan playerClan = clanManager.getClanByPlayer(player).orElseThrow();
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/StuckSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/StuckSubCommand.java
@@ -1,0 +1,54 @@
+package me.mykindos.betterpvp.clans.clans.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
+import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.framework.delayedactions.events.ClanStuckTeleportEvent;
+import me.mykindos.betterpvp.core.gamer.GamerManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@Singleton
+@SubCommand(ClanCommand.class)
+public class StuckSubCommand extends ClanSubCommand {
+
+    @Inject
+    public StuckSubCommand(ClanManager clanManager, GamerManager gamerManager) {
+        super(clanManager, gamerManager);
+    }
+
+    @Override
+    public String getName() {
+        return "stuck";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Teleport out of a claim if you are stuck.";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        Location nearestWilderness = clanManager.closestWilderness(player);
+
+        if (nearestWilderness == null) {
+            UtilMessage.message(player, "Clans", Component.text("No wilderness found to teleport to", NamedTextColor.RED));
+            return;
+        }
+
+        UtilServer.callEvent(new ClanStuckTeleportEvent(player, () -> player.teleport(nearestWilderness)));
+    }
+
+    @Override
+    public boolean canExecuteWithoutClan() {
+        return true;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/StuckSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/StuckSubCommand.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.clans.clans.commands.subcommands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
 import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
@@ -11,18 +13,25 @@ import me.mykindos.betterpvp.core.framework.delayedactions.events.ClanStuckTelep
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import java.util.Optional;
+
 @Singleton
 @SubCommand(ClanCommand.class)
 public class StuckSubCommand extends ClanSubCommand {
 
+    private final Clans clans;
+
+    private long lastRun = System.currentTimeMillis();
     @Inject
-    public StuckSubCommand(ClanManager clanManager, GamerManager gamerManager) {
+    public StuckSubCommand(Clans clans, ClanManager clanManager, GamerManager gamerManager) {
         super(clanManager, gamerManager);
+        this.clans = clans;
     }
 
     @Override
@@ -37,15 +46,33 @@ public class StuckSubCommand extends ClanSubCommand {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        Location nearestWilderness = clanManager.closestWilderness(player);
-
-        if (nearestWilderness == null) {
-            UtilMessage.message(player, "Clans", Component.text("No wilderness found to teleport to", NamedTextColor.RED));
+        if (!UtilTime.elapsed(lastRun, 1 * 1000)) {
+            UtilMessage.message(player, "Clans", "Try again in a second");
             return;
         }
 
-        UtilServer.callEvent(new ClanStuckTeleportEvent(player, () -> player.teleport(nearestWilderness)));
+        lastRun = System.currentTimeMillis();
+
+        Optional<Clan> territoryOptional = clanManager.getClanByLocation(player.getLocation());
+
+            if (territoryOptional.isEmpty()) {
+                UtilMessage.message(player, "Clans", Component.text("You must be in a claimed territory to use ", NamedTextColor.GRAY)
+                        .append(Component.text("/c stuck", NamedTextColor.YELLOW)));
+                return;
+            }
+
+
+            Location nearestWilderness = clanManager.closestWilderness(player);
+
+            if (nearestWilderness == null) {
+                UtilMessage.message(player, "Clans", Component.text("No wilderness found to teleport to", NamedTextColor.RED));
+                return;
+            }
+
+            UtilServer.callEvent(new ClanStuckTeleportEvent(player, () -> player.teleport(nearestWilderness)));
     }
+
+
 
     @Override
     public boolean canExecuteWithoutClan() {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -117,7 +117,6 @@ public class ClansMovementListener extends ClanListener {
 
             UtilMessage.message(event.getPlayer(), "Clans", "You can only teleport to your clan home from spawn or the wilderness.");
             event.setCancelled(true);
-
         }, () -> {
             event.setDelayInSeconds(30);
         });
@@ -135,8 +134,7 @@ public class ClansMovementListener extends ClanListener {
         if (territoryOptional.isEmpty()) {
             UtilMessage.message(player, "Clans", Component.text("You must be in a claimed territory to use ", NamedTextColor.GRAY)
                     .append(Component.text("/c stuck", NamedTextColor.YELLOW)));
-            event.setCancelReason("In wilderness");
-            event.setCountdown(true);
+           event.cancel("In wilderness.");
             return;
         }
 
@@ -144,9 +142,9 @@ public class ClansMovementListener extends ClanListener {
         ClanRelation relation = clanManager.getRelation(clanManager.getClanByPlayer(player).orElse(null), territoryOptional.get());
 
         if (relation == ClanRelation.ENEMY) {
-            event.setDelayInSeconds(3 * 60);
+            event.setDelayInSeconds(3 * 5);
         } else {
-            event.setDelayInSeconds(2 * 60);
+            event.setDelayInSeconds(2 * 5);
         }
     }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -118,7 +118,6 @@ public class ClansMovementListener extends ClanListener {
             UtilMessage.message(event.getPlayer(), "Clans", "You can only teleport to your clan home from spawn or the wilderness.");
             event.setCancelled(true);
 
-
         }, () -> {
             event.setDelayInSeconds(30);
         });

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -16,6 +16,7 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.world.events.SpawnTeleportEvent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -129,12 +130,19 @@ public class ClansMovementListener extends ClanListener {
 
         Player player = event.getPlayer();
 
+        Location nearestWilderness = clanManager.closestWilderness(player);
+
+        if (nearestWilderness == null) {
+            UtilMessage.message(player, "Clans", Component.text("No wilderness found to teleport to", NamedTextColor.RED));
+            return;
+        }
+
         Optional<Clan> territoryOptional = clanManager.getClanByLocation(player.getLocation());
 
         if (territoryOptional.isEmpty()) {
             UtilMessage.message(player, "Clans", Component.text("You must be in a claimed territory to use ", NamedTextColor.GRAY)
                     .append(Component.text("/c stuck", NamedTextColor.YELLOW)));
-           event.cancel("In wilderness.");
+            event.cancel("In wilderness.");
             return;
         }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/delayedactions/events/ClanStuckTeleportEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/delayedactions/events/ClanStuckTeleportEvent.java
@@ -1,0 +1,14 @@
+package me.mykindos.betterpvp.core.framework.delayedactions.events;
+
+import org.bukkit.entity.Player;
+
+public class ClanStuckTeleportEvent extends PlayerDelayedActionEvent {
+
+    public ClanStuckTeleportEvent(Player player, Runnable runnable) {
+        super(player, runnable);
+        this.titleText = "Teleport";
+        this.subtitleText = "teleporting";
+        this.countdown = true;
+        this.countdownText = "Teleporting in";
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilWorld.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilWorld.java
@@ -4,7 +4,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 
+import java.util.Collection;
 import java.util.Iterator;
 
 public class UtilWorld {
@@ -47,6 +49,26 @@ public class UtilWorld {
 
         return location;
 
+    }
+
+    public static Chunk closestChunkToPlayer(Collection<Chunk> chunkList, Player player) {
+        if (chunkList.isEmpty()) {
+            return null;
+        }
+        Chunk closestChunk = (Chunk) chunkList.stream().findFirst().get();
+
+        int y = (int) player.getY();
+
+        double closestDistance = player.getLocation().distanceSquared(closestChunk.getBlock(8, y, 8).getLocation());
+
+        for (Chunk chunk : chunkList) {
+            double distance = player.getLocation().distanceSquared(chunk.getBlock(8, y, 8).getLocation());
+            if (closestDistance > distance) {
+                closestDistance = distance;
+                closestChunk = chunk;
+            }
+        }
+        return closestChunk;
     }
 
     /**


### PR DESCRIPTION
1. Implements https://github.com/Mykindos/BetterPvP/issues/66. Adds setEnergy in clan.java and a new admin command /c setenergy.
2. Implements #70. Adds /c list which lists all clans in the server.
3. Implements #73. Adds /c stuck which teleports the user after a lengthy delay out of a claimed area.