### PR TITLE
arrow damage change

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
@@ -9,7 +9,6 @@ import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
 import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.PassiveSkill;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
@@ -1,4 +1,4 @@
-package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
+package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.bow;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -9,6 +9,7 @@ import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
 import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.PassiveSkill;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
@@ -169,14 +170,15 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
     @Override
     public SkillType getType() {
 
-        return SkillType.PASSIVE_A;
+        return SkillType.BOW;
     }
 
     @Override
     public void activate(Player player, int level) {
         if (!data.containsKey(player)) {
-            data.put(player, new OverchargeData(player.getUniqueId(), damageIncrement, (1 + level)));
+            data.put(player, new OverchargeData(player.getUniqueId(), damageIncrement, (3 + level)));
             charging.add(player.getUniqueId());
+
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
@@ -118,6 +118,6 @@ public class HeavyArrows extends Skill implements PassiveSkill, EnergySkill {
     }
 
     public void loadSkillConfig(){
-        basePushBack = getConfig("basePushBack", 1.25, Double.class);
+        basePushBack = getConfig("basePushBack", 1.0, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
@@ -53,7 +53,7 @@ public class Longshot extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Your arrow damage is set to <stat>" + minDamage + "</stat>, but gains",
-                "<stat>1</stat> additional damage for every 4 blocks it travels",
+                "<stat>1.0</stat> additional damage for every <stat>3.0</stat> blocks it travels",
                 "",
                 "Caps out at <val>" + (baseDamage + level) + "</val> damage",
                 "",
@@ -107,9 +107,9 @@ public class Longshot extends Skill implements PassiveSkill {
 
         Location loc = arrows.remove(arrow);
         double length = UtilMath.offset(loc, event.getDamagee().getLocation());
-        double damage = Math.min(baseDamage + getLevel(damager),(length / 4) + minDamage);
+        double damage = Math.min(baseDamage + getLevel(damager), (length / 3) + minDamage);
 
-        event.setDamage(event.getDamage() + (damage));
+        event.setDamage(damage);
         event.setReason(getName() + (length > deathMessageThreshold ? " <gray>from <green>" + (int) length + "<gray> blocks" : ""));
 
     }
@@ -122,7 +122,7 @@ public class Longshot extends Skill implements PassiveSkill {
 
     @Override
     public void loadSkillConfig() {
-        baseDamage = getConfig("baseDamage", 16.0, Double.class);
+        baseDamage = getConfig("baseDamage", 23.0, Double.class);
         deathMessageThreshold = getConfig("deathMessageThreshold", 40.0, Double.class);
         minDamage = getConfig("minDamage", 1.0, Double.class);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
@@ -36,6 +36,8 @@ public class Longshot extends Skill implements PassiveSkill {
     private double baseDamage;
     private double deathMessageThreshold;
     private double minDamage;
+    private double blockScale;
+    private double damageScale;
 
     @Inject
     public Longshot(Champions champions, ChampionsManager championsManager) {
@@ -53,7 +55,7 @@ public class Longshot extends Skill implements PassiveSkill {
 
         return new String[]{
                 "Your arrow damage is set to <stat>" + minDamage + "</stat>, but gains",
-                "<stat>1.0</stat> additional damage for every <stat>3.0</stat> blocks it travels",
+                "<stat>" + damageScale + "</stat> additional damage for every <stat>" + blockScale + "</stat> blocks it travels",
                 "",
                 "Caps out at <val>" + (baseDamage + level) + "</val> damage",
                 "",
@@ -107,7 +109,7 @@ public class Longshot extends Skill implements PassiveSkill {
 
         Location loc = arrows.remove(arrow);
         double length = UtilMath.offset(loc, event.getDamagee().getLocation());
-        double damage = Math.min(baseDamage + getLevel(damager), (length / 3) + minDamage);
+        double damage = Math.min(baseDamage + getLevel(damager), (damageScale * (length / blockScale)) + minDamage);
 
         event.setDamage(damage);
         event.setReason(getName() + (length > deathMessageThreshold ? " <gray>from <green>" + (int) length + "<gray> blocks" : ""));
@@ -125,6 +127,8 @@ public class Longshot extends Skill implements PassiveSkill {
         baseDamage = getConfig("baseDamage", 23.0, Double.class);
         deathMessageThreshold = getConfig("deathMessageThreshold", 40.0, Double.class);
         minDamage = getConfig("minDamage", 1.0, Double.class);
+        blockScale = getConfig("blockScale", 3.0, Double.class);
+        damageScale = getConfig("damageScale",1.0, Double.class);
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
@@ -35,6 +35,7 @@ public class Longshot extends Skill implements PassiveSkill {
 
     private double baseDamage;
     private double deathMessageThreshold;
+    private double minDamage;
 
     @Inject
     public Longshot(Champions champions, ChampionsManager championsManager) {
@@ -51,8 +52,8 @@ public class Longshot extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         return new String[]{
-                "Shoot an arrow that gains additional",
-                "damage the further it travels",
+                "Your arrow damage is set to <stat>" + minDamage + "</stat>, but gains",
+                "<stat>1</stat> additional damage for every 4 blocks it travels",
                 "",
                 "Caps out at <val>" + (baseDamage + level) + "</val> damage",
                 "",
@@ -106,18 +107,12 @@ public class Longshot extends Skill implements PassiveSkill {
 
         Location loc = arrows.remove(arrow);
         double length = UtilMath.offset(loc, event.getDamagee().getLocation());
-        double damage = Math.min(baseDamage + getLevel(damager), length / 3.5);
+        double damage = Math.min(baseDamage + getLevel(damager),(length / 4) + minDamage);
 
         event.setDamage(event.getDamage() + (damage));
         event.setReason(getName() + (length > deathMessageThreshold ? " <gray>from <green>" + (int) length + "<gray> blocks" : ""));
 
     }
-
-    @EventHandler
-    public void onDeath(CustomDeathEvent event) {
-
-    }
-
 
     @Override
     public SkillType getType() {
@@ -126,9 +121,10 @@ public class Longshot extends Skill implements PassiveSkill {
     }
 
     @Override
-    public void loadSkillConfig(){
-        baseDamage = getConfig("baseDamage", 14.0, Double.class);
+    public void loadSkillConfig() {
+        baseDamage = getConfig("baseDamage", 16.0, Double.class);
         deathMessageThreshold = getConfig("deathMessageThreshold", 40.0, Double.class);
+        minDamage = getConfig("minDamage", 1.0, Double.class);
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Overcharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Overcharge.java
@@ -1,4 +1,4 @@
-package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.bow;
+package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -72,7 +72,8 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
                 "Draw back harder on your bow, giving",
                 "<stat>" + damageIncrement + "</stat> bonus damage per <stat>" + durationIncrement + "</stat> seconds",
                 "",
-                "Maximum Damage: <val>" + (2 + level)
+                "Maximum Damage: <val>" + (3 + level)
+
         };
     }
 
@@ -168,7 +169,7 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
     @Override
     public SkillType getType() {
 
-        return SkillType.BOW;
+        return SkillType.PASSIVE_A;
     }
 
     @Override
@@ -216,7 +217,7 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
 
     }
     public void loadSkillConfig() {
-        damageIncrement = getConfig("damageIncrement", 2, Integer.class);
-        durationIncrement = getConfig("durationIncrement", 0.8, Double.class);
+        damageIncrement = getConfig("damageIncrement", 1, Integer.class);
+        durationIncrement = getConfig("durationIncrement", 0.5, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
@@ -34,7 +34,7 @@ public class Precision extends Skill implements PassiveSkill {
     public String[] getDescription(int level) {
 
         return new String[] {
-                "Your arrows deal <val>" + (level * 0.5) + "</val> bonus damage on hit"
+                "Your arrows deal <val>" + (0.5 + ((level - 1) * 0.25)) + "</val> bonus damage on hit"
         };
     }
 
@@ -57,7 +57,7 @@ public class Precision extends Skill implements PassiveSkill {
 
         int level = getLevel(damager);
         if(level > 0) {
-            event.setDamage(event.getDamage() + (level * 0.5));
+            event.setDamage(event.getDamage() + (0.5 + ((level - 1) * 0.25)));
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
@@ -66,7 +66,7 @@ public class Sharpshooter extends Skill implements PassiveSkill {
 
             StackingHitData hitData = data.get(damager);
             hitData.addCharge();
-            event.setDamage(event.getDamage() + (Math.min(maxConsecutiveHits, hitData.getCharge()) * (level * 0.75)));
+            event.setDamage(event.getDamage() + (Math.min(maxConsecutiveHits, hitData.getCharge()) * (level * 0.5)));
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Sharpshooter.java
@@ -15,6 +15,7 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileHitEvent;
 
 import java.util.WeakHashMap;
 
@@ -40,7 +41,7 @@ public class Sharpshooter extends Skill implements PassiveSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "You deal <val>" + (level * 0.75) + "</val> extra damage for",
+                "You deal <val>" + (level * 0.5) + "</val> extra damage for",
                 "each consecutive hit up to a maximum of <stat>"+ maxConsecutiveHits +"</stat> hits",
                 "",
                 "After <stat>" + maxTimeBetweenShots + "</stat> seconds, bonus damage resets",
@@ -68,6 +69,17 @@ public class Sharpshooter extends Skill implements PassiveSkill {
             event.setDamage(event.getDamage() + (Math.min(maxConsecutiveHits, hitData.getCharge()) * (level * 0.75)));
         }
 
+    }
+
+    @EventHandler
+    public void onArrowMiss(ProjectileHitEvent event) {
+        if(!(event.getEntity() instanceof Arrow)) return;
+        Arrow arrow = (Arrow) event.getEntity();
+        if(!(arrow.getShooter() instanceof Player)) return;
+        if(event.getHitEntity() != null) return;
+
+        Player shooter = (Player) arrow.getShooter();
+        data.remove(shooter);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/listeners/ArrowListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/listeners/ArrowListener.java
@@ -31,7 +31,7 @@ public class ArrowListener implements Listener {
     private boolean critArrowsEnabled;
 
     @Inject
-    @Config(path = "combat.arrow-base-damage", defaultValue = "4.5")
+    @Config(path = "combat.arrow-base-damage", defaultValue = "6")
     private double baseArrowDamage;
 
     private final HashMap<Arrow, Float> arrows = new HashMap<>();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/listeners/ArrowListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/listeners/ArrowListener.java
@@ -31,7 +31,7 @@ public class ArrowListener implements Listener {
     private boolean critArrowsEnabled;
 
     @Inject
-    @Config(path = "combat.arrow-base-damage", defaultValue = "6")
+    @Config(path = "combat.arrow-base-damage", defaultValue = "6.0")
     private double baseArrowDamage;
 
     private final HashMap<Arrow, Float> arrows = new HashMap<>();

--- a/champions/src/main/resources/config.yml
+++ b/champions/src/main/resources/config.yml
@@ -365,7 +365,7 @@ skills:
     longshot:
       enabled: true
       maxlevel: 5
-      baseDamage: 18.0
+      baseDamage: 16.0
       deathMessageThreshold: 40.0
     heavyarrows:
       enabled: true
@@ -374,7 +374,7 @@ skills:
       basePushBack: 1.25
     overcharge:
       enabled: true
-      maxlevel: 5
+      maxlevel: 3
     huntersthrill:
       enabled: true
       maxlevel: 5

--- a/champions/src/main/resources/config.yml
+++ b/champions/src/main/resources/config.yml
@@ -365,13 +365,13 @@ skills:
     longshot:
       enabled: true
       maxlevel: 5
-      baseDamage: 16.0
+      baseDamage: 23.0
       deathMessageThreshold: 40.0
     heavyarrows:
       enabled: true
       maxlevel: 5
       energy: 20
-      basePushBack: 1.25
+      basePushBack: 1.0
     overcharge:
       enabled: true
       maxlevel: 3

--- a/champions/src/main/resources/config.yml
+++ b/champions/src/main/resources/config.yml
@@ -367,6 +367,8 @@ skills:
       maxlevel: 5
       baseDamage: 23.0
       deathMessageThreshold: 40.0
+      blockScale: 3.0
+      damageScale: 1.0
     heavyarrows:
       enabled: true
       maxlevel: 5


### PR DESCRIPTION
Arrows:
- [BUFF] Increased all arrow damage from 4.5 to 6.0

Puts arrow damage more in line with Mineplex values

Precision:
- [NERF] Decreased precision max damage to 1.0(previously 1.5)

Must be lowered to account for higher base arrow damage.

Sharpshooter:
- [NERF] Decreased sharpshooter max damage to 1.5(previously 2.25)
- [NERF] Fixed sharpshooter not resetting damage when user missed an arrow

Overall nerf to sharpshooter to account for higher base arrow damage, the damage also wasn’t properly resetting when you missed an arrow before.

Longshot:
- [NERF] Started longshot at 1 damage instead of arrow damage
- [BUFF] Buffed Longshot base damage from 18 to 23
- [BUFF] Decreased blocks-per-damage from 3.5 to 3

Longshot will now do reduced damage up close, the maximum damage cap has been increased by 5 to account for the 5 less starting damage(max damage remains the same at 29). Damage scaling has been reduced from 3.5 blocks to 3, bringing the maximum damage distance from 80.5 to 84(nerf). Overall the power of this skill has slightly lowered to account for higher base arrow damage and bring it more in line with the mineplex system.

Overcharge:
- [NERF] Made overcharge scale 1 damage per 0.5 seconds(previously 2 damage every 0.8)
- [NERF] Lowered overcharge max damage cap from 7 to 6
- [BUFF] Lowered overcharge max level from 5 to 3

Overcharge will now scale up by values of 1, fixing the previous bug that wouldn't count odd number caps. Overall the power of the skill has lowered slightly to account for higher base arrow damage.

Heavy Arrows:
- [NERF] Reduced knockback multiplier from 1.25 to 1.0

Cooked a bit too hard on these ones