### PR TITLE
Add pull strengths to roped arrow

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
@@ -108,11 +108,6 @@ public class RopedArrow extends PrepareArrowSkill {
     }
 
     @Override
-    public boolean shouldDisplayActionBar(Gamer gamer) {
-        return false;
-    }
-
-    @Override
     public void processEntityShootBowEvent(EntityShootBowEvent event, Player player, int level, Arrow arrow) {
         super.processEntityShootBowEvent(event, player, level, arrow);
         championsManager.getCooldowns().removeCooldown(player, getName(), true);
@@ -122,7 +117,7 @@ public class RopedArrow extends PrepareArrowSkill {
                 showCooldownFinished(),
                 false,
                 isCancellable(),
-                true);
+                this::shouldDisplayActionBar);
     }
 
     @Override
@@ -161,14 +156,16 @@ public class RopedArrow extends PrepareArrowSkill {
     public boolean canUse(Player player) {
         if (active.contains(player.getUniqueId())) {
             // Meaning they have already prepared a shot
-            strength.compute(player, (p, curStrength) -> {
-                final int newStrength = Optional.ofNullable(curStrength).orElse(0) + 1;
+            int curStrength = strength.compute(player, (p, current) -> {
+                final int newStrength = Optional.ofNullable(current).orElse(0) + 1;
                 if (newStrength > MAX_STRENGTH) {
                     return 1;
                 } else {
                     return newStrength;
                 }
             });
+
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.4f + curStrength * 0.2f);
             return false;
         }
         return super.canUse(player);

--- a/champions/src/main/resources/config.yml
+++ b/champions/src/main/resources/config.yml
@@ -346,7 +346,7 @@ skills:
     ropedarrow:
       enabled: true
       maxlevel: 5
-      cooldown: 17
+      cooldown: 4
     levitatingshot:
       enabled: true
       maxlevel: 5


### PR DESCRIPTION
Changes:
- Allow players to cycle between pull strengths on Roped Arrow by left clicking their bow once prepared.
- Add an [indicator](https://i.imgur.com/itRY92M.png) above players' hotbars displaying the pull strength.
- For each level of pull strength, your cooldown is doubled, with a base value of 4 seconds. The max pull strength matches the current velocity strength, and the cooldown is on par to what it was before.

Changes were tested