### PR TITLE
Multi-plugin adapters, custom tab header/footer impl, fixes

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/leaderboard/ClanLeaderboard.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/leaderboard/ClanLeaderboard.java
@@ -101,7 +101,7 @@ public class ClanLeaderboard extends Leaderboard<UUID, Clan> implements Sorted {
     @Override
     protected Map<UUID, Clan> fetchAll(@NotNull SearchOptions options, @NotNull Database database, @NotNull String tablePrefix) {
         final ClanSort sort = (ClanSort) Objects.requireNonNull(options.getSort());
-        final Collection<Clan> pool = clanManager.getObjects().values();
+        final Collection<Clan> pool = new HashSet<>(clanManager.getObjects().values());
         pool.removeIf(Clan::isAdmin);
         return switch (sort) {
             case LEVEL -> pool.stream()

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/ProgressionAdapter.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
 import me.mykindos.betterpvp.core.framework.adapter.PluginAdapter;
+import me.mykindos.betterpvp.core.utilities.model.ConfigAccessor;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.ProgressionsManager;
 import me.mykindos.betterpvp.progression.model.ProgressionPerk;
@@ -47,6 +48,10 @@ public class ProgressionAdapter{
         for (Class<? extends Listener> clazz : listenerClasses) {
             if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
             final Listener listener = clans.getInjector().getInstance(clazz);
+            if (listener instanceof ConfigAccessor accessor) {
+                accessor.loadConfig(clans.getConfig());
+            }
+
             progression.getInjector().injectMembers(listener);
             listenerLoader.load(clazz);
         }
@@ -59,6 +64,10 @@ public class ProgressionAdapter{
         for (Class<? extends ProgressionPerk> clazz : perkClasses) {
             if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
             final ProgressionPerk perk = clans.getInjector().getInstance(clazz);
+            if (perk instanceof ConfigAccessor accessor) {
+                accessor.loadConfig(clans.getConfig());
+            }
+
             progression.getInjector().injectMembers(perk);
             clans.getInjector().injectMembers(perk);
             final Class<? extends ProgressionTree>[] trees = perk.acceptedTrees();

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/MiningListener.java
@@ -6,7 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.fields.event.FieldsInteractableUseEvent;
 import me.mykindos.betterpvp.clans.fields.model.FieldsInteractable;
 import me.mykindos.betterpvp.clans.fields.model.FieldsOre;
-import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
+import me.mykindos.betterpvp.core.utilities.model.ConfigAccessor;
 import me.mykindos.betterpvp.progression.tree.mining.Mining;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -15,11 +16,9 @@ import org.bukkit.event.Listener;
 
 @Slf4j
 @Singleton
-public class MiningListener implements Listener {
+public class MiningListener implements Listener, ConfigAccessor {
 
-    @Config(path = "fields.fieldsXpMultiplier", defaultValue = "5.0")
-    @Inject(optional = true)
-    private double xpMultiplier = 5;
+    private double xpMultiplier;
 
     @Inject(optional = true)
     private Mining mining;
@@ -36,4 +35,8 @@ public class MiningListener implements Listener {
         mining.getMiningService().attemptMineOre(player, block, experience -> (long) (experience * xpMultiplier));
     }
 
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        this.xpMultiplier = config.getOrSaveObject("fields.fieldsXpMultiplier", 5d, Double.class);
+    }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/perks/BaseFishingPerk.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/perks/BaseFishingPerk.java
@@ -5,9 +5,10 @@ import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
-import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.ConfigAccessor;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.model.ProgressionPerk;
 import me.mykindos.betterpvp.progression.model.ProgressionTree;
@@ -25,10 +26,8 @@ import java.util.Optional;
 
 @Singleton
 @Slf4j
-public class BaseFishingPerk implements Listener, ProgressionPerk {
+public class BaseFishingPerk implements Listener, ConfigAccessor, ProgressionPerk {
 
-    @Config(path = "fishing.base-fishing-perk.level", defaultValue = "500")
-    @Inject(optional = true)
     private int requiredLevel;
 
     @Inject(optional = true)
@@ -83,5 +82,10 @@ public class BaseFishingPerk implements Listener, ProgressionPerk {
             log.error("Failed to check if player " + player.getName() + " has perk " + getName(), throwable);
             return null;
         });
+    }
+
+    @Override
+    public void loadConfig(ExtendedYamlConfiguration config) {
+        this.requiredLevel = config.getOrSaveObject("fishing.base-fishing-perk.level", 500, Integer.class);
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/listener/ClientListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/listener/ClientListener.java
@@ -1,7 +1,6 @@
 package me.mykindos.betterpvp.core.client.listener;
 
 import com.google.inject.Inject;
-import lombok.SneakyThrows;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.ClientManager;
 import me.mykindos.betterpvp.core.client.Rank;
@@ -15,12 +14,9 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -36,22 +32,6 @@ public class ClientListener implements Listener {
     @Inject
     @Config(path = "pvp.enableOldPvP", defaultValue = "true")
     private boolean enableOldPvP;
-
-    @Inject
-    @Config(path = "tab.title", defaultValue = "Welcome to Mineplex Clans!")
-    private String tabTitle;
-
-    @Inject
-    @Config(path = "tab.website", defaultValue = "https://mineplex.com")
-    private String website;
-
-    @Inject
-    @Config(path = "tab.shop", defaultValue = "mineplex.com/shop")
-    private String shop;
-
-    @Inject
-    @Config(path = "tab.server", defaultValue = "Clans-1")
-    private String server;
 
     @Inject
     @Config(path = "server.unlimitedPlayers", defaultValue = "false")
@@ -117,9 +97,6 @@ public class ClientListener implements Listener {
                 }
             }
         }
-
-        updateTab(event.getPlayer());
-
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -143,25 +120,6 @@ public class ClientListener implements Listener {
         clientOptional.ifPresent(client -> {
             client.putProperty(ClientProperty.LUNAR, event.isRegistered());
         });
-    }
-
-
-    @UpdateEvent(delay = 5000)
-    public void updateTabAllPlayers() {
-        Bukkit.getOnlinePlayers().forEach(this::updateTab);
-    }
-
-    @SneakyThrows
-    public void updateTab(Player player) {
-        var header = Component.text("Mineplex ", NamedTextColor.GOLD)
-                .append(Component.text("Network ", NamedTextColor.WHITE))
-                .append(Component.text(server, NamedTextColor.GREEN));
-
-        var footer = Component.text("Visit ", NamedTextColor.WHITE)
-                .append(Component.text(shop, NamedTextColor.YELLOW))
-                .append(Component.text(" for cool perks!", NamedTextColor.WHITE));
-
-        player.sendPlayerListHeaderAndFooter(header, footer);
     }
 
     @EventHandler

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapter.java
@@ -1,14 +1,12 @@
 package me.mykindos.betterpvp.core.framework.adapter;
 
 import javax.inject.Singleton;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Singleton
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PluginAdapters.class)
 public @interface PluginAdapter {
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapters.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/adapter/PluginAdapters.java
@@ -1,0 +1,17 @@
+package me.mykindos.betterpvp.core.framework.adapter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Represents a collection of PluginAdapter annotations.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PluginAdapters {
+
+    PluginAdapter[] value();
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/gamer/Gamer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/gamer/Gamer.java
@@ -11,6 +11,7 @@ import me.mykindos.betterpvp.core.gamer.properties.GamerPropertyUpdateEvent;
 import me.mykindos.betterpvp.core.properties.PropertyContainer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.display.ActionBar;
+import me.mykindos.betterpvp.core.utilities.model.display.PlayerList;
 import me.mykindos.betterpvp.core.utilities.model.display.TitleQueue;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -30,6 +31,7 @@ public class Gamer extends PropertyContainer implements Invitable, IMapListener 
     private final String uuid;
     private ActionBar actionBar = new ActionBar();
     private TitleQueue titleQueue = new TitleQueue();
+    private PlayerList playerList = new PlayerList();
 
     private long lastDamaged;
     private long lastTip;

--- a/core/src/main/java/me/mykindos/betterpvp/core/gamer/listeners/GamerListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/gamer/listeners/GamerListener.java
@@ -95,6 +95,7 @@ public class GamerListener implements Listener {
         Bukkit.getOnlinePlayers().forEach(player ->
                 UtilServer.runTaskLater(core, () -> UtilServer.callEvent(new ScoreboardUpdateEvent(player)), 1));
 
+        gamer.getPlayerList().clear();
         gamer.getPlayerList().add(PlayerListType.FOOTER, footer);
         gamer.getPlayerList().add(PlayerListType.HEADER, header);
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/gamer/listeners/GamerListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/gamer/listeners/GamerListener.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.gamer.listeners;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.events.ClientLoginEvent;
 import me.mykindos.betterpvp.core.config.Config;
@@ -11,15 +12,24 @@ import me.mykindos.betterpvp.core.gamer.GamerManager;
 import me.mykindos.betterpvp.core.gamer.properties.GamerProperty;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.display.PermanentComponent;
+import me.mykindos.betterpvp.core.utilities.model.display.PlayerListType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @BPvPListener
+@Singleton
 public class GamerListener implements Listener {
+
+    private final PermanentComponent header;
+    private final PermanentComponent footer;
 
     @Inject
     @Config(path="gamer.default.coins", defaultValue = "5000")
@@ -29,6 +39,14 @@ public class GamerListener implements Listener {
     @Config(path="gamer.default.fragments", defaultValue = "0")
     private int defaultFragments;
 
+    @Inject
+    @Config(path = "tab.shop", defaultValue = "mineplex.com/shop")
+    private String shop;
+
+    @Inject
+    @Config(path = "tab.server", defaultValue = "Clans-1")
+    private String server;
+
     private final Core core;
     private final GamerManager gamerManager;
 
@@ -36,6 +54,14 @@ public class GamerListener implements Listener {
     public GamerListener(Core core, GamerManager gamerManager){
         this.core = core;
         this.gamerManager = gamerManager;
+
+        this.header = new PermanentComponent(gamer -> Component.text("Mineplex ", NamedTextColor.GOLD)
+                .append(Component.text("Network ", NamedTextColor.WHITE))
+                .append(Component.text(Objects.requireNonNull(server, ""), NamedTextColor.GREEN)));
+
+        this.footer = new PermanentComponent(gamer -> Component.text("Visit ", NamedTextColor.WHITE)
+                .append(Component.text(Objects.requireNonNull(shop, ""), NamedTextColor.YELLOW))
+                .append(Component.text(" for cool perks!", NamedTextColor.WHITE)));
     }
 
     @UpdateEvent (isAsync = true)
@@ -44,14 +70,13 @@ public class GamerListener implements Listener {
             gamerManager.getObject(player.getUniqueId()).ifPresent(gamer -> {
                 gamer.getActionBar().show(gamer);
                 gamer.getTitleQueue().show(gamer);
+                gamer.getPlayerList().show(gamer);
             });
         }
     }
 
-
     @EventHandler
     public void onClientLogin(ClientLoginEvent event) {
-
         Optional<Gamer> gamerOptional = gamerManager.getObject(event.getClient().getUuid());
         Gamer gamer;
         if(gamerOptional.isEmpty()){
@@ -61,15 +86,17 @@ public class GamerListener implements Listener {
             gamerManager.getGamerRepository().save(gamer);
 
             // TODO new player protection
-        }else{
+        } else {
             gamer = gamerOptional.get();
-
         }
+
         checkUnsetProperties(gamer);
 
         Bukkit.getOnlinePlayers().forEach(player ->
                 UtilServer.runTaskLater(core, () -> UtilServer.callEvent(new ScoreboardUpdateEvent(player)), 1));
 
+        gamer.getPlayerList().add(PlayerListType.FOOTER, footer);
+        gamer.getPlayerList().add(PlayerListType.HEADER, header);
     }
 
     private void checkUnsetProperties(Gamer gamer) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/listener/loader/ListenerLoader.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/listener/loader/ListenerLoader.java
@@ -11,14 +11,18 @@ public class ListenerLoader extends Loader {
         super(plugin);
     }
 
+    public void load(Listener listener) {
+        plugin.getInjector().injectMembers(listener);
+        plugin.getListeners().add(listener);
+        Bukkit.getPluginManager().registerEvents(listener, plugin);
+        count++;
+    }
+
     @Override
     public void load(Class<?> clazz) {
         try {
             Listener listener = (Listener) plugin.getInjector().getInstance(clazz);
-            plugin.getInjector().injectMembers(listener);
-            plugin.getListeners().add(listener);
-            Bukkit.getPluginManager().registerEvents(listener, plugin);
-            count++;
+            load(listener);
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/display/PlayerList.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/display/PlayerList.java
@@ -1,0 +1,115 @@
+package me.mykindos.betterpvp.core.utilities.model.display;
+
+import me.mykindos.betterpvp.core.gamer.Gamer;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+public class PlayerList {
+
+    static final Component EMPTY = Component.empty();
+
+    private final List<DisplayComponent> headers = new ArrayList<>();
+    private final List<DisplayComponent> footers = new ArrayList<>();
+
+    // Use a lock to synchronize access to the components PriorityQueue
+    private final Object lock = new Object();
+
+    public List<DisplayComponent> getHeader() {
+        synchronized (lock) {
+            return headers;
+        }
+    }
+
+    public List<DisplayComponent> getFooter() {
+        synchronized (lock) {
+            return footers;
+        }
+    }
+
+    public void add(PlayerListType type, DisplayComponent component) {
+        synchronized (lock) {
+            List<DisplayComponent> components = type == PlayerListType.HEADER ? headers : footers;
+            components.add(component);
+            if (component instanceof TimedComponent timed && !timed.isWaitToExpire()) {
+                timed.startTime();
+            }
+        }
+    }
+
+    public void remove(PlayerListType type, DisplayComponent component) {
+        synchronized (lock) {
+            List<DisplayComponent> components = type == PlayerListType.HEADER ? headers : footers;
+            components.remove(component);
+        }
+    }
+
+    public void clear() {
+        synchronized (lock) {
+            headers.clear();
+            footers.clear();
+        }
+    }
+
+    public void show(Gamer gamer) {
+        // Cleanup the action bar
+        cleanUp();
+
+        // The component to show
+        Component header;
+        Component footer;
+        synchronized (lock) {
+            header = getComponent(PlayerListType.HEADER, gamer);
+            footer = getComponent(PlayerListType.FOOTER, gamer);
+        }
+
+        // Send the action bar to the player
+        final Player player = Bukkit.getPlayer(UUID.fromString(gamer.getUuid()));
+        if (player != null) {
+            player.sendPlayerListHeaderAndFooter(header, footer);
+        }
+    }
+
+    private Component getComponent(PlayerListType type, Gamer gamer) {
+        synchronized (lock) {
+            List<DisplayComponent> components = type == PlayerListType.HEADER ? headers : footers;
+            if (components.isEmpty()) {
+                return EMPTY;
+            }
+
+            final Iterator<DisplayComponent> iterator = components.iterator();
+            Component advComponent = null;
+
+            do {
+                DisplayComponent display = iterator.next();
+                Component provided = display.getProvider().apply(gamer);
+                if (provided != null) {
+                    if (advComponent == null) {
+                        advComponent = provided;
+                    } else {
+                        advComponent = advComponent.appendNewline().append(provided);
+                    }
+
+                    if (display instanceof TimedComponent timed) {
+                        timed.startTime();
+                    }
+                }
+            } while (iterator.hasNext());
+
+            return advComponent;
+        }
+    }
+
+    private void cleanUp() {
+        synchronized (lock) {
+            // Clean up dynamic components that have expired
+            headers.removeIf(DisplayComponent::isInvalid);
+            footers.removeIf(DisplayComponent::isInvalid);
+        }
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/display/PlayerListType.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/display/PlayerListType.java
@@ -1,0 +1,8 @@
+package me.mykindos.betterpvp.core.utilities.model.display;
+
+public enum PlayerListType {
+
+    HEADER,
+    FOOTER
+
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/event/PlayerCaughtFishEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/event/PlayerCaughtFishEvent.java
@@ -13,6 +13,8 @@ public class PlayerCaughtFishEvent extends ProgressionFishingEvent {
     private FishingLoot loot;
     final FishHook hook;
     final Entity caught;
+    @Setter
+    private boolean ignoresWeight;
 
     public PlayerCaughtFishEvent(Player player, FishingLoot loot, FishHook hook, Entity caught) {
         super(player);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/event/PlayerStartFishingEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/event/PlayerStartFishingEvent.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.progression.tree.fishing.event;
 import lombok.Getter;
 import lombok.Setter;
 import me.mykindos.betterpvp.progression.tree.fishing.model.FishingLoot;
+import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
 
 @Getter
@@ -10,9 +11,11 @@ import org.bukkit.entity.Player;
 public class PlayerStartFishingEvent extends ProgressionFishingEvent {
 
     private final FishingLoot boundLoot;
+    private final FishHook hook;
 
-    public PlayerStartFishingEvent(Player player, FishingLoot boundLoot) {
+    public PlayerStartFishingEvent(Player player, FishingLoot boundLoot, FishHook hook) {
         super(player);
         this.boundLoot = boundLoot;
+        this.hook = hook;
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/tree/fishing/listener/FishingListener.java
@@ -152,7 +152,7 @@ public class FishingListener implements Listener {
 
     private void startFishing(Player player, FishHook hook) {
         final FishingLoot loot = this.fish.get(player);// store a new fish in the cache for them
-        UtilServer.callEvent(new PlayerStartFishingEvent(player, loot));
+        UtilServer.callEvent(new PlayerStartFishingEvent(player, loot, hook));
 
         // Process baits
         activeBaits.values().stream()
@@ -204,7 +204,7 @@ public class FishingListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     void onCatch (PlayerCaughtFishEvent event) {
-        //this is the final step
+        // this is the final step
         Player player = event.getPlayer();
         FishHook hook = event.getHook();
         final Item entity = (Item) Objects.requireNonNull(event.getCaught());
@@ -219,7 +219,7 @@ public class FishingListener implements Listener {
 
         boolean canMainReel = main.map(rod -> rod.canReel(caught)).orElse(false);
         boolean canOffReel = off.map(rod -> rod.canReel(caught)).orElse(false);
-        if (!canMainReel && !canOffReel) {
+        if (!canMainReel && !canOffReel && !event.isIgnoresWeight()) {
             FishingRodType rod = main.orElse(off.orElse(null));
             UtilServer.callEvent(new PlayerStopFishingEvent(player, rod, caught, PlayerStopFishingEvent.FishingResult.BAD_ROD));
             UtilMessage.message(event.getPlayer(), "Fishing", "<red>Your rod couldn't reel this <dark_red>%s</dark_red>!", caught.getType().getName());


### PR DESCRIPTION
Changes:
- Add a custom header and footer attachable object `PlayerList` on gamers.
- Fix admin clans being removed from the cache by `ClanLeaderboard`
- Add a way to ignore fish weight on catch to avoid getting blocked by the rod requirement 
- Fix Clans <-> Progression co-dependency

Changes were tested