### PR TITLE
Fix skills not properly tracking players upon relogging

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/event/LoadBuildsEvent.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/event/LoadBuildsEvent.java
@@ -1,0 +1,16 @@
+package me.mykindos.betterpvp.champions.champions.builds.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+@Getter
+@AllArgsConstructor
+public class LoadBuildsEvent extends CustomEvent {
+
+    private final Player player;
+    private final GamerBuilds gamerBuilds;
+
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
+import me.mykindos.betterpvp.champions.champions.builds.event.LoadBuildsEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.ClassSelectionMenu;
 import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.ApplyBuildEvent;
@@ -46,6 +47,9 @@ public class BuildListener implements Listener {
             buildManager.getBuildRepository().loadBuilds(builds);
             buildManager.getBuildRepository().loadDefaultBuilds(builds);
             buildManager.addObject(event.getClient().getUuid(), builds);
+            UtilServer.runTask(champions, () -> {
+                UtilServer.callEvent(new LoadBuildsEvent(event.getPlayer(), builds));
+            });
         });
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -30,6 +30,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -50,6 +51,11 @@ public class RoleListener implements Listener {
         this.gamerManager = gamerManager;
         this.buildManager = buildManager;
         this.cooldownManager = cooldownManager;
+    }
+
+    @EventHandler
+    public void onLeave(PlayerQuitEvent event) {
+        roleManager.removeObject(event.getPlayer().getUniqueId().toString());
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -6,20 +6,14 @@ import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.BuildSkill;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
+import me.mykindos.betterpvp.champions.champions.builds.event.LoadBuildsEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequipEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillEquipEvent;
 import me.mykindos.betterpvp.champions.champions.roles.RoleManager;
 import me.mykindos.betterpvp.champions.champions.roles.events.RoleChangeEvent;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
-import me.mykindos.betterpvp.champions.champions.skills.types.ActiveToggleSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.ChannelSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.CooldownSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.EnergySkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.PrepareArrowSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.PrepareSkill;
-import me.mykindos.betterpvp.champions.champions.skills.types.ToggleSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.*;
 import me.mykindos.betterpvp.core.components.champions.ISkill;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
@@ -45,7 +39,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffectType;
 
@@ -330,21 +323,18 @@ public class SkillListener implements Listener {
         event.getSkill().invalidatePlayer(event.getPlayer());
     }
 
-    @EventHandler
-    public void onJoin(PlayerJoinEvent event) {
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onLoadBuilds(LoadBuildsEvent event) {
         final Player player = event.getPlayer();
 
         Role role = roleManager.getObject(player.getUniqueId().toString()).orElse(null);
-        Optional<GamerBuilds> gamerBuildsOptional = buildManager.getObject(player.getUniqueId().toString());
-        if (gamerBuildsOptional.isPresent()) {
-            GamerBuilds builds = gamerBuildsOptional.get();
+        GamerBuilds builds = event.getGamerBuilds();
 
-            // Track new skills
-            String name = role == null ? null : role.getName();
-            RoleBuild build = builds.getActiveBuilds().get(name);
-            if (build != null) {
-                build.getActiveSkills().forEach(skill -> skill.invalidatePlayer(player));
-            }
+        // Track new skills
+        String name = role == null ? null : role.getName();
+        RoleBuild build = builds.getActiveBuilds().get(name);
+        if (build != null) {
+            build.getActiveSkills().forEach(skill -> skill.trackPlayer(player));
         }
     }
 


### PR DESCRIPTION
Changes:
- Fix memory leak caused by players leaving and `RoleListener` not removing them from the `RoleManager`
- Create `LoadBuildsEvent` called after `GamerBuilds` are loaded asynchronously upon a player logging in.
- Properly track players on active skills after their builds are loaded and not as soon as they join.

Aims to fix #134 for all skills, not just Flash. Should also make it so equip messages are displayed upon logging in for all players who have an equipped set.