### PR TITLE
Allow for reason stacking in death messages

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -25,6 +25,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -35,6 +36,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 @BPvPListener
 public class RoleListener implements Listener {
@@ -266,21 +268,20 @@ public class RoleListener implements Listener {
         });
     }
 
-    @EventHandler(priority = EventPriority.LOW)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onDeath(CustomDeathEvent event) {
-        if (event.getKilled() instanceof Player killed) {
-            roleManager.getObject(killed.getUniqueId()).ifPresent(role -> {
-                event.setCustomDeathMessage(event.getCustomDeathMessage()
-                        .replace(killed.getName(), "<green>" + role.getPrefix() + ".<yellow>" + killed.getName()));
-            });
-        }
-
-        if (event.getKiller() instanceof Player killer) {
-            roleManager.getObject(killer.getUniqueId()).ifPresent(role -> {
-                event.setCustomDeathMessage(event.getCustomDeathMessage()
-                        .replace(killer.getName(), "<green>" + role.getPrefix() + ".<yellow>" + killer.getName()));
-            });
-        }
+        final Function<LivingEntity, Component> def = event.getNameFormat();
+        event.setNameFormat(entity -> {
+            Component name = def.apply(entity);
+            if (entity instanceof Player player) {
+                final Optional<Role> role = roleManager.getObject(player.getUniqueId());
+                if (role.isPresent()) {
+                    final String prefix = role.get().getPrefix();
+                    name = Component.text(prefix + ". ", NamedTextColor.GREEN).append(name);
+                }
+            }
+            return name;
+        });
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -21,6 +21,8 @@ import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -276,8 +278,8 @@ public class RoleListener implements Listener {
             if (entity instanceof Player player) {
                 final Optional<Role> role = roleManager.getObject(player.getUniqueId());
                 if (role.isPresent()) {
-                    final String prefix = role.get().getPrefix();
-                    name = Component.text(prefix + ". ", NamedTextColor.GREEN).append(name);
+                    final TextComponent prefix = Component.text(role.get().getPrefix() + ".", NamedTextColor.GREEN);
+                    name = Component.join(JoinConfiguration.separator(Component.space()), prefix, name);
                 }
             }
             return name;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -279,7 +279,7 @@ public class RoleListener implements Listener {
                 final Optional<Role> role = roleManager.getObject(player.getUniqueId());
                 if (role.isPresent()) {
                     final TextComponent prefix = Component.text(role.get().getPrefix() + ".", NamedTextColor.GREEN);
-                    name = Component.join(JoinConfiguration.separator(Component.space()), prefix, name);
+                    name = Component.join(JoinConfiguration.noSeparators(), prefix, name);
                 }
             }
             return name;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
@@ -71,7 +71,7 @@ public class Backstab extends Skill implements PassiveSkill, Listener {
 
             }
 
-            event.setReason("Backstab");
+            event.addReason("Backstab");
         }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ComboAttack.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ComboAttack.java
@@ -82,7 +82,7 @@ public class ComboAttack extends Skill implements PassiveSkill, Listener {
             event.setDamage(event.getDamage() + repeat.get(damager));
             repeat.put(damager, Math.min((level * damageIncrement), repeat.get(damager) + damageIncrement));
             last.put(damager, System.currentTimeMillis());
-            event.setReason(getName());
+            event.addReason(getName());
 
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ShockingStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ShockingStrikes.java
@@ -63,7 +63,7 @@ public class ShockingStrikes extends Skill implements PassiveSkill, Listener {
 
         championsManager.getEffects().addEffect(damagee, EffectType.SHOCK, level * 1000L);
         damagee.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 20, 0));
-        event.setReason(getName());
+        event.addReason(getName());
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SilencingStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SilencingStrikes.java
@@ -78,7 +78,7 @@ public class SilencingStrikes extends Skill implements PassiveSkill, Listener {
 
             silenceData.addCount();
             silenceData.setLastHit(System.currentTimeMillis());
-            event.setReason(getName());
+            event.addReason(getName());
             if (silenceData.getCount() == hitsNeeded) {
                 championsManager.getEffects().addEffect(damagee, EffectType.SILENCE, (long) ((level * 1000L) * 0.75));
                 //if (championsManager.getEffects().hasEffect(damagee, EffectType.IMMUNETOEFFECTS)) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -108,10 +108,8 @@ public class SmokeBomb extends Skill implements ToggleSkill, CooldownSkill, List
     public void onDamage(CustomDamageEvent event) {
         if (event.getDamager() instanceof Player player) {
             if (smoked.containsKey(player)) {
-                if (event.getReason() != null) {
-                    if (event.getReason().equalsIgnoreCase("Sever")) {
-                        return;
-                    }
+                if (event.hasReason("Sever")) {
+                    return;
                 }
 
                 reappear(player);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ViperStrikes.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/ViperStrikes.java
@@ -70,7 +70,7 @@ public class ViperStrikes extends Skill implements PassiveSkill, Listener {
 
         final int ticks = (int) (getSeconds(level) * 20);
         damagee.addPotionEffect(PotionEffectType.POISON.createEffect(ticks, 0));
-        event.setReason(getName());
+        event.addReason(getName());
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -84,7 +84,7 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener 
         if (level <= 0) return;
 
         if (active.contains(damager.getUniqueId())) {
-            e.setReason("Concussion");
+            e.addReason("Concussion");
             damagee.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, (int) (level * durationPerLevel) * 20, 0));
             UtilMessage.simpleMessage(damager, getName(), "You gave <alt>" + damagee.getName() + "</alt> a concussion.");
             UtilMessage.simpleMessage(damagee, getName(), "<alt>" + damager.getName() + "</alt> gave you a concussion.");

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/CripplingBlow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/CripplingBlow.java
@@ -58,7 +58,7 @@ public class CripplingBlow extends Skill implements PassiveSkill {
         if(level > 0) {
             LivingEntity target = event.getDamagee();
             target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, (int) ((slowDuration + (level * 0.5)) * 20), 0));
-            event.setReason(getName());
+            event.addReason(getName());
             event.setKnockback(false);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/PowerChop.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/PowerChop.java
@@ -84,7 +84,7 @@ public class PowerChop extends PrepareSkill implements CooldownSkill {
         if (level > 0) {
             event.setDamage(event.getDamage() + ((Math.max(0.75, (level + 2)) * 0.75)));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_HURT, 1.0F, 1.0F);
-            event.setReason(getName());
+            event.addReason(getName());
             charge.remove(player);
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
@@ -62,7 +62,7 @@ public class Cleave extends Skill implements PassiveSkill, Listener {
         if (event.getCause() != DamageCause.ENTITY_ATTACK) return;
         if (!(event.getDamager() instanceof Player damager)) return;
         if (!UtilPlayer.isHoldingItem(damager, SkillWeapons.AXES)) return;
-        if (event.getReason().equals(getName())) return; // Don't get stuck in an endless damage loop
+        if (event.hasReason(getName())) return; // Don't get stuck in an endless damage loop
 
         int level = getLevel(damager);
         if (level > 0) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/MoltenBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/MoltenBlast.java
@@ -120,7 +120,7 @@ public class MoltenBlast extends Skill implements InteractSkill, CooldownSkill, 
 
                 event.setKnockback(true);
                 event.setDamage(damage);
-                event.setReason(getName());
+                event.addReason(getName());
                 UtilServer.runTaskLater(champions, () -> event.getDamagee().setFireTicks((int) (20 * (0 + (getLevel(player) * 0.5)))), 2);
 
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
@@ -81,7 +81,7 @@ public class WolvesFury extends Skill implements InteractSkill, CooldownSkill, L
         int level = getLevel(damager);
         if(level > 0) {
             e.setKnockback(false);
-            e.setReason(getName());
+            e.addReason(getName());
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Overcharge.java
@@ -110,7 +110,7 @@ public class Overcharge extends Skill implements InteractSkill, Listener {
         if (!(event.getDamager() instanceof Player)) return;
         if (bonus.containsKey(arrow)) {
             event.setDamage(event.getDamage() + bonus.get(arrow));
-            event.setReason(getName());
+            event.addReason(getName());
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Volley.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/Volley.java
@@ -105,7 +105,7 @@ public class Volley extends PrepareArrowSkill {
 
 
         event.setDamage(8);
-        event.setReason(getName());
+        event.addReason(getName());
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Entangle.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Entangle.java
@@ -59,7 +59,7 @@ public class Entangle extends Skill implements PassiveSkill {
 
         int level = getLevel(damager);
         if (level > 0) {
-            event.setReason(getName());
+            event.addReason(getName());
             event.getDamagee().addPotionEffect(new PotionEffect(PotionEffectType.SLOW, (int) ((baseDuration + (level * 0.5)) * 20), 1));
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Longshot.java
@@ -109,7 +109,7 @@ public class Longshot extends Skill implements PassiveSkill {
         double damage = Math.min(baseDamage + getLevel(damager), length / 3.5);
 
         event.setDamage(event.getDamage() + (damage));
-        event.setReason(getName() + (length > deathMessageThreshold ? " <gray>from <green>" + (int) length + "<gray> blocks" : ""));
+        event.addReason(getName() + (length > deathMessageThreshold ? " (" + (int) length + " blocks)" : ""));
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
@@ -39,7 +39,7 @@ public abstract class PrepareArrowSkill extends PrepareSkill implements Cooldown
 
             onHit(damager, event.getDamagee(), level);
             arrows.remove(arrow);
-            event.setReason(getName());
+            event.addReason(getName());
 
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/combat/damage/DamageListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/combat/damage/DamageListener.java
@@ -28,7 +28,7 @@ public class DamageListener implements Listener {
     public void onWeaponDamage(CustomDamageEvent event) {
         if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK) return;
         if (!(event.getDamager() instanceof Player player)) return;
-        if (!event.getReason().equals("")) return;
+        if (event.hasReason()) return; // Skip custom damage reasoned events
 
         Material material = player.getInventory().getItemInMainHand().getType();
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/damagelog/DamageLog.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/damagelog/DamageLog.java
@@ -14,7 +14,7 @@ public class DamageLog {
 
     private final EntityDamageEvent.DamageCause damageCause;
     private final double damage;
-    private final String reason;
+    private final String[] reason;
     private final long expiry = System.currentTimeMillis() + 10000;
 
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/death/DeathListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/death/DeathListener.java
@@ -1,16 +1,16 @@
 package me.mykindos.betterpvp.core.combat.death;
 
 import com.google.inject.Inject;
-import me.mykindos.betterpvp.core.combat.death.events.CustomDeathEvent;
 import me.mykindos.betterpvp.core.combat.damagelog.DamageLog;
 import me.mykindos.betterpvp.core.combat.damagelog.DamageLogManager;
+import me.mykindos.betterpvp.core.combat.death.events.CustomDeathEvent;
 import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
@@ -22,6 +22,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 @BPvPListener
 public class DeathListener implements Listener {
@@ -55,59 +58,65 @@ public class DeathListener implements Listener {
 
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCustomDeath(CustomDeathEvent event) {
+        final String[] reasonRaw = Objects.requireNonNullElse(event.getReason(), new String[]{});
+        final Component[] reasons = Arrays.stream(reasonRaw).map(text -> Component.text(text, NamedTextColor.GREEN)).toArray(Component[]::new);
+        Component reason = Component.join(JoinConfiguration.separator(Component.text(", ", NamedTextColor.GRAY)), reasons).applyFallbackStyle(NamedTextColor.GRAY);
+        Component message;
+        final Component killedName = event.getKilledName().applyFallbackStyle(NamedTextColor.YELLOW);
         if (event.getKiller() == null) {
-            if (event.getReason() == null || event.getReason().equals("")) {
-                event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed.", event.getKilled().getName()));
+            if (reasons.length == 0) {
+                message = killedName.append(Component.text(" was killed.", NamedTextColor.GRAY));
             } else {
-                event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed by <yellow>%s<gray>.",
-                        event.getKilled().getName(), event.getReason()));
+                message = killedName.append(Component.text(" was killed by ", NamedTextColor.GRAY)).append(reason);
             }
         } else {
-
+            final Component killerName = event.getKillerName().applyFallbackStyle(NamedTextColor.YELLOW);
             LivingEntity killer = event.getKiller();
+            boolean with = false;
             if (killer.getEquipment() != null) {
                 ItemStack item = killer.getEquipment().getItemInMainHand();
-                if (event.getReason().equals("") && item.getType() != Material.AIR) {
-                    event.setReason("<gray>a <green>" + PlainTextComponentSerializer.plainText()
-                            .serialize(item.displayName()).replaceAll("[\\[\\]]", ""));
+                if (reasons.length == 0 && item.getType() != Material.AIR) {
+                    Component itemCmpt = Component.text(PlainTextComponentSerializer.plainText().serialize(item.displayName()).replaceAll("[\\[\\]]", ""), NamedTextColor.GREEN);
+                    reason = Component.text("a ", NamedTextColor.GRAY).append(itemCmpt);
+                    with = true;
                 }
             }
 
-            if (event.getReason().equals("")) {
+            if (reasons.length == 0 && !with) {
                 if (!(event.getKiller() instanceof Player)) {
-                    if (event.getKiller().customName() == null) {
-                        // Better english if the killer doesnt have a custom name
-                        event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed by a <yellow>%s<gray>.",
-                                event.getKilled().getName(), event.getKiller().getName()));
+                    final Component customName = event.getKiller().customName();
+                    if (customName == null) {
+                        // Better english if the killer doesn't have a custom name
+                        message = killedName
+                                .append(Component.text(" was killed by a ", NamedTextColor.GRAY)
+                                .append(killerName));
                     } else {
-                        event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed by <yellow>%s<gray>.",
-                                event.getKilled().getName(), event.getKiller().getName()));
+                        message = killedName
+                                .append(Component.text(" was killed by ", NamedTextColor.GRAY))
+                                .append(customName.applyFallbackStyle(NamedTextColor.YELLOW));
                     }
                 } else {
-                    event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed by <yellow>%s<gray>.",
-                            event.getKilled().getName(), event.getKiller().getName()));
+                    message = killedName
+                            .append(Component.text(" was killed by ", NamedTextColor.GRAY))
+                            .append(killerName);
                 }
             } else {
-                event.setCustomDeathMessage(String.format("<yellow>%s<gray> was killed by <yellow>%s<gray> with <green>%s<gray>.",
-                        event.getKilled().getName(), event.getKiller().getName(), event.getReason()));
+                message = killedName.append(Component.text(" was killed by ", NamedTextColor.GRAY))
+                        .append(killerName)
+                        .append(Component.text(" with ", NamedTextColor.GRAY))
+                        .append(reason);
             }
-
         }
 
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void finishCustomDeath(CustomDeathEvent event) {
-        if (event.isCancelled()) return;
-
+        message = Component.text("").applyFallbackStyle(NamedTextColor.GRAY).append(message).append(Component.text("."));
         Component hoverComponent = Component.text("Damage Breakdown", NamedTextColor.GOLD).appendNewline();
         for (var breakdown : damageLogManager.getDamageBreakdown(event.getKilled())) {
             hoverComponent = hoverComponent.append(Component.text(breakdown.getKey() + ": ", NamedTextColor.YELLOW)
                     .append(Component.text(UtilMath.round(breakdown.getValue(), 1), NamedTextColor.GREEN))).appendNewline();
         }
 
-        UtilMessage.simpleMessage(event.getReceiver(), "Death", UtilFormat.stripColor(event.getCustomDeathMessage()), hoverComponent);
+        UtilMessage.simpleMessage(event.getReceiver(), "Death", message, hoverComponent);
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/death/events/CustomDeathEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/death/events/CustomDeathEvent.java
@@ -1,14 +1,20 @@
 package me.mykindos.betterpvp.core.combat.death.events;
 
+import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+
+import java.util.function.Function;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class CustomDeathEvent extends CustomCancellableEvent {
+
+    private Function<LivingEntity, Component> nameFormat = entity -> Component.text(entity.getName());
 
     // The person to receive the death message
     private final Player receiver;
@@ -16,7 +22,15 @@ public class CustomDeathEvent extends CustomCancellableEvent {
     // The entity that was killed
     private final LivingEntity killed;
     private LivingEntity killer;
-    private String reason;
-    private String customDeathMessage;
+    private String[] reason;
+
+    public Component getKillerName() {
+        Preconditions.checkNotNull(killer, "Killer is null");
+        return nameFormat.apply(killer);
+    }
+
+    public Component getKilledName() {
+        return nameFormat.apply(killed);
+    }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/events/CustomDamageEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/events/CustomDamageEvent.java
@@ -9,6 +9,9 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class CustomDamageEvent extends CustomCancellableEvent {
@@ -24,7 +27,7 @@ public class CustomDamageEvent extends CustomCancellableEvent {
     private long damageDelay = 200;
     private LightningStrike lightning;
     private boolean ignoreArmour;
-    private String reason = "";
+    private Set<String> reason = new HashSet<>();
 
     private boolean doVanillaEvent;
 
@@ -59,7 +62,7 @@ public class CustomDamageEvent extends CustomCancellableEvent {
      */
     public CustomDamageEvent(LivingEntity damagee, LivingEntity damager, Projectile proj, DamageCause cause, double damage, boolean knockback, String reason) {
         this(damagee, damager, proj, cause, damage, knockback);
-        this.reason = reason;
+        this.reason.add(reason);
     }
 
     /**
@@ -82,6 +85,21 @@ public class CustomDamageEvent extends CustomCancellableEvent {
 
     }
 
+    public void addReason(String reason) {
+        this.reason.add(reason);
+    }
+
+    public String[] getReason() {
+        return reason.toArray(String[]::new);
+    }
+
+    public boolean hasReason(String reason) {
+        return this.reason.stream().anyMatch(s -> s.equalsIgnoreCase(reason));
+    }
+
+    public boolean hasReason() {
+        return !reason.isEmpty();
+    }
 
     /**
      * Sets the damage of the event


### PR DESCRIPTION
Changes:
- Replace reasons in `CustomDeathEvent` with components.
- Allow for modules to replace the name formatting for the death event.
- Reasons are concatenated with a comma. Example:
![image](https://github.com/Mykindos/BetterPvP/assets/40250304/9f6cc507-21d8-4efd-846b-1d8859b71563)

Aims to implement #139 