### PR TITLE
Complete mining progression tree

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansExplosionListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansExplosionListener.java
@@ -30,16 +30,13 @@ import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.TNTPrimeEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 
 @Slf4j
 @BPvPListener
@@ -191,7 +188,8 @@ public class ClansExplosionListener extends ClanListener {
         if (event.getEntity().getType() != EntityType.PRIMED_TNT) return;
         event.getEntity().getWorld().playSound(event.getEntity().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 2.0f, 1.0f);
         event.setYield(2.5f);
-        for (Block block : UtilBlock.getInRadius(event.getLocation(), event.getYield()).keySet()) {
+        final Set<Block> blocks = UtilBlock.getInRadius(event.getLocation(), event.getYield()).keySet();
+        for (Block block : blocks) {
             if (protectedBlocks.contains(block.getType())) continue;
             if (worldBlockHandler.isRestoreBlock(block)) continue;
             if (block.getType().isAir()) continue;
@@ -211,6 +209,10 @@ public class ClansExplosionListener extends ClanListener {
         Clan attackedClan = null;
 
         boolean schedulingRollback = false;
+
+        // todo: allow changing yield
+        final BlockExplodeEvent explodeEvent = new BlockExplodeEvent(event.getLocation().getBlock(), new ArrayList<>(blocks), 1.0f, null);
+        UtilServer.callEvent(explodeEvent);
 
         for (Block block : event.blockList()) {
             if (protectedBlocks.contains(block.getType())) continue;

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.clans.events.TerritoryInteractEvent;
 import me.mykindos.betterpvp.clans.clans.listeners.ClanListener;
+import me.mykindos.betterpvp.clans.fields.event.FieldsInteractableUseEvent;
 import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
 import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
 import me.mykindos.betterpvp.core.client.events.ClientAdministrateEvent;
@@ -13,6 +14,7 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.gamer.exceptions.NoSuchGamerException;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.block.Block;
@@ -104,6 +106,7 @@ public class FieldsListener extends ClanListener {
             event.getBlock().setBlockData(type.getReplacement());
             block.setLastUsed(System.currentTimeMillis());
             block.setActive(false);
+            UtilServer.callEvent(new FieldsInteractableUseEvent(fields, type, block, event.getPlayer()));
         }
     }
 
@@ -158,7 +161,7 @@ public class FieldsListener extends ClanListener {
                         return; // The block is already the interactable, ignore
                     }
 
-                    final Block block = interactable.toLocation().getBlock();
+                    final Block block = interactable.getLocation().getBlock();
                     block.setType(type.getType().getMaterial());
                     block.setBlockData(type.getType());
                     interactable.setActive(true);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/FieldsListener.java
@@ -102,11 +102,11 @@ public class FieldsListener extends ClanListener {
 
         if (allow) {
             event.setInform(false); // Block the message that they cant break
-            event.getBlock().setType(type.getReplacement().getMaterial()); // Then replace the block
-            event.getBlock().setBlockData(type.getReplacement());
             block.setLastUsed(System.currentTimeMillis());
             block.setActive(false);
             UtilServer.callEvent(new FieldsInteractableUseEvent(fields, type, block, event.getPlayer()));
+            event.getBlock().setType(type.getReplacement().getMaterial()); // Then replace the block
+            event.getBlock().setBlockData(type.getReplacement());
         }
     }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/event/FieldsInteractableUseEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/event/FieldsInteractableUseEvent.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.clans.fields.event;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.clans.fields.Fields;
+import me.mykindos.betterpvp.clans.fields.model.FieldsBlock;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+@Getter
+public class FieldsInteractableUseEvent extends CustomEvent {
+
+    private final Fields fields;
+    private final FieldsInteractable type;
+    private final FieldsBlock block;
+    private final Player player;
+
+    public FieldsInteractableUseEvent(Fields fields, FieldsInteractable type, FieldsBlock block, Player player) {
+        this.fields = fields;
+        this.type = type;
+        this.block = block;
+        this.player = player;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsBlock.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/FieldsBlock.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 
 /**
  * Represents an ore in the Fields zone.
@@ -24,8 +25,12 @@ public class FieldsBlock {
         return Bukkit.getWorld(world);
     }
 
-    public Location toLocation() {
+    public Location getLocation() {
         return new Location(getWorld(), x, y, z);
+    }
+
+    public Block getBlock() {
+        return getLocation().getBlock();
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
@@ -37,7 +37,19 @@ public class ProgressionAdapter{
     }
 
     public void load() {
+        loadListeners();
         loadPerks();
+    }
+
+    private void loadListeners() {
+        Reflections reflections = new Reflections(getClass().getPackageName());
+        final Set<Class<? extends Listener>> listenerClasses = reflections.getSubTypesOf(Listener.class);
+        for (Class<? extends Listener> clazz : listenerClasses) {
+            if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
+            final Listener listener = clans.getInjector().getInstance(clazz);
+            progression.getInjector().injectMembers(listener);
+        }
+        log.info("Loaded " + listenerClasses.size() + " clans progression listeners");
     }
 
     private void loadPerks() {
@@ -50,10 +62,6 @@ public class ProgressionAdapter{
             final Class<? extends ProgressionTree>[] trees = perk.acceptedTrees();
             for (Class<? extends ProgressionTree> tree : trees) {
                 progressionsManager.fromClass(tree).addPerk(perk);
-            }
-
-            if (Listener.class.isAssignableFrom(clazz)) {
-                listenerLoader.load(clazz);
             }
         }
         log.info("Loaded " + perkClasses.size() + " clans progression perks");

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
@@ -48,6 +48,7 @@ public class ProgressionAdapter{
             if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
             final Listener listener = clans.getInjector().getInstance(clazz);
             progression.getInjector().injectMembers(listener);
+            listenerLoader.load(clazz);
         }
         log.info("Loaded " + listenerClasses.size() + " clans progression listeners");
     }
@@ -59,6 +60,7 @@ public class ProgressionAdapter{
             if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
             final ProgressionPerk perk = clans.getInjector().getInstance(clazz);
             progression.getInjector().injectMembers(perk);
+            clans.getInjector().injectMembers(perk);
             final Class<? extends ProgressionTree>[] trees = perk.acceptedTrees();
             for (Class<? extends ProgressionTree> tree : trees) {
                 progressionsManager.fromClass(tree).addPerk(perk);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
@@ -8,6 +8,8 @@ import me.mykindos.betterpvp.clans.fields.model.FieldsOre;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.progression.tree.mining.Mining;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -28,18 +30,9 @@ public class MiningListener implements Listener {
             return;
         }
 
-        mining.getStatsRepository().getDataAsync(event.getPlayer()).whenComplete((miningData, throwable) -> {
-            if (throwable != null) {
-                log.error("Failed to update mining data for " + event.getPlayer().getName(), throwable);
-                return;
-            }
-
-            final long defaultXp = mining.getMiningService().getExperience(event.getBlock().getBlock().getType());
-            miningData.grantExperience((long) (defaultXp * xpMultiplier));
-        }).exceptionally(throwable -> {
-            log.error("Failed to update mining data for " + event.getPlayer().getName(), throwable);
-            return null;
-        });
+        final Player player = event.getPlayer();
+        final Block block = event.getBlock().getBlock();
+        mining.getMiningService().attemptMineOre(player, block, experience -> (long) (experience * xpMultiplier));
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
@@ -1,23 +1,24 @@
 package me.mykindos.betterpvp.clans.progression.listener;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.fields.event.FieldsInteractableUseEvent;
 import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
 import me.mykindos.betterpvp.clans.fields.model.FieldsOre;
 import me.mykindos.betterpvp.core.config.Config;
-import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.progression.tree.mining.Mining;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-@BPvPListener
 @Slf4j
+@Singleton
 public class MiningListener implements Listener {
 
-    @Config(path = "progression-hook.mining.fieldsXpMultiplier", defaultValue = "5.0")
+    @Config(path = "fields.fieldsXpMultiplier", defaultValue = "5.0")
+    @Inject(optional = true)
     private double xpMultiplier = 5;
 
     @Inject(optional = true)

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
@@ -1,0 +1,45 @@
+package me.mykindos.betterpvp.clans.progression.listener;
+
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.clans.fields.event.FieldsInteractableUseEvent;
+import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
+import me.mykindos.betterpvp.clans.fields.model.FieldsOre;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.progression.tree.mining.Mining;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+@BPvPListener
+@Slf4j
+public class MiningListener implements Listener {
+
+    @Config(path = "progression-hook.mining.fieldsXpMultiplier", defaultValue = "5.0")
+    private double xpMultiplier = 5;
+
+    @Inject(optional = true)
+    private Mining mining;
+
+    @EventHandler
+    public void onFieldsOreMine(FieldsInteractableUseEvent event) {
+        final FieldsInteractable type = event.getType();
+        if (!(type instanceof FieldsOre)) {
+            return;
+        }
+
+        mining.getStatsRepository().getDataAsync(event.getPlayer()).whenComplete((miningData, throwable) -> {
+            if (throwable != null) {
+                log.error("Failed to update mining data for " + event.getPlayer().getName(), throwable);
+                return;
+            }
+
+            final long defaultXp = mining.getMiningService().getExperience(event.getBlock().getBlock().getType());
+            miningData.grantExperience((long) (defaultXp * xpMultiplier));
+        }).exceptionally(throwable -> {
+            log.error("Failed to update mining data for " + event.getPlayer().getName(), throwable);
+            return null;
+        });
+    }
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/CoreNamespaceKeys.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/CoreNamespaceKeys.java
@@ -9,4 +9,8 @@ public class CoreNamespaceKeys {
     public static final NamespacedKey GLOW_KEY = new NamespacedKey("core", "glow");
     public static final NamespacedKey IMMUTABLE_KEY = new NamespacedKey("core", "immutable");
 
+    public static final NamespacedKey BLOCK_TAG_CONTAINER_KEY = new NamespacedKey("core", "block-containers");
+    public static final NamespacedKey BLOCK_TAG_KEY = new NamespacedKey("core", "block-key");
+    public static final NamespacedKey PLAYER_PLACED_KEY = new NamespacedKey("core", "player-placed");
+
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/blocktag/BlockTaggingListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/blocktag/BlockTaggingListener.java
@@ -1,0 +1,133 @@
+package me.mykindos.betterpvp.core.framework.blocktag;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.data.CustomDataType;
+import org.bukkit.GameMode;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.*;
+import org.bukkit.persistence.PersistentDataContainer;
+
+import java.util.UUID;
+
+@BPvPListener
+@Singleton
+public class BlockTaggingListener implements Listener {
+
+    @Inject
+    private Core core;
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        untagBlock(event.getBlock());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBurn(BlockBurnEvent event) {
+        untagBlock(event.getBlock());
+    }
+
+    @EventHandler   (priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockExplode(BlockExplodeEvent event) {
+        event.blockList().forEach(this::untagBlock);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockFade(BlockFadeEvent event) {
+        untagBlock(event.getBlock());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockFertilize(BlockFertilizeEvent event) {
+        tagBlock(event.getBlock(), event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
+        event.getReplacedBlockStates().forEach(blockState -> tagBlock(blockState.getBlock(), event.getPlayer()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPistonExtend(BlockPistonExtendEvent event) {
+        event.getBlocks().forEach(block -> shift(block, event.getDirection()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        if (!event.isSticky()) return;
+        event.getBlocks().forEach(block -> shift(block, event.getDirection()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        tagBlock(event.getBlock(), event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityBlockForm(EntityBlockFormEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        tagBlock(event.getBlock(), player.getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onLeafDecay(LeavesDecayEvent event) {
+        untagBlock(event.getBlock());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPrime(TNTPrimeEvent event) {
+        untagBlock(event.getBlock());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onSpongeAbsorb(SpongeAbsorbEvent event) {
+        event.getBlocks().forEach(state -> untagBlock(state.getBlock()));
+    }
+
+    private void shift(Block block, BlockFace direction) {
+        final UUID player = getTaggedPlayer(block);
+        if (player == null) return; // It wasn't a player placed block
+        final Block relative = block.getRelative(direction);
+        untagBlock(block);
+        tagBlock(relative, player);
+    }
+
+    private UUID getTaggedPlayer(Block block) {
+        final PersistentDataContainer pdc = UtilBlock.getPersistentDataContainer(block);
+        return pdc.get(CoreNamespaceKeys.PLAYER_PLACED_KEY, CustomDataType.UUID);
+    }
+
+    private void tagBlock(Block block, Player player) {
+        if (player == null || player.getGameMode() == GameMode.CREATIVE) return;
+        tagBlock(block, player.getUniqueId());
+    }
+
+    // Run next tick to allow other plugins to read the block
+    private void tagBlock(Block block, UUID uuid) {
+        UtilServer.runTaskLater(core, false, () -> {
+            final PersistentDataContainer pdc = UtilBlock.getPersistentDataContainer(block);
+            pdc.set(CoreNamespaceKeys.PLAYER_PLACED_KEY, CustomDataType.UUID, uuid);
+            UtilBlock.setPersistentDataContainer(block, pdc);
+        }, 1L);
+    }
+
+    // Run next tick to allow other plugins to read the block
+    private void untagBlock(Block block) {
+        UtilServer.runTaskLater(core, false, () -> {
+            final PersistentDataContainer pdc = UtilBlock.getPersistentDataContainer(block);
+            pdc.remove(CoreNamespaceKeys.PLAYER_PLACED_KEY);
+            UtilBlock.setPersistentDataContainer(block, pdc);
+        }, 1L);
+    }
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/stats/Leaderboard.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/stats/Leaderboard.java
@@ -10,8 +10,14 @@ import me.mykindos.betterpvp.core.stats.repository.LeaderboardEntry;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardEntryComparator;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardEntryKey;
 import me.mykindos.betterpvp.core.stats.sort.SortType;
+import me.mykindos.betterpvp.core.stats.sort.TemporalSort;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.UtilSound;
 import org.apache.commons.lang3.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -32,37 +38,42 @@ public abstract class Leaderboard<E, T extends Comparable<T>> {
 
     private final ConcurrentHashMap<SortType, TreeSet<LeaderboardEntry<E, T>>> topTen;
     private final AsyncLoadingCache<LeaderboardEntryKey<E>, T> entryCache;
+    private final Database database;
+    private final String tablePrefix;
 
     protected Leaderboard(BPvPPlugin plugin, String tablePrefix) {
         Validate.isTrue(acceptedSortTypes().length > 0, "Leaderboard must accept at least one sort type.");
-        final Database database = plugin.getInjector().getInstance(Database.class);
+        this.database = plugin.getInjector().getInstance(Database.class);
+        this.tablePrefix = tablePrefix;
         this.topTen = new ConcurrentHashMap<>();
         this.entryCache = Caffeine.newBuilder()
                 .expireAfterWrite(10, TimeUnit.MINUTES)
                 .buildAsync((key, executor) -> CompletableFuture.supplyAsync(() -> fetch(key.getSortType(), database, tablePrefix, key.getValue())));
 
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-            for (SortType sortType : acceptedSortTypes()) {
-                CompletableFuture.supplyAsync(() -> fetchAll(sortType, database, tablePrefix)).thenApply(fetch -> {
-                    TreeSet<LeaderboardEntry<E, T>> set = new TreeSet<>(new LeaderboardEntryComparator<>());
-                    set.addAll(fetch.entrySet().stream().map(entry -> LeaderboardEntry.of(entry.getKey(), entry.getValue())).toList());
-                    return set;
-                }).exceptionally(ex -> {
-                    log.error("Failed to fetch leaderboard data for " + sortType + "!", ex);
-                    ex.printStackTrace();
-                    return null;
-                }).whenComplete((set, ex) -> {
-                    if (ex != null) {
-                        log.error("Failed to fetch leaderboard data for " + sortType + "!", ex);
-                        ex.printStackTrace();
-                        return;
-                    }
-                    topTen.put(sortType, set);
-                });
-            }
-        }, 0L, 10L, TimeUnit.MINUTES);
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(this::forceUpdate, 0L, 10L, TimeUnit.MINUTES);
 
         UtilServer.callEvent(new LeaderboardInitializeEvent(this));
+    }
+
+    public void forceUpdate() {
+        for (SortType sortType : acceptedSortTypes()) {
+            CompletableFuture.supplyAsync(() -> fetchAll(sortType, database, tablePrefix)).thenApply(fetch -> {
+                TreeSet<LeaderboardEntry<E, T>> set = new TreeSet<>(new LeaderboardEntryComparator<>());
+                set.addAll(fetch.entrySet().stream().map(entry -> LeaderboardEntry.of(entry.getKey(), entry.getValue())).toList());
+                return set;
+            }).exceptionally(ex -> {
+                log.error("Failed to fetch leaderboard data for " + sortType + "!", ex);
+                ex.printStackTrace();
+                return null;
+            }).whenComplete((set, ex) -> {
+                if (ex != null) {
+                    log.error("Failed to fetch leaderboard data for " + sortType + "!", ex);
+                    ex.printStackTrace();
+                    return;
+                }
+                topTen.put(sortType, set);
+            });
+        }
     }
 
     public abstract String getName();
@@ -216,5 +227,29 @@ public abstract class Leaderboard<E, T extends Comparable<T>> {
      * @param tablePrefix The prefix of the table.
      */
     protected abstract Map<E, T> fetchAll(@NotNull SortType sortType, @NotNull Database database, @NotNull String tablePrefix);
+
+    public void attemptAnnounce(Player player, Map<SortType, Integer> newPositions) {
+        if (newPositions.isEmpty()) {
+            return;
+        }
+
+        final Map.Entry<TemporalSort, Integer> highestEntry = newPositions.entrySet().stream()
+                .map(entry -> Map.entry((TemporalSort) entry.getKey(), entry.getValue()))
+                .max(Map.Entry.comparingByKey(Comparator.comparing(TemporalSort::getDays)))
+                .orElseThrow();
+
+        if (highestEntry.getKey() == TemporalSort.SEASONAL && highestEntry.getValue() <= 3) {
+            final String playerName = player.getName();
+            UtilMessage.simpleBroadcast("Leaderboard", "<dark_green>%s <green>has reached <dark_green>#%d</dark_green> on the %s %s leaderboard!",
+                    playerName,
+                    highestEntry.getValue(),
+                    highestEntry.getKey().getName().toLowerCase(),
+                    this.getName());
+
+            for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                UtilSound.playSound(onlinePlayer, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1.0F, 1.0F, true);
+            }
+        }
+    }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/stats/repository/StatsRepository.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/stats/repository/StatsRepository.java
@@ -26,8 +26,8 @@ public abstract class StatsRepository<T extends PlayerData> implements ConfigAcc
     protected final BPvPPlugin plugin;
     protected final String tableName;
 
-    protected StatsRepository(Database database, BPvPPlugin plugin, String tableName) {
-        this.database = database;
+    protected StatsRepository(BPvPPlugin plugin, String tableName) {
+        this.database = plugin.getInjector().getInstance(Database.class);
         this.plugin = plugin;
         this.tableName = tableName;
         this.dataCache = Caffeine.newBuilder()
@@ -113,12 +113,19 @@ public abstract class StatsRepository<T extends PlayerData> implements ConfigAcc
             dataCache.put(player, saved);
             return saved;
         }
-        return loadDataAsync(player).exceptionally(throwable -> {
+        return fetchDataAsync(player).exceptionally(throwable -> {
             log.error("Error loading data for " + player, throwable);
             return null;
         });
     }
 
-    protected abstract CompletableFuture<T> loadDataAsync(UUID player);
+    /**
+     * Fetches the data for the given player directly from the database.
+     *
+     * <b>NOTE: Use with caution. This is a direct database call. For common use call {@link StatsRepository#getDataAsync}</b>
+     * @param player
+     * @return
+     */
+    public abstract CompletableFuture<T> fetchDataAsync(UUID player);
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/data/CustomDataType.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/data/CustomDataType.java
@@ -1,0 +1,13 @@
+package me.mykindos.betterpvp.core.utilities.model.data;
+
+import lombok.experimental.UtilityClass;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.UUID;
+
+@UtilityClass
+public class CustomDataType {
+
+    public static final PersistentDataType<String, UUID> UUID = new PersistentUUIDType();
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/data/PersistentUUIDType.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/data/PersistentUUIDType.java
@@ -1,0 +1,33 @@
+package me.mykindos.betterpvp.core.utilities.model.data;
+
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class PersistentUUIDType implements PersistentDataType<String, UUID> {
+
+    PersistentUUIDType() {
+    }
+
+    @Override
+    public @NotNull Class<String> getPrimitiveType() {
+        return String.class;
+    }
+
+    @Override
+    public @NotNull Class<UUID> getComplexType() {
+        return UUID.class;
+    }
+
+    @Override
+    public @NotNull String toPrimitive(@NotNull UUID complex, @NotNull PersistentDataAdapterContext context) {
+        return complex.toString();
+    }
+
+    @Override
+    public @NotNull UUID fromPrimitive(@NotNull String primitive, @NotNull PersistentDataAdapterContext context) {
+        return UUID.fromString(primitive);
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/listener/ProgressionListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/listener/ProgressionListener.java
@@ -40,14 +40,24 @@ public class ProgressionListener implements Listener {
         progressionsManager.getTrees().forEach(tree -> tree.getStatsRepository().saveAll(true));
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGainExperience(PlayerProgressionExperienceEvent event) {
         final Player player = event.getPlayer();
         gamerManager.getObject(player.getUniqueId()).ifPresent(gamer -> {
             // Action bar XP
             final String tree = event.getTree().getName();
             final long amount = event.getGainedExp();
-            final TextComponent actionBarText = Component.text("+" + amount + " " + tree + " XP", NamedTextColor.DARK_AQUA);
+            final TextComponent actionBarText;
+            if (amount > 0) {
+                actionBarText = Component.text("+" + amount + " " + tree + " XP", NamedTextColor.DARK_AQUA);
+            } else {
+                String amountString = String.valueOf(amount);
+                if (amount == 0) {
+                    amountString = "+" + amountString;
+                }
+                actionBarText = Component.text(amountString + " " + tree + " XP", NamedTextColor.RED);
+            }
+
             final TimedComponent component = new TimedComponent(1.0, false, gmr -> actionBarText);
             gamer.getActionBar().add(250, component);
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/model/stats/ProgressionStatsRepository.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/model/stats/ProgressionStatsRepository.java
@@ -2,7 +2,6 @@ package me.mykindos.betterpvp.progression.model.stats;
 
 import com.google.common.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
-import me.mykindos.betterpvp.core.database.Database;
 import me.mykindos.betterpvp.core.database.query.Statement;
 import me.mykindos.betterpvp.core.database.query.values.LongStatementValue;
 import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
@@ -24,8 +23,8 @@ public abstract class ProgressionStatsRepository<T extends ProgressionTree, K ex
 
     protected T tree;
 
-    protected ProgressionStatsRepository(Database database, Progression plugin, String tableName) {
-        super(database, plugin, tableName);
+    protected ProgressionStatsRepository(Progression plugin, String tableName) {
+        super(plugin, tableName);
     }
 
     @Override

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/model/stats/ProgressionStatsRepository.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/model/stats/ProgressionStatsRepository.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.progression.model.stats;
 
-import com.google.common.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.database.query.Statement;
 import me.mykindos.betterpvp.core.database.query.values.LongStatementValue;
@@ -27,6 +26,8 @@ public abstract class ProgressionStatsRepository<T extends ProgressionTree, K ex
         super(plugin, tableName);
     }
 
+    protected abstract Class<T> getTreeClass();
+
     @Override
     protected void postSaveAll() {
         String expStmt = "INSERT INTO " + plugin.getDatabasePrefix() + "exp (Gamer, " + tableName + ") VALUES (?, ?) ON DUPLICATE KEY UPDATE " + tableName + " = VALUES(" + tableName + ");";
@@ -45,10 +46,7 @@ public abstract class ProgressionStatsRepository<T extends ProgressionTree, K ex
         }
 
         if (tree == null) {
-            @SuppressWarnings("unchecked")
-            final Class<T> clazz = (Class<T>) new TypeToken<>(getClass()) {
-            }.getType();
-            tree = ((Progression) plugin).getProgressionsManager().fromClass(clazz);
+            tree = ((Progression) plugin).getProgressionsManager().fromClass(getTreeClass());
         }
 
         // Otherwise, these people were just loaded from the database, so load their XP

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/data/FishingWeightLeaderboard.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/data/FishingWeightLeaderboard.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.progression.tree.fishing.data;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.database.Database;
@@ -22,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
+@Singleton
 public class FishingWeightLeaderboard extends Leaderboard<UUID, Long> {
 
     @Inject

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingListener.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.gamer.Gamer;
@@ -41,6 +42,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @BPvPListener
+@Singleton
 public class FishingListener implements Listener {
 
     private static final Random RANDOM = new Random();

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingStatsListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingStatsListener.java
@@ -1,33 +1,24 @@
 package me.mykindos.betterpvp.progression.tree.fishing.listener;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilSound;
-import me.mykindos.betterpvp.core.stats.Leaderboard;
-import me.mykindos.betterpvp.core.stats.sort.SortType;
-import me.mykindos.betterpvp.core.stats.sort.TemporalSort;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.tree.fishing.Fishing;
 import me.mykindos.betterpvp.progression.tree.fishing.event.PlayerStopFishingEvent;
 import me.mykindos.betterpvp.progression.tree.fishing.fish.Fish;
 import me.mykindos.betterpvp.progression.tree.fishing.model.FishingLoot;
 import me.mykindos.betterpvp.progression.tree.fishing.repository.FishingRepository;
-import org.bukkit.Bukkit;
-import org.bukkit.Sound;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import java.util.Comparator;
-import java.util.Map;
-
 @BPvPListener
 @Slf4j
+@Singleton
 public class FishingStatsListener implements Listener {
 
     @Inject
@@ -77,7 +68,7 @@ public class FishingStatsListener implements Listener {
                     return;
                 }
 
-                announceIfPresent(event.getPlayer(), fishing.getWeightLeaderboard(), result);
+                fishing.getWeightLeaderboard().attemptAnnounce(event.getPlayer(),  result);
             });
 
             fishing.getCountLeaderboard().add(event.getPlayer().getUniqueId(), 1L).whenComplete((result, throwable2) -> {
@@ -86,36 +77,12 @@ public class FishingStatsListener implements Listener {
                     return;
                 }
 
-                announceIfPresent(event.getPlayer(), fishing.getCountLeaderboard(), result);
+                fishing.getCountLeaderboard().attemptAnnounce(event.getPlayer(), result);
             });
         }).exceptionally(throwable -> {
             log.error("Failed to get progression data for player " + event.getPlayer().getName(), throwable);
             return null;
         }).thenRun(() -> repository.saveAsync(event.getPlayer()));
-    }
-
-    private void announceIfPresent(Player player, Leaderboard<?, ?> leaderboard, Map<SortType, Integer> newPositions) {
-        if (newPositions.isEmpty()) {
-            return;
-        }
-        final Map.Entry<TemporalSort, Integer> highestEntry = newPositions.entrySet().stream()
-                .map(entry -> Map.entry((TemporalSort) entry.getKey(), entry.getValue()))
-                .max(Map.Entry.comparingByKey(Comparator.comparing(TemporalSort::getDays)))
-                .orElseThrow();
-
-        final String playerName = player.getName();
-        UtilMessage.simpleBroadcast("Fishing",
-                "<dark_green>%s <green>has reached <dark_green>#%d</dark_green> on the %s %s leaderboard!",
-                playerName,
-                highestEntry.getValue(),
-                highestEntry.getKey().getName().toLowerCase(),
-                leaderboard.getName());
-
-        if (highestEntry.getKey() == TemporalSort.SEASONAL) {
-            for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-                UtilSound.playSound(onlinePlayer, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1.0F, 1.0F, true);
-            }
-        }
     }
 
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/repository/FishingRepository.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/repository/FishingRepository.java
@@ -1,10 +1,10 @@
 package me.mykindos.betterpvp.progression.tree.fishing.repository;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
-import me.mykindos.betterpvp.core.database.Database;
 import me.mykindos.betterpvp.core.database.query.Statement;
 import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
 import me.mykindos.betterpvp.core.utilities.model.WeighedList;
@@ -39,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 // The data should be saved as a fallback to the database every 5 minutes
 // The data should be saved on shutdown
 @Slf4j
+@Singleton
 public class FishingRepository extends ProgressionStatsRepository<Fishing, FishingData> {
 
     @Getter
@@ -58,11 +59,11 @@ public class FishingRepository extends ProgressionStatsRepository<Fishing, Fishi
 
     @Inject
     public FishingRepository(Progression progression) {
-        super(progression.getInjector().getInstance(Database.class), progression, "Fishing");
+        super(progression, "Fishing");
     }
 
     @Override
-    public CompletableFuture<FishingData> loadDataAsync(UUID player) {
+    public CompletableFuture<FishingData> fetchDataAsync(UUID player) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 String stmt = "SELECT COUNT(*), SUM(Weight) FROM " + plugin.getDatabasePrefix() + "fishing WHERE gamer = ?;";
@@ -75,11 +76,11 @@ public class FishingRepository extends ProgressionStatsRepository<Fishing, Fishi
                 }
                 return data;
             } catch (SQLException e) {
-                log.error("Failed to get progression data for player " + player, e);
+                log.error("Failed to get fishing data for player " + player, e);
             }
             return new FishingData();
         }).exceptionally(throwable -> {
-            log.error("Failed to get progression data for player " + player, throwable);
+            log.error("Failed to get fishing data for player " + player, throwable);
             return null;
         });
     }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/repository/FishingRepository.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/repository/FishingRepository.java
@@ -194,4 +194,8 @@ public class FishingRepository extends ProgressionStatsRepository<Fishing, Fishi
         log.info("Loaded " + lootTypes.size() + " loot types");
     }
 
+    @Override
+    protected Class<Fishing> getTreeClass() {
+        return Fishing.class;
+    }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/Mining.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/Mining.java
@@ -30,7 +30,6 @@ public class Mining extends ProgressionTree {
     @Override
     public void loadConfig(ExtendedYamlConfiguration config) {
         statsRepository.loadConfig(config);
-        miningService.loadConfig(config);
         leaderboard.forceUpdate(); // Force update because mining service reloads tracked blocks
     }
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/Mining.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/Mining.java
@@ -1,0 +1,37 @@
+package me.mykindos.betterpvp.progression.tree.mining;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.Getter;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import me.mykindos.betterpvp.progression.model.ProgressionTree;
+import me.mykindos.betterpvp.progression.tree.mining.data.MiningOresMinedLeaderboard;
+import me.mykindos.betterpvp.progression.tree.mining.repository.MiningRepository;
+import org.jetbrains.annotations.NotNull;
+
+@Singleton
+@Getter
+public class Mining extends ProgressionTree {
+
+    @Inject
+    private MiningRepository statsRepository;
+
+    @Inject
+    private MiningService miningService;
+
+    @Inject
+    private MiningOresMinedLeaderboard leaderboard;
+
+    @Override
+    public @NotNull String getName() {
+        return "Mining";
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        statsRepository.loadConfig(config);
+        miningService.loadConfig(config);
+        leaderboard.forceUpdate(); // Force update because mining service reloads tracked blocks
+    }
+
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/MiningService.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/MiningService.java
@@ -1,0 +1,58 @@
+package me.mykindos.betterpvp.progression.tree.mining;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import me.mykindos.betterpvp.core.utilities.model.ConfigAccessor;
+import me.mykindos.betterpvp.progression.Progression;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.*;
+
+@Slf4j
+@Singleton
+public class MiningService implements ConfigAccessor {
+
+    private final Map<Material, Long> experiencePerBlock = new EnumMap<>(Material.class);
+    private final Set<Material> leaderboardBlocks = new HashSet<>();
+
+    @Inject
+    public MiningService(Progression progression) {
+        loadConfig(progression.getConfig()); // Load before leaderboards
+    }
+
+    public long getExperience(Material material) {
+        return experiencePerBlock.getOrDefault(material, 0L);
+    }
+
+    public Set<Material> getLeaderboardBlocks() {
+        return Collections.unmodifiableSet(leaderboardBlocks);
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        experiencePerBlock.clear();
+        ConfigurationSection section = config.getConfigurationSection("mining.xpPerBlock");
+        if (section == null) {
+            section = config.createSection("mining.xpPerBlock");
+        }
+
+        for (String key : section.getKeys(false)) {
+            final Material material = Material.getMaterial(key.toUpperCase());
+            if (material == null) {
+                continue;
+            }
+
+            experiencePerBlock.put(material, config.getLong("mining.xpPerBlock." + key));
+        }
+        log.info("Loaded " + experiencePerBlock.size() + " mining blocks");
+
+        final int minXpThreshold = config.getInt("mining.minLeaderboardBlockXp");
+        leaderboardBlocks.clear();
+        leaderboardBlocks.addAll(experiencePerBlock.keySet());
+        leaderboardBlocks.removeIf(material -> experiencePerBlock.get(material) < minXpThreshold);
+    }
+
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/MiningService.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/MiningService.java
@@ -3,56 +3,79 @@ package me.mykindos.betterpvp.progression.tree.mining;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
-import me.mykindos.betterpvp.core.utilities.model.ConfigAccessor;
-import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.progression.tree.mining.data.MiningOresMinedLeaderboard;
+import me.mykindos.betterpvp.progression.tree.mining.repository.MiningRepository;
 import org.bukkit.Material;
-import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
 
-import java.util.*;
+import java.util.function.LongUnaryOperator;
 
 @Slf4j
 @Singleton
-public class MiningService implements ConfigAccessor {
-
-    private final Map<Material, Long> experiencePerBlock = new EnumMap<>(Material.class);
-    private final Set<Material> leaderboardBlocks = new HashSet<>();
+public class MiningService {
 
     @Inject
-    public MiningService(Progression progression) {
-        loadConfig(progression.getConfig()); // Load before leaderboards
-    }
+    private MiningRepository repository;
+
+    @Inject
+    private MiningOresMinedLeaderboard leaderboard;
 
     public long getExperience(Material material) {
-        return experiencePerBlock.getOrDefault(material, 0L);
+        return repository.getExperienceFor(material);
     }
 
-    public Set<Material> getLeaderboardBlocks() {
-        return Collections.unmodifiableSet(leaderboardBlocks);
+    public void attemptMineOre(Player player, Block block) {
+        attemptMineOre(player, block, LongUnaryOperator.identity());
     }
 
-    @Override
-    public void loadConfig(ExtendedYamlConfiguration config) {
-        experiencePerBlock.clear();
-        ConfigurationSection section = config.getConfigurationSection("mining.xpPerBlock");
-        if (section == null) {
-            section = config.createSection("mining.xpPerBlock");
+    public void attemptMineOre(Player player, Block block, LongUnaryOperator experienceModifier) {
+        long experience = getExperience(block.getType());
+        if (experience <= 0) {
+            return; // Cancel if they don't get experience from this block
         }
 
-        for (String key : section.getKeys(false)) {
-            final Material material = Material.getMaterial(key.toUpperCase());
-            if (material == null) {
-                continue;
+        final long finalExperience = experienceModifier.applyAsLong(experience);
+        repository.getDataAsync(player).whenComplete((miningData, throwable) -> {
+            if (throwable != null) {
+                log.error("Failed to update mining data for " + player.getName(), throwable);
+                return;
             }
 
-            experiencePerBlock.put(material, config.getLong("mining.xpPerBlock." + key));
-        }
-        log.info("Loaded " + experiencePerBlock.size() + " mining blocks");
+            // If it was player placed, grant 0 experience, so they get no XP and have a message sent anyway
+            final PersistentDataContainer pdc = UtilBlock.getPersistentDataContainer(block);
+            final boolean playerPlaced = pdc.has(CoreNamespaceKeys.PLAYER_PLACED_KEY);
+            if (playerPlaced) {
+                miningData.grantExperience(0, player);
+                return;
+            }
 
-        final int minXpThreshold = config.getInt("mining.minLeaderboardBlockXp");
-        leaderboardBlocks.clear();
-        leaderboardBlocks.addAll(experiencePerBlock.keySet());
-        leaderboardBlocks.removeIf(material -> experiencePerBlock.get(material) < minXpThreshold);
+            // We give XP for any block that gives XP, even if it's not in the leaderboard
+            miningData.grantExperience(finalExperience, player);
+            miningData.saveOreMined(block); // Save this block to the database
+
+            if (!repository.getLeaderboardBlocks().contains(block.getType())) {
+                return;
+            }
+
+            // But only add the stat if it's in the leaderboard
+            miningData.increaseMinedStat(block); // Only give the stat if it's in the threshold
+            leaderboard.add(player.getUniqueId(), 1L).whenComplete((result, throwable2) -> {
+                if (throwable2 != null) {
+                    log.error("Failed to add ore count to leaderboard for player " + player.getName(), throwable2);
+                    return;
+                }
+
+                leaderboard.attemptAnnounce(player, result);
+            });
+
+        }).exceptionally(throwable -> {
+            log.error("Failed to update mining data for " + player.getName(), throwable);
+            return null;
+        }).thenRun(() -> repository.saveAsync(player));
     }
 
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/data/MiningData.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/data/MiningData.java
@@ -1,0 +1,64 @@
+package me.mykindos.betterpvp.progression.tree.mining.data;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.core.database.Database;
+import me.mykindos.betterpvp.core.database.query.Statement;
+import me.mykindos.betterpvp.core.database.query.values.IntegerStatementValue;
+import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
+import me.mykindos.betterpvp.core.database.query.values.UuidStatementValue;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.progression.model.stats.ProgressionData;
+import me.mykindos.betterpvp.progression.tree.mining.Mining;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+@Setter
+public class MiningData extends ProgressionData<Mining> {
+
+    private long oresMined = 0;
+    @Getter(AccessLevel.NONE)
+    private final ConcurrentHashMap<Material, Integer> oresToSave = new ConcurrentHashMap<>();
+
+    public void increaseMinedStat(Block block) {
+        oresMined++;
+    }
+
+    public void saveOreMined(Block block) {
+        oresToSave.compute(block.getType(), (material, integer) -> integer == null ? 1 : integer + 1);
+    }
+
+    @Override
+    protected void prepareUpdates(@NotNull UUID uuid, @NotNull Database database, String databasePrefix) {
+        final String stmt = "INSERT INTO " + databasePrefix + "mining (Gamer,Material,AmountMined) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE AmountMined = AmountMined + VALUES(AmountMined);";
+        List<Statement> statements = new ArrayList<>();
+        for (Map.Entry<Material, Integer> entry : oresToSave.entrySet()) {
+            final Material type = entry.getKey();
+            final int amount = entry.getValue();
+            Statement statement = new Statement(stmt,
+                    new UuidStatementValue(uuid),
+                    new StringStatementValue(type.name()),
+                    new IntegerStatementValue(amount));
+            statements.add(statement);
+        }
+        database.executeBatch(statements, false);
+        oresToSave.clear();
+    }
+
+    @Override
+    public Component[] getDescription() {
+        return new Component[] {
+                UtilMessage.deserialize("Ores Mined: <alt>%,d", oresMined)
+        };
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/listener/MiningStatsListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/listener/MiningStatsListener.java
@@ -1,0 +1,71 @@
+package me.mykindos.betterpvp.progression.tree.mining.listener;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.progression.tree.mining.MiningService;
+import me.mykindos.betterpvp.progression.tree.mining.data.MiningOresMinedLeaderboard;
+import me.mykindos.betterpvp.progression.tree.mining.repository.MiningRepository;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+@BPvPListener
+@Slf4j
+@Singleton
+public class MiningStatsListener implements Listener {
+
+    @Inject
+    private MiningService service;
+
+    @Inject
+    private MiningRepository repository;
+
+    @Inject
+    private MiningOresMinedLeaderboard leaderboard;
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBreak(BlockBreakEvent event) {
+        final Block block = event.getBlock();
+        final long experience = service.getExperience(block.getType());
+        if (experience <= 0) {
+            return; // Cancel if they don't get experience from this block
+        }
+
+        final Player player = event.getPlayer();
+        repository.getDataAsync(player).whenComplete((miningData, throwable) -> {
+            if (throwable != null) {
+                log.error("Failed to update mining data for " + player.getName(), throwable);
+                return;
+            }
+
+            // We give XP for any block that gives XP, even if it's not in the leaderboard
+            miningData.grantExperience(experience, player);
+            miningData.saveOreMined(block); // Save this block to the database
+
+            if (!service.getLeaderboardBlocks().contains(block.getType())) {
+                return;
+            }
+
+            // But only add the stat if it's in the leaderboard
+            miningData.increaseMinedStat(block); // Only give the stat if it's in the threshold
+            leaderboard.add(player.getUniqueId(), 1L).whenComplete((result, throwable2) -> {
+                if (throwable2 != null) {
+                    log.error("Failed to add ore count to leaderboard for player " + player.getName(), throwable2);
+                    return;
+                }
+
+                leaderboard.attemptAnnounce(player, result);
+            });
+
+        }).exceptionally(throwable -> {
+            log.error("Failed to update mining data for " + player.getName(), throwable);
+            return null;
+        }).thenRun(() -> repository.saveAsync(player));
+    }
+
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/listener/MiningStatsListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/listener/MiningStatsListener.java
@@ -5,10 +5,6 @@ import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.progression.tree.mining.MiningService;
-import me.mykindos.betterpvp.progression.tree.mining.data.MiningOresMinedLeaderboard;
-import me.mykindos.betterpvp.progression.tree.mining.repository.MiningRepository;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -22,50 +18,9 @@ public class MiningStatsListener implements Listener {
     @Inject
     private MiningService service;
 
-    @Inject
-    private MiningRepository repository;
-
-    @Inject
-    private MiningOresMinedLeaderboard leaderboard;
-
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBreak(BlockBreakEvent event) {
-        final Block block = event.getBlock();
-        final long experience = service.getExperience(block.getType());
-        if (experience <= 0) {
-            return; // Cancel if they don't get experience from this block
-        }
-
-        final Player player = event.getPlayer();
-        repository.getDataAsync(player).whenComplete((miningData, throwable) -> {
-            if (throwable != null) {
-                log.error("Failed to update mining data for " + player.getName(), throwable);
-                return;
-            }
-
-            // We give XP for any block that gives XP, even if it's not in the leaderboard
-            miningData.grantExperience(experience, player);
-            miningData.saveOreMined(block); // Save this block to the database
-
-            if (!service.getLeaderboardBlocks().contains(block.getType())) {
-                return;
-            }
-
-            // But only add the stat if it's in the leaderboard
-            miningData.increaseMinedStat(block); // Only give the stat if it's in the threshold
-            leaderboard.add(player.getUniqueId(), 1L).whenComplete((result, throwable2) -> {
-                if (throwable2 != null) {
-                    log.error("Failed to add ore count to leaderboard for player " + player.getName(), throwable2);
-                    return;
-                }
-
-                leaderboard.attemptAnnounce(player, result);
-            });
-
-        }).exceptionally(throwable -> {
-            log.error("Failed to update mining data for " + player.getName(), throwable);
-            return null;
-        }).thenRun(() -> repository.saveAsync(player));
+        service.attemptMineOre(event.getPlayer(), event.getBlock());
     }
 
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/repository/MiningRepository.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/mining/repository/MiningRepository.java
@@ -1,0 +1,67 @@
+package me.mykindos.betterpvp.progression.tree.mining.repository;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import me.mykindos.betterpvp.core.database.query.Statement;
+import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
+import me.mykindos.betterpvp.core.database.query.values.UuidStatementValue;
+import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.model.stats.ProgressionStatsRepository;
+import me.mykindos.betterpvp.progression.tree.mining.Mining;
+import me.mykindos.betterpvp.progression.tree.mining.MiningService;
+import me.mykindos.betterpvp.progression.tree.mining.data.MiningData;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Singleton
+public class MiningRepository extends ProgressionStatsRepository<Mining, MiningData> {
+
+    private final MiningService service;
+
+    @Inject
+    public MiningRepository(Progression progression, MiningService service) {
+        super(progression, "Mining");
+        this.service = service;
+    }
+
+    public String getDbMaterialsList() {
+        return service.getLeaderboardBlocks().stream()
+                .map(mat -> "'" + mat.name() + "'")
+                .reduce((a, b) -> a + "," + b)
+                .orElse("''");
+    }
+
+    @Override
+    public CompletableFuture<MiningData> fetchDataAsync(UUID player) {
+        return CompletableFuture.supplyAsync(() -> {
+            final MiningData data = new MiningData();
+            Statement statement = new Statement("CALL GetGamerOresMined(?, ?, ?)",
+                    new UuidStatementValue(player),
+                    new StringStatementValue(getDbMaterialsList()),
+                    new StringStatementValue(plugin.getDatabasePrefix()));
+            database.executeProcedure(statement, -1, result -> {
+                try {
+                    if (result.next()) {
+                        data.setOresMined(result.getLong(1));
+                    }
+                } catch (SQLException e) {
+                    log.error("Failed to load mining data for " + player, e);
+                }
+            });
+            return data;
+        }).exceptionally(throwable -> {
+            log.error("Failed to load mining data for " + player, throwable);
+            return null;
+        });
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        // ignore
+    }
+}

--- a/progression/src/main/resources/config.yml
+++ b/progression/src/main/resources/config.yml
@@ -1,0 +1,97 @@
+progression:
+  database:
+    prefix: progression_
+
+mining:
+  minLeaderboardBlockXp: 45
+  xpPerBlock:
+    STONE: 15
+    ANDESITE: 15
+    GRANITE: 15
+    COBBLESTONE: 15
+    REDSTONE_ORE: 50
+    DIAMOND_ORE: 50
+    GOLD_ORE: 50
+    COPPER_ORE: 50
+    IRON_ORE: 50
+    COAL_ORE: 50
+    LAPIS_ORE: 50
+    EMERALD_ORE: 50
+    DEEPSLATE_REDSTONE_ORE: 50
+    DEEPSLATE_DIAMOND_ORE: 50
+    DEEPSLATE_GOLD_ORE: 50
+    DEEPSLATE_COPPER_ORE: 50
+    DEEPSLATE_IRON_ORE: 50
+    DEEPSLATE_COAL_ORE: 50
+    DEEPSLATE_LAPIS_ORE: 50
+    DEEPSLATE_EMERALD_ORE: 50
+
+
+fishing:
+  minWaitTime: 5.0
+  maxWaitTime: 20.0
+  bait:
+    speedy:
+      type: speed
+      seconds: 200.0
+      name: Speedy Bait
+      radius: 5.0
+      multiplier: 10.0
+      texture: http://textures.minecraft.net/texture/eb7a8d0d7365de95f23ac375498024cb31ae4e8d6d06d12a621e43cf1b7667d6
+    test:
+      type: speed
+      seconds: 200.0
+      name: Test Bait
+      radius: 5.0
+      multiplier: 20.0
+      texture: http://textures.minecraft.net/texture/1713f2a526e9e681092dd09e2180fcc00fc9fc33d288954c52fea6b959bc4e6e
+  #    meaty:
+  #      type: weight
+  #      name: Fat Bait
+  #      seconds: 5.0
+  #      radius: 2.5
+  #      weightAdd: 100
+  loot:
+    scepter:
+      type: treasure
+      material: DIAMOND
+      customModelData: 70
+      frequency: 100
+      minAmount: 1
+      maxAmount: 10
+    zombie:
+      type: entity
+      entity: DROWNED
+      frequency: 100
+    tuna:
+      type: fish
+      name: Tuna
+      maxWeight: 400
+      minWeight: 1
+      frequency: 50
+    barracuda:
+      type: fish
+      name: Barracuda
+      maxWeight: 401
+      minWeight: 401
+      frequency: 10000
+  xpPerPound: 0.05
+command:
+  progression:
+    enabled: true
+    requiredRank: ADMIN
+    reload:
+      enabled: true
+      requiredRank: ADMIN
+  fishing:
+    enabled: true
+    requiredRank: ADMIN
+    givebait:
+      enabled: true
+      requiredRank: ADMIN
+    giverod:
+      enabled: true
+      requiredRank: ADMIN
+  stats:
+    enabled: true
+    requiredRank: ADMIN


### PR DESCRIPTION
Changes:
- Add mining progression tree
- Configurable XP per material type
- Add `Total Ores Mined` leaderboard.
    - Configurable minimum XP threshold to only count certain blocks towards statistics.
    
Changes were tested