### PR TITLE
Create plugin adapter annotation to support plugin-dependent classes

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
@@ -6,17 +6,18 @@ import com.google.inject.Singleton;
 import lombok.Getter;
 import lombok.Setter;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
-import me.mykindos.betterpvp.clans.tips.ClansTipLoader;
 import me.mykindos.betterpvp.clans.commands.ClansCommandLoader;
 import me.mykindos.betterpvp.clans.injector.ClansInjectorModule;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
-import me.mykindos.betterpvp.clans.progression.ProgressionAdapter;
+import me.mykindos.betterpvp.clans.tips.ClansTipLoader;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.config.ConfigInjectorModule;
 import me.mykindos.betterpvp.core.database.Database;
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
 import me.mykindos.betterpvp.core.framework.ModuleLoadedEvent;
+import me.mykindos.betterpvp.core.framework.adapter.Adapters;
+import me.mykindos.betterpvp.core.framework.adapter.PluginAdapter;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEventExecutor;
 import me.mykindos.betterpvp.core.items.ItemHandler;
 import org.bukkit.Bukkit;
@@ -83,10 +84,7 @@ public class Clans extends BPvPPlugin {
 
             updateEventExecutor.loadPlugin(this);
 
-            var progression = Bukkit.getPluginManager().getPlugin("Progression");
-            if (progression != null) {
-                new ProgressionAdapter(this, (BPvPPlugin) progression, listenerLoader).load();
-            }
+            new Adapters(this).loadAdapters(new Reflections(PACKAGE).getTypesAnnotatedWith(PluginAdapter.class));
         }
     }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
@@ -1,30 +1,38 @@
 package me.mykindos.betterpvp.clans.progression;
 
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
-import me.mykindos.betterpvp.core.framework.BPvPPlugin;
+import me.mykindos.betterpvp.core.framework.adapter.PluginAdapter;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.ProgressionsManager;
 import me.mykindos.betterpvp.progression.model.ProgressionPerk;
 import me.mykindos.betterpvp.progression.model.ProgressionTree;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.reflections.Reflections;
 
 import java.lang.reflect.Modifier;
+import java.util.Objects;
 import java.util.Set;
 
+@PluginAdapter("Progression")
+@Slf4j
 public class ProgressionAdapter {
 
     private final Clans clans;
     private final Progression progression;
     private final ProgressionsManager progressionsManager;
     private final ClansListenerLoader listenerLoader;
-    
-    public ProgressionAdapter(Clans clans, BPvPPlugin progressions, ClansListenerLoader listenerLoader) {
+
+    @Inject
+    public ProgressionAdapter(Clans clans, ClansListenerLoader listenerLoader) {
         this.clans = clans;
         this.listenerLoader = listenerLoader;
-        this.progression = (Progression) progressions;
+        this.progression = Objects.requireNonNull((Progression) Bukkit.getPluginManager().getPlugin("Progression"));
         this.progressionsManager = progression.getProgressionsManager();
+        load();
     }
 
     public void load() {
@@ -47,7 +55,7 @@ public class ProgressionAdapter {
                 listenerLoader.load(clazz);
             }
         }
-
+        log.info("Loaded " + perkClasses.size() + " clans progression perks");
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/Adapters.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/Adapters.java
@@ -1,0 +1,38 @@
+package me.mykindos.betterpvp.core.framework.adapter;
+
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.framework.BPvPPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Slf4j
+public final class Adapters {
+
+    private final BPvPPlugin plugin;
+
+    public Adapters(BPvPPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void loadAdapters(Collection<Class<?>> adapters) {
+        final PluginManager pluginManager = Bukkit.getPluginManager();
+        for (Class<?> clazz : adapters) {
+            PluginAdapter adapterAnnotation = clazz.getAnnotation(PluginAdapter.class);
+            final String pluginName = adapterAnnotation.value();
+
+            Optional.ofNullable(pluginManager.getPlugin(pluginName)).ifPresentOrElse(dependencyPlugin -> {
+                try {
+                    final Object adapter = plugin.getInjector().getInstance(clazz);
+                    plugin.getInjector().injectMembers(adapter);
+                    log.info("Loaded adapter " + clazz.getSimpleName() + " for " + pluginName + "!");
+                } catch (Exception e) {
+                    log.error("Failed to load adapter " + clazz.getSimpleName() + " for " + pluginName + "!", e);
+                }
+            }, () -> log.info("Plugin " + pluginName + " not found! Adapter " + clazz.getSimpleName() + " will not be loaded."));
+        }
+    }
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/Compatibility.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/Compatibility.java
@@ -1,0 +1,19 @@
+package me.mykindos.betterpvp.core.framework.adapter;
+
+import lombok.experimental.UtilityClass;
+import org.bukkit.Bukkit;
+
+@UtilityClass
+public class Compatibility {
+
+    /**
+     * Whether the server is running MythicMobs
+     */
+    public static boolean MYTHIC_MOBS = Bukkit.getPluginManager().isPluginEnabled("MythicMobs");
+
+    /**
+     * Whether the server is running ItemsAdder
+     */
+    public static boolean ITEMS_ADDER = Bukkit.getPluginManager().isPluginEnabled("ItemsAdder");
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapter.java
@@ -1,0 +1,20 @@
+package me.mykindos.betterpvp.core.framework.adapter;
+
+import javax.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Singleton
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PluginAdapter {
+
+    /**
+     * The name of the plugin that this adapter is for.
+     * @return The name of the plugin that this adapter is for.
+     */
+    String value();
+
+}


### PR DESCRIPTION
Changes:
- Create `@PluginAdapter` annotation. Classes annotated with this annotation can be reflectively obtained by a module, then passed into an `Adapters` class instance to force the creation of a new instance of that class using the injector provided by that module.
- Create `Compatibility` class with convenience fields for convenience. Currently only supports `MYTHIC_MOBS` and `ITEMS_ADDER` boolean fields to know if either of those plugins are enabled.
- Adjust `ProgressionAdapter` in the clans module to work with the new adapter-style system.

Changes were tested