### PR TITLE
Admin claim/unclaim QOL

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
@@ -60,7 +60,7 @@ public class ClaimSubCommand extends ClanSubCommand {
             return;
         }
 
-        if (!clan.isAdmin()) {
+        if (!clan.isAdmin() || client.isAdministrating()) {
             if (clan.getTerritory().size() >= clan.getMembers().size() + additionalClaims) { // Previously
                 UtilMessage.message(player, "Clans", "Your Clan cannot claim more Territory.");
                 return;

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/ClaimSubCommand.java
@@ -60,7 +60,7 @@ public class ClaimSubCommand extends ClanSubCommand {
             return;
         }
 
-        if (!clan.isAdmin() || client.isAdministrating()) {
+        if (!(clan.isAdmin() || client.isAdministrating())) {
             if (clan.getTerritory().size() >= clan.getMembers().size() + additionalClaims) { // Previously
                 UtilMessage.message(player, "Clans", "Your Clan cannot claim more Territory.");
                 return;

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
 import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
 import me.mykindos.betterpvp.clans.clans.events.ChunkUnclaimEvent;
 import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.ClientManager;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.components.clans.data.ClanMember;
 import me.mykindos.betterpvp.core.config.Config;
@@ -26,9 +27,12 @@ public class UnclaimSubCommand extends ClanSubCommand {
     @Config(path = "clans.claims.additional", defaultValue = "3")
     private int additionalClaims;
 
+    private final ClientManager clientManager;
+
     @Inject
-    public UnclaimSubCommand(ClanManager clanManager, GamerManager gamerManager) {
+    public UnclaimSubCommand(ClanManager clanManager, GamerManager gamerManager, ClientManager clientManager) {
         super(clanManager, gamerManager);
+        this.clientManager = clientManager;
     }
 
     @Override
@@ -69,6 +73,15 @@ public class UnclaimSubCommand extends ClanSubCommand {
                 UtilMessage.simpleMessage(player, "Clans", "<yellow>%s<gray> has enough members to keep this territory.",
                         locationClan.getName());
                 return;
+            }
+
+            for (ClanMember clanMember : locationClan.getMembers()) {
+                Optional<Client> clientOptional = clientManager.getObject(clanMember.getUuid());
+                if (clientOptional.isPresent()) {
+                    if (clientOptional.get().isAdministrating()) {
+                        UtilMessage.message(player, "Clans", "You may not unclaim territory from this Clan at this time.");
+                    }
+                }
             }
         }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
@@ -31,7 +31,6 @@ public class UnclaimSubCommand extends ClanSubCommand {
     @Inject
     public UnclaimSubCommand(ClanManager clanManager, GamerManager gamerManager) {
         super(clanManager, gamerManager);
-        this.clientManager = clientManager;
     }
 
     @Override

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/UnclaimSubCommand.java
@@ -12,6 +12,7 @@ import me.mykindos.betterpvp.core.client.ClientManager;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.components.clans.data.ClanMember;
 import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.gamer.Gamer;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
@@ -27,10 +28,8 @@ public class UnclaimSubCommand extends ClanSubCommand {
     @Config(path = "clans.claims.additional", defaultValue = "3")
     private int additionalClaims;
 
-    private final ClientManager clientManager;
-
     @Inject
-    public UnclaimSubCommand(ClanManager clanManager, GamerManager gamerManager, ClientManager clientManager) {
+    public UnclaimSubCommand(ClanManager clanManager, GamerManager gamerManager) {
         super(clanManager, gamerManager);
         this.clientManager = clientManager;
     }
@@ -76,10 +75,11 @@ public class UnclaimSubCommand extends ClanSubCommand {
             }
 
             for (ClanMember clanMember : locationClan.getMembers()) {
-                Optional<Client> clientOptional = clientManager.getObject(clanMember.getUuid());
-                if (clientOptional.isPresent()) {
-                    if (clientOptional.get().isAdministrating()) {
+                Optional<Gamer> gamerOptional = gamerManager.getObject(clanMember.getUuid());
+                if (gamerOptional.isPresent()) {
+                    if (gamerOptional.get().getClient().isAdministrating()) {
                         UtilMessage.message(player, "Clans", "You may not unclaim territory from this Clan at this time.");
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
Implements #71. Admins in /client admin can claim more territory than a Clan is normally allowed to have (for handling accidental/mistaken/bugged disbands) according to their members. Territory cannot be unclaimed if the Clan that holds it has an admin in /client admin in it (to prevent unclaiming territory that would otherwise be unclaimable while in the process of restoring a Clans claims).