### PR TITLE
Make packet-based claim outlines

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
@@ -1,16 +1,23 @@
 package me.mykindos.betterpvp.core.world.blocks;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.Getter;
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.HeightMap;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
+import org.bukkit.block.data.BlockData;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Singleton
@@ -18,8 +25,11 @@ public class WorldBlockHandler {
 
     @Getter
     private final List<RestoreBlock> restoreBlocks;
+    private final Core core;
 
-    public WorldBlockHandler() {
+    @Inject
+    public WorldBlockHandler(Core core) {
+        this.core = core;
         this.restoreBlocks = new ArrayList<>();
     }
 
@@ -41,20 +51,25 @@ public class WorldBlockHandler {
         return restoreBlocks.stream().filter(restoreBlock -> restoreBlock.getBlock().getLocation().equals(block.getLocation())).findFirst();
     }
 
-
     public void outlineChunk(Chunk chunk) {
+        final BlockData data = Material.SEA_LANTERN.createBlockData();
+        final Map<Location, BlockData> outline = new HashMap<>();
+        final Map<Location, BlockData> original = new HashMap<>();
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
                 if (z == 0 || z == 15 || x == 0 || x == 15) {
                     Location blockLoc = chunk.getBlock(x, 0, z).getLocation();
                     Block down = chunk.getWorld().getHighestBlockAt(blockLoc, HeightMap.MOTION_BLOCKING_NO_LEAVES);
                     if (!(down.getState() instanceof Container)) {
-                        addRestoreBlock(down, Material.SEA_LANTERN, 60_000L);
+                        original.put(down.getLocation(), down.getBlockData());
+                        outline.put(down.getLocation(), data);
                     }
                 }
             }
         }
 
+        Bukkit.getOnlinePlayers().forEach(player -> player.sendMultiBlockChange(outline));
+        UtilServer.runTaskLater(core, () -> Bukkit.getOnlinePlayers().forEach(player -> player.sendMultiBlockChange(original)), 60 * 20L);
     }
 
 }


### PR DESCRIPTION
Changes:
- Claim outlines are now packet-based, meaning re-logging or clicking the blocks will reset their state.

Changes were tested
Fixes #230 