### PR TITLE
Remove hard redis requirement to host a BetterPvP server

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
@@ -1,19 +1,54 @@
 package me.mykindos.betterpvp.core.redis;
 
+import com.google.common.base.Preconditions;
 import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.NotNull;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
 import java.time.Duration;
 
 @Singleton
+@Slf4j
 public class Redis {
 
     private JedisPool pool;
 
     public void credentials(final RedisCredentials redisCredentials) {
+        Preconditions.checkNotNull(redisCredentials, "Redis credentials cannot be null!");
+        Preconditions.checkState(pool == null, "Redis credentials have already been set!");
+
+        final JedisPoolConfig poolConfig = getJedisPoolConfig();
+        if (redisCredentials.getPassword() == null || redisCredentials.getPassword().isEmpty()) {
+            // Passwordless redis
+            this.pool = new JedisPool(
+                    poolConfig,
+                    redisCredentials.getHost(),
+                    redisCredentials.getPort(),
+                    0,
+                    null,
+                    redisCredentials.getDatabase()
+            );
+        } else {
+            // Passworded redis
+            this.pool = new JedisPool(
+                    poolConfig,
+                    redisCredentials.getHost(),
+                    redisCredentials.getPort(),
+                    0,
+                    redisCredentials.getPassword(),
+                    redisCredentials.getDatabase()
+            );
+        }
+
+        log.info("Redis has been enabled.");
+    }
+
+    @NotNull
+    private static JedisPoolConfig getJedisPoolConfig() {
         final JedisPoolConfig poolConfig = new JedisPoolConfig();
         poolConfig.setMaxTotal(128);
         poolConfig.setMaxIdle(128);
@@ -25,21 +60,18 @@ public class Redis {
         poolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(30));
         poolConfig.setNumTestsPerEvictionRun(3);
         poolConfig.setBlockWhenExhausted(true);
-
-        this.pool = new JedisPool(
-                poolConfig,
-                redisCredentials.getHost(),
-                redisCredentials.getPort(),
-                0,
-                redisCredentials.getPassword(),
-                redisCredentials.getDatabase()
-        );
+        return poolConfig;
     }
 
     public void credentials(final FileConfiguration fileConfiguration) {
         final ConfigurationSection section = fileConfiguration.getConfigurationSection("core.redis");
         if (section == null) {
             throw new IllegalArgumentException("The configuration file provided does not contain database details!");
+        }
+
+        if (!section.getBoolean("enabled")) {
+            log.warn("Redis has been disabled in the configuration file. Cross-server functionality will not work.");
+            return;
         }
 
         final RedisCredentials redisInfo = new RedisCredentials(
@@ -54,6 +86,10 @@ public class Redis {
 
     public RedisAgent createAgent() {
         return new RedisAgent(pool);
+    }
+
+    public boolean isEnabled() {
+        return pool != null;
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
@@ -28,9 +28,7 @@ public class Redis {
                     poolConfig,
                     redisCredentials.getHost(),
                     redisCredentials.getPort(),
-                    0,
-                    null,
-                    redisCredentials.getDatabase()
+                    0
             );
         } else {
             // Passworded redis
@@ -39,8 +37,7 @@ public class Redis {
                     redisCredentials.getHost(),
                     redisCredentials.getPort(),
                     0,
-                    redisCredentials.getPassword(),
-                    redisCredentials.getDatabase()
+                    redisCredentials.getPassword()
             );
         }
 
@@ -77,7 +74,6 @@ public class Redis {
         final RedisCredentials redisInfo = new RedisCredentials(
                 section.getString("password"),
                 section.getString("host"),
-                section.getInt("database"),
                 section.getInt("port")
         );
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/redis/RedisCredentials.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/redis/RedisCredentials.java
@@ -7,14 +7,11 @@ public class RedisCredentials {
 
     String password;
     String host;
-    int database;
     int port;
 
-    RedisCredentials(final String password, final String host, final int database,
-                     final int port) {
+    RedisCredentials(final String password, final String host, final int port) {
         this.password = password;
         this.host = host;
-        this.database = database;
         this.port = port;
     }
 
@@ -24,10 +21,6 @@ public class RedisCredentials {
 
     public String getHost() {
         return this.host;
-    }
-
-    public int getDatabase() {
-        return this.database;
     }
 
     public int getPort() {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -11,6 +11,7 @@ core:
       password: BetterPvP123!
       ip: 127.0.0.1:27821
   redis:
+    enabled: false
     database: 0
     password: BetterPvPAdmin123!
     host: 127.0.0.1

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -12,7 +12,6 @@ core:
       ip: 127.0.0.1:27821
   redis:
     enabled: false
-    database: 0
     password: BetterPvPAdmin123!
     host: 127.0.0.1
     port: 27822


### PR DESCRIPTION
Changes:
- Add `enabled` boolean option in Core `config.yml` under the `redis` subsection.
- `password` field in the `redis` subsection located in the Core `config.yml` is no longer required.
- Added logging for Redis enable/disable.

Changes were tested.