### PR TITLE
Fix only being able to edit/delete the first build.

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
-import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.DeleteBuildEvent;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
+import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.DeleteBuildEvent;
@@ -17,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+@Slf4j
 public class DeleteBuildButton extends Button {
 
     private final GamerBuilds builds;
@@ -32,6 +34,7 @@ public class DeleteBuildButton extends Button {
 
     @Override
     public void onClick(Player player, Gamer gamer, ClickType clickType) {
+        log.info("delete " + buildNumber);
         Optional<RoleBuild> roleBuildOptional = builds.getBuild(role, buildNumber);
         roleBuildOptional.ifPresent(build -> {
             build.deleteBuild();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
@@ -18,7 +18,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
-@Slf4j
 public class DeleteBuildButton extends Button {
 
     private final GamerBuilds builds;
@@ -26,7 +25,7 @@ public class DeleteBuildButton extends Button {
     private final int buildNumber;
 
     public DeleteBuildButton(GamerBuilds builds, Role role, int buildNumber, int slot) {
-        super(slot, new ItemStack(Material.RED_CONCRETE), Component.text("Delete" , NamedTextColor.RED));
+        super(slot, new ItemStack(Material.RED_CONCRETE), Component.text("Delete Build " + buildNumber , NamedTextColor.RED));
         this.builds = builds;
         this.role = role;
         this.buildNumber = buildNumber;
@@ -34,7 +33,6 @@ public class DeleteBuildButton extends Button {
 
     @Override
     public void onClick(Player player, Gamer gamer, ClickType clickType) {
-        log.info("delete " + buildNumber);
         Optional<RoleBuild> roleBuildOptional = builds.getBuild(role, buildNumber);
         roleBuildOptional.ifPresent(build -> {
             build.deleteBuild();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -16,7 +16,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
-@Slf4j
 public class EditBuildButton extends Button {
 
     private final GamerBuilds builds;
@@ -25,7 +24,7 @@ public class EditBuildButton extends Button {
     private final SkillManager skillManager;
 
     public EditBuildButton(GamerBuilds builds, Role role, int buildNumber, SkillManager skillManager, int slot) {
-        super(slot, new ItemStack(Material.ANVIL), Component.text("Edit Build", NamedTextColor.GRAY));
+        super(slot, new ItemStack(Material.ANVIL), Component.text("Edit Build " + buildNumber, NamedTextColor.GRAY));
         this.builds = builds;
         this.role = role;
         this.buildNumber = buildNumber;
@@ -34,7 +33,6 @@ public class EditBuildButton extends Button {
 
     @Override
     public void onClick(Player player, Gamer gamer, ClickType clickType) {
-        log.info("Clicking " + buildNumber);
         MenuManager.openMenu(player, new SkillMenu(player, builds, role, buildNumber, skillManager));
         player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0F, 2.0F);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
+import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.skills.SkillManager;
@@ -15,6 +16,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
+@Slf4j
 public class EditBuildButton extends Button {
 
     private final GamerBuilds builds;
@@ -32,6 +34,7 @@ public class EditBuildButton extends Button {
 
     @Override
     public void onClick(Player player, Gamer gamer, ClickType clickType) {
+        log.info("Clicking " + buildNumber);
         MenuManager.openMenu(player, new SkillMenu(player, builds, role, buildNumber, skillManager));
         player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0F, 2.0F);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 
-import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.skills.SkillManager;


### PR DESCRIPTION
Fixes #174. Because of how getButton is implemented, it finds the first item in the menu that matches the interacted with item. Items match if they share the same meta-data, which all the edit/delete build buttons did. Therefore, it would always select the first one it came across. By renaming them, this prevents this issue from happening.