### PR TITLE
Update build loading.

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/BuildManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/BuildManager.java
@@ -3,8 +3,13 @@ package me.mykindos.betterpvp.champions.champions.builds;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.Getter;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.builds.event.LoadBuildsEvent;
 import me.mykindos.betterpvp.champions.champions.builds.repository.BuildRepository;
 import me.mykindos.betterpvp.core.framework.manager.Manager;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 @Singleton
 @Getter
@@ -12,8 +17,30 @@ public class BuildManager extends Manager<GamerBuilds> {
 
     private final BuildRepository buildRepository;
 
+    private final Champions champions;
+
     @Inject
-    public BuildManager(BuildRepository buildRepository) {
+    public BuildManager(BuildRepository buildRepository, Champions champions) {
         this.buildRepository = buildRepository;
+        this.champions = champions;
     }
+
+    public void loadBuilds(Player player) {
+        GamerBuilds builds = new GamerBuilds(player.getUniqueId().toString());
+        getBuildRepository().loadBuilds(builds);
+        getBuildRepository().loadDefaultBuilds(builds);
+        addObject(player.getUniqueId().toString(), builds);
+        UtilServer.runTask(champions, () -> {
+            UtilServer.callEvent(new LoadBuildsEvent(player, builds));
+        });
+    }
+
+    public void reloadBuilds() {
+        getObjects().clear();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            loadBuilds(player);
+        }
+    }
+
+
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
-import me.mykindos.betterpvp.champions.champions.builds.event.LoadBuildsEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.ClassSelectionMenu;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.ApplyBuildEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.DeleteBuildEvent;
@@ -41,13 +40,7 @@ public class BuildListener implements Listener {
     @EventHandler
     public void onClientJoin(ClientJoinEvent event) {
         UtilServer.runTaskAsync(champions, () -> {
-            GamerBuilds builds = new GamerBuilds(event.getClient().getUuid());
-            buildManager.getBuildRepository().loadBuilds(builds);
-            buildManager.getBuildRepository().loadDefaultBuilds(builds);
-            buildManager.addObject(event.getClient().getUuid(), builds);
-            UtilServer.runTask(champions, () -> {
-                UtilServer.callEvent(new LoadBuildsEvent(event.getPlayer(), builds));
-            });
+            buildManager.loadBuilds(event.getPlayer());
         });
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/repository/BuildRepository.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/repository/BuildRepository.java
@@ -52,6 +52,9 @@ public class BuildRepository implements IRepository<RoleBuild> {
                 int id = result.getInt(3);
                 RoleBuild build = new RoleBuild(uuid, Role.valueOf(role.toUpperCase()), id);
 
+                boolean active = result.getBoolean(10);
+                build.setActive(active);
+
                 String sword = result.getString(4);
                 setSkill(build, SkillType.SWORD, sword);
 
@@ -69,9 +72,6 @@ public class BuildRepository implements IRepository<RoleBuild> {
 
                 String global = result.getString(9);
                 setSkill(build, SkillType.GLOBAL, global);
-
-                boolean active = result.getBoolean(10);
-                build.setActive(active);
 
                 if (active) {
                     builds.getActiveBuilds().put(role, build);
@@ -98,6 +98,7 @@ public class BuildRepository implements IRepository<RoleBuild> {
         Skill skill = skillManager.getObjects().get(skillName);
         if (skill == null) return;
         if (!skill.isEnabled()) {
+            if (!build.isActive()) return;
             Player player = Bukkit.getPlayer(fromString(build.getUuid()));
             if (player == null) return;
             UtilMessage.message(player, "Champions", UtilMessage.deserialize("<green>%s</green> has been disabled on this server, refunding <green>%s</green> skill point(s) and removing from <yellow>%s</yellow> build <green>%s</green>", skill.getName(), level, build.getRole().toString(), build.getId()));

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/repository/BuildRepository.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/repository/BuildRepository.java
@@ -14,11 +14,16 @@ import me.mykindos.betterpvp.core.database.query.values.BooleanStatementValue;
 import me.mykindos.betterpvp.core.database.query.values.IntegerStatementValue;
 import me.mykindos.betterpvp.core.database.query.values.StringStatementValue;
 import me.mykindos.betterpvp.core.database.repository.IRepository;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 import javax.sql.rowset.CachedRowSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.UUID.fromString;
 
 @Singleton
 public class BuildRepository implements IRepository<RoleBuild> {
@@ -85,16 +90,21 @@ public class BuildRepository implements IRepository<RoleBuild> {
 
         if (value != null && !value.isEmpty()) {
             String[] split = value.split(",");
-            Skill skill = skillManager.getObjects().get(split[0]);
-            if(skill == null) return;
-            if (!skill.isEnabled()) return;
-
-            int level = Integer.parseInt(split[1]);
-            build.setSkill(type, skill, level);
-            build.takePoints(level);
-
-
+            setSkill(build, type, split[0], Integer.parseInt(split[1]));
         }
+    }
+
+    private void setSkill(RoleBuild build, SkillType type, String skillName, int level) {
+        Skill skill = skillManager.getObjects().get(skillName);
+        if (skill == null) return;
+        if (!skill.isEnabled()) {
+            Player player = Bukkit.getPlayer(fromString(build.getUuid()));
+            if (player == null) return;
+            UtilMessage.message(player, "Champions", UtilMessage.deserialize("<green>%s</green> has been disabled on this server, refunding <green>%s</green> skill point(s) and removing from <yellow>%s</yellow> build <green>%s</green>", skill.getName(), level, build.getRole().toString(), build.getId()));
+            return;
+        }
+        build.setSkill(type, skill, level);
+        build.takePoints(level);
     }
 
     @Override
@@ -146,47 +156,41 @@ public class BuildRepository implements IRepository<RoleBuild> {
         for (int d = 1; d < 5; d++) {
 
             RoleBuild assassin = new RoleBuild(uuid, Role.valueOf("ASSASSIN"), d);
-
-            assassin.setSkill(SkillType.SWORD, skillManager.getObjects().get("Sever"), 3);
-            assassin.setSkill(SkillType.AXE, skillManager.getObjects().get("Leap"), 5);
-            assassin.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Backstab"), 1);
-            assassin.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Smoke Bomb"), 3);
-            assassin.takePoints(12);
+            setSkill(assassin, SkillType.SWORD, "Sever", 3);
+            setSkill(assassin, SkillType.AXE, "Leap", 5);
+            setSkill(assassin, SkillType.PASSIVE_A, "Backstab", 1);
+            setSkill(assassin, SkillType.PASSIVE_B, "Smoke Bomb", 3);
 
             RoleBuild brute = new RoleBuild(uuid, Role.valueOf("BRUTE"), d);
-            brute.setSkill(SkillType.SWORD, skillManager.getObjects().get("Takedown"), 5);
-            brute.setSkill(SkillType.AXE, skillManager.getObjects().get("Seismic Slam"), 3);
-            brute.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Colossus"), 1);
-            brute.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Stampede"), 3);
-            brute.takePoints(12);
+            setSkill(brute, SkillType.SWORD, "Takedown", 5);
+            setSkill(brute, SkillType.AXE, "Seismic Slam", 3);
+            setSkill(brute, SkillType.PASSIVE_A, "Colossus", 1);
+            setSkill(brute, SkillType.PASSIVE_B, "Stampede", 3);
+
 
             RoleBuild ranger = new RoleBuild(uuid, Role.valueOf("RANGER"), d);
-            ranger.setSkill(SkillType.SWORD, skillManager.getObjects().get("Disengage"), 3);
-            ranger.setSkill(SkillType.BOW, skillManager.getObjects().get("Incendiary Shot"), 5);
-            ranger.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Longshot"), 3);
-            ranger.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Sharpshooter"), 1);
-            ranger.takePoints(12);
+            setSkill(ranger, SkillType.SWORD, "Disengage", 3);
+            setSkill(ranger, SkillType.BOW, "Incendiary Shot", 5);
+            setSkill(ranger, SkillType.PASSIVE_A, "Longshot", 3);
+            setSkill(ranger, SkillType.PASSIVE_B, "Sharpshooter", 1);
 
             RoleBuild mage = new RoleBuild(uuid, Role.valueOf("MAGE"), d);
-            mage.setSkill(SkillType.SWORD, skillManager.getObjects().get("Inferno"), 5);
-            mage.setSkill(SkillType.AXE, skillManager.getObjects().get("Molten Blast"), 3);
-            mage.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Holy Light"), 2);
-            mage.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Immolate"), 2);
-            mage.takePoints(12);
+            setSkill(mage, SkillType.SWORD, "Inferno", 5);
+            setSkill(mage, SkillType.AXE, "Molten Blast", 3);
+            setSkill(mage, SkillType.PASSIVE_A, "Holy Light", 2);
+            setSkill(mage, SkillType.PASSIVE_B, "Immolate", 2);
 
             RoleBuild knight = new RoleBuild(uuid, Role.valueOf("KNIGHT"), d);
-            knight.setSkill(SkillType.SWORD, skillManager.getObjects().get("Riposte"), 3);
-            knight.setSkill(SkillType.AXE, skillManager.getObjects().get("Bulls Charge"), 5);
-            knight.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Fury"), 3);
-            knight.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Swordsmanship"), 1);
-            knight.takePoints(12);
+            setSkill(knight, SkillType.SWORD, "Riposte", 3);
+            setSkill(knight, SkillType.AXE, "Bulls Charge", 5);
+            setSkill(knight, SkillType.PASSIVE_A, "Fury", 3);
+            setSkill(knight, SkillType.PASSIVE_B, "Swordsmanship", 1);
 
             RoleBuild warlock = new RoleBuild(uuid, Role.valueOf("WARLOCK"), d);
-            warlock.setSkill(SkillType.SWORD, skillManager.getObjects().get("Leech"), 4);
-            warlock.setSkill(SkillType.AXE, skillManager.getObjects().get("Bloodshed"), 5);
-            warlock.setSkill(SkillType.PASSIVE_A, skillManager.getObjects().get("Frailty"), 1);
-            warlock.setSkill(SkillType.PASSIVE_B, skillManager.getObjects().get("Soul Harvest"), 2);
-            warlock.takePoints(12);
+            setSkill(warlock, SkillType.SWORD, "Leech", 4);
+            setSkill(warlock, SkillType.AXE, "Bloodshed", 5);
+            setSkill(warlock, SkillType.PASSIVE_A, "Frailty", 1);
+            setSkill(warlock, SkillType.PASSIVE_B, "Soul Harvest", 2);
 
             builds.addAll(List.of(knight, ranger, brute, mage, assassin, warlock));
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/commands/ChampionsCommand.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/commands/ChampionsCommand.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.commands;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.skills.SkillManager;
 import me.mykindos.betterpvp.champions.listeners.ChampionsListenerLoader;
 import me.mykindos.betterpvp.champions.weapons.WeaponManager;
@@ -67,6 +68,9 @@ public class ChampionsCommand extends Command implements IConsoleCommand {
         @Inject
         private WeaponManager weaponManager;
 
+        @Inject
+        private BuildManager buildManager;
+
         @Override
         public String getName() {
             return "reload";
@@ -90,6 +94,7 @@ public class ChampionsCommand extends Command implements IConsoleCommand {
             listenerLoader.reload(champions.getClass().getPackageName());
             skillManager.reloadSkills();
             weaponManager.reload();
+            buildManager.reloadBuilds();
 
             itemHandler.loadItemData("Champions");
 


### PR DESCRIPTION
#253, #210. On champions reload, disabled skills are now removed from builds and points refunded. Default builds now use the same method as saved builds, and won't take points from disabled/null skills. A new notification is given to players if a skill they had is no longer available.


This does not update builds in the database, if a player does not change their build in the build table, it will continue to give the warning.