### PR TITLE
Remove extra tick extension on blocking

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
@@ -10,13 +10,16 @@ import me.mykindos.betterpvp.core.framework.customtypes.IMapListener;
 import me.mykindos.betterpvp.core.framework.events.scoreboard.ScoreboardUpdateEvent;
 import me.mykindos.betterpvp.core.framework.inviting.Invitable;
 import me.mykindos.betterpvp.core.properties.PropertyContainer;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.Unique;
 import me.mykindos.betterpvp.core.utilities.model.display.ActionBar;
 import me.mykindos.betterpvp.core.utilities.model.display.PlayerList;
 import me.mykindos.betterpvp.core.utilities.model.display.TitleQueue;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,7 +49,24 @@ public class Gamer extends PropertyContainer implements Invitable, Unique, IMapL
         properties.registerListener(this);
     }
 
+    public boolean canBlock() {
+        final Player player = getPlayer();
+        if (player != null) {
+            final ItemStack main = player.getInventory().getItemInMainHand();
+            final ItemStack off = player.getInventory().getItemInOffHand();
+            return UtilItem.isSword(main) || main.getType().equals(Material.SHIELD)
+                    || UtilItem.isSword(off) || off.getType().equals(Material.SHIELD);
+        }
+
+        return false;
+    }
+
     public boolean isHoldingRightClick() {
+        if (canBlock()) {
+            final Player player = getPlayer();
+            return player != null && (player.isBlocking() || player.isHandRaised());
+        }
+
         return isHoldingRightClick;
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
@@ -54,8 +54,8 @@ public class Gamer extends PropertyContainer implements Invitable, Unique, IMapL
         if (player != null) {
             final ItemStack main = player.getInventory().getItemInMainHand();
             final ItemStack off = player.getInventory().getItemInOffHand();
-            return UtilItem.isSword(main) || main.getType().equals(Material.SHIELD)
-                    || UtilItem.isSword(off) || off.getType().equals(Material.SHIELD);
+            return UtilItem.isSword(main) || (main.getType().equals(Material.SHIELD) && !UtilItem.isCosmeticShield(main))
+                    || UtilItem.isSword(off) || (off.getType().equals(Material.SHIELD) && !UtilItem.isCosmeticShield(off));
         }
 
         return false;

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
@@ -78,7 +78,7 @@ public class RightClickListener implements Listener {
 
             // If the click took longer than 250ms, remove it from the cache
             // Unless they're blocking with a shield, meaning they are still holding right click
-            if (!player.isBlocking() && System.currentTimeMillis() - context.getTime() > 260) {
+            if (!(gamer.canBlock() && (player.isBlocking() || player.isHandRaised())) && System.currentTimeMillis() - context.getTime() > 249) {
                 iterator.remove();
                 context.getGamer().setHoldingRightClick(false);
                 final RightClickEndEvent releaseEvent = new RightClickEndEvent(context.getGamer().getPlayer());

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
@@ -7,7 +7,6 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.combat.click.events.RightClickEndEvent;
 import me.mykindos.betterpvp.core.combat.click.events.RightClickEvent;
-import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
@@ -25,8 +24,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataType;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,7 +67,7 @@ public class RightClickListener implements Listener {
             if (!player.isOnline()) {
                 iterator.remove();
                 context.getGamer().setHoldingRightClick(false);
-                if (isCosmeticShield(player.getInventory().getItemInOffHand())) {
+                if (UtilItem.isCosmeticShield(player.getInventory().getItemInOffHand())) {
                     player.getInventory().setItemInOffHand(null);
                 }
                 continue;
@@ -141,7 +138,7 @@ public class RightClickListener implements Listener {
 
     @EventHandler
     public void onPickupShield(EntityPickupItemEvent event) {
-        if (isCosmeticShield(event.getItem().getItemStack())) {
+        if (UtilItem.isCosmeticShield(event.getItem().getItemStack())) {
             event.setCancelled(true);
             event.getItem().remove();
         }
@@ -152,7 +149,7 @@ public class RightClickListener implements Listener {
         // Prevent from touching the shield
         if (event.getClickedInventory() != null) {
             if (event.getCurrentItem() != null) {
-                if (isCosmeticShield(event.getCurrentItem())) {
+                if (UtilItem.isCosmeticShield(event.getCurrentItem())) {
                     event.setCancelled(true);
                     return;
                 }
@@ -163,7 +160,7 @@ public class RightClickListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onReleaseClick(RightClickEndEvent event) {
         Player player = event.getPlayer();
-        if (isCosmeticShield(player.getInventory().getItemInOffHand())) {
+        if (UtilItem.isCosmeticShield(player.getInventory().getItemInOffHand())) {
             player.getInventory().setItemInOffHand(null);
         }
     }
@@ -185,31 +182,20 @@ public class RightClickListener implements Listener {
             return;
         }
 
-        if (isCosmeticShield(offhand)) {
+        if (UtilItem.isCosmeticShield(offhand)) {
             return; // Don't replace if we are already holding a cosmetic shield
         }
 
         // Replace offhand with shield because we are blocking
-        ItemStack shield = new ItemStack(Material.SHIELD);
-        final ItemMeta meta = shield.getItemMeta();
-        meta.setCustomModelData(event.getShieldModelData());
-        meta.getPersistentDataContainer().set(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN, true);
-        shield.setItemMeta(meta);
-        player.getInventory().setItemInOffHand(shield);
+        player.getInventory().setItemInOffHand(UtilItem.createCosmeticShield(event.getShieldModelData()));
     }
 
     @EventHandler
     public void onDropOffhand(PlayerDropItemEvent event) {
         final ItemStack item = event.getItemDrop().getItemStack();
-        if (isCosmeticShield(item)) {
+        if (UtilItem.isCosmeticShield(item)) {
             event.setCancelled(true);
         }
-    }
-
-    private boolean isCosmeticShield(ItemStack item) {
-        return item.getType() == Material.SHIELD && item.hasItemMeta()
-                && item.getItemMeta().getPersistentDataContainer().has(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN)
-                && Boolean.TRUE.equals(item.getItemMeta().getPersistentDataContainer().get(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN));
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/click/RightClickListener.java
@@ -66,7 +66,7 @@ public class RightClickListener implements Listener {
             final Gamer gamer = context.getGamer();
             if (!player.isOnline()) {
                 iterator.remove();
-                context.getGamer().setHoldingRightClick(false);
+                gamer.setLastBlock(-1);
                 if (UtilItem.isCosmeticShield(player.getInventory().getItemInOffHand())) {
                     player.getInventory().setItemInOffHand(null);
                 }
@@ -77,7 +77,7 @@ public class RightClickListener implements Listener {
             // Unless they're blocking with a shield, meaning they are still holding right click
             if (!(gamer.canBlock() && (player.isBlocking() || player.isHandRaised())) && System.currentTimeMillis() - context.getTime() > 249) {
                 iterator.remove();
-                context.getGamer().setHoldingRightClick(false);
+                gamer.setLastBlock(-1);
                 final RightClickEndEvent releaseEvent = new RightClickEndEvent(context.getGamer().getPlayer());
                 UtilServer.callEvent(releaseEvent);
                 continue;
@@ -88,14 +88,14 @@ public class RightClickListener implements Listener {
             ItemStack holding = player.getInventory().getItem(context.getEvent().getHand());
             if (!UtilItem.isSimilar(holding, previouslyHolding)) {
                 iterator.remove();
-                context.getGamer().setHoldingRightClick(false);
+                gamer.setLastBlock(-1);
                 final RightClickEndEvent releaseEvent = new RightClickEndEvent(context.getGamer().getPlayer());
                 UtilServer.callEvent(releaseEvent);
                 continue;
             }
 
             // Otherwise, keep holding the item
-            gamer.setHoldingRightClick(true);
+            gamer.setLastBlock(System.currentTimeMillis());
             final RightClickEvent previousEvent = context.getEvent();
             final RightClickEvent event = new RightClickEvent(player,
                     previousEvent.isUseShield(),
@@ -122,7 +122,7 @@ public class RightClickListener implements Listener {
         // Call event
         final Player player = event.getPlayer();
         final Gamer gamer = clientManager.search().online(player).getGamer();
-        gamer.setHoldingRightClick(true);
+        gamer.setLastBlock(System.currentTimeMillis());
         final RightClickEvent clickEvent = new RightClickEvent(player, false, 0, false, event.getHand());
         final RightClickContext context = new RightClickContext(gamer, clickEvent, item);
         final RightClickContext previous = rightClickCache.remove(player);

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.utilities;
 
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
+import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
 import me.mykindos.betterpvp.core.utilities.model.WeighedList;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -11,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +21,20 @@ import java.util.Map;
 
 public class UtilItem {
 
+    public static boolean isCosmeticShield(ItemStack item) {
+        return item.getType() == Material.SHIELD && item.hasItemMeta()
+                && item.getItemMeta().getPersistentDataContainer().has(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN)
+                && Boolean.TRUE.equals(item.getItemMeta().getPersistentDataContainer().get(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN));
+    }
+
+    public static ItemStack createCosmeticShield(int modelData) {
+        ItemStack shield = new ItemStack(Material.SHIELD);
+        final ItemMeta meta = shield.getItemMeta();
+        meta.setCustomModelData(modelData);
+        meta.getPersistentDataContainer().set(CoreNamespaceKeys.UNDROPPABLE_KEY, PersistentDataType.BOOLEAN, true);
+        shield.setItemMeta(meta);
+        return shield;
+    }
 
     /**
      * Updates an ItemStack, giving it a custom name and lore


### PR DESCRIPTION
Changes:
- Migrate to state-based checking for sword and shield right clicking.
- Remove extra tick extension on all right-clicks for every other item.

Changes were tested.