### PR TITLE
QoL fixes for click registration and warning removal

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/types/ChannelWeapon.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/types/ChannelWeapon.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.weapons.types;
 import me.mykindos.betterpvp.champions.weapons.Weapon;
 import me.mykindos.betterpvp.core.components.champions.weapons.IWeapon;
 import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -26,6 +27,10 @@ public abstract class ChannelWeapon extends Weapon implements IWeapon, Listener 
     }
 
     public abstract double getEnergy();
+
+    public boolean useShield(Player player) {
+        return false;
+    }
 
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/types/InteractWeapon.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/types/InteractWeapon.java
@@ -8,8 +8,4 @@ public interface InteractWeapon extends IWeapon {
     void activate(Player player);
     boolean canUse(Player player);
 
-    default boolean useShield(Player player) {
-        return false;
-    }
-
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/legendaries/KnightsGreatlance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/legendaries/KnightsGreatlance.java
@@ -199,6 +199,12 @@ public class KnightsGreatlance extends ChannelWeapon implements InteractWeapon, 
                 continue;
             }
 
+            if (!energyHandler.use(player, "Knight's Greatlance", energyPerTick, true)) {
+                iterator.remove();
+                deactivate(player, data);
+                return;
+            }
+
             // Get all enemies that collide with the player from the last location to the new location
             final Location newLocation = getMidpoint(player);
             final Optional<LivingEntity> hit = trace(player, data.getLastLocation(), newLocation);
@@ -247,10 +253,6 @@ public class KnightsGreatlance extends ChannelWeapon implements InteractWeapon, 
             Vector direction = player.getLocation().getDirection().multiply(chargeVelocity);
             direction.setY(0); // Make them stick to the ground
             player.setVelocity(direction);
-
-            if (!energyHandler.use(player, "Knight's Greatlance", energyPerTick, true)) {
-                return;
-            }
 
             // Cues
             new ParticleBuilder(Particle.CRIT)

--- a/champions/src/main/resources/champions-migrations/V4__Add_items.sql
+++ b/champions/src/main/resources/champions-migrations/V4__Add_items.sql
@@ -307,13 +307,13 @@ INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, H
     ('MUSIC_DISC_BLOCKS', 'champions', 'hyper_axe', '<orange>Hyper Axe', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
-    ('MUSIC_DISC_WAIT", "champions", "knights_greatlance", "<orange>Knight"s Greatlance", 1, 0, 1);
+    ('MUSIC_DISC_WAIT', 'champions', 'knights_greatlance', '<orange>Knight''s Greatlance', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
     ('MUSIC_DISC_FAR', 'champions', 'magnetic_maul', '<orange>Magnetic Maul', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
-    ('MUSIC_DISC_CAT', 'champions', 'giants_broadsword', "<orange>Giant's Broadsword", 1, 0, 1);
+    ('MUSIC_DISC_CAT', 'champions', 'giants_broadsword', '<orange>Giant''s Broadsword', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
     ('ELYTRA', 'champions', 'wings_of_zanzul', '<orange>Wings of Zanzul', 1, 0, 1);

--- a/core/src/main/java/me/mykindos/betterpvp/core/Core.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/Core.java
@@ -98,6 +98,8 @@ public class Core extends BPvPPlugin {
     @Override
     public void onDisable() {
         clientManager.processStatUpdates(false);
+        clientManager.shutdown();
+        redis.shutdown();
         injector.getInstance(GlobalCombatStatsRepository.class).shutdown();
 
         if (hasListener(listenerKey)) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientManager.java
@@ -78,6 +78,12 @@ public class ClientManager extends PlayerManager<Client> {
                 .build(key -> CACHE_DUMMY);
     }
 
+    public void shutdown() {
+        if (this.redis.isEnabled()) {
+            this.redisLayer.getObserver().shutdown();
+        }
+    }
+
     public void sendMessageToRank(String prefix, Component message, Rank rank) {
         List<Client> clients = this.getOnline().stream().filter(client -> client.hasRank(rank)).toList();
         clients.forEach(client -> {

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientObserver.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientObserver.java
@@ -26,7 +26,7 @@ public class ClientObserver extends JedisPubSub {
     @Inject
     public ClientObserver(Core core, Redis redis) {
         this.agent = redis.createAgent();
-        UtilServer.runTaskAsync(core, () -> redis.createAgent().useResource(jedis -> jedis.subscribe(this, CHANNEL)));
+        UtilServer.runTaskAsync(core, () -> agent.useResource(jedis -> jedis.subscribe(this, CHANNEL)));
     }
 
     public static String encode(UUID uuid) {
@@ -58,5 +58,9 @@ public class ClientObserver extends JedisPubSub {
 
     public void register(Consumer<UUID> listener) {
         this.listeners.add(listener);
+    }
+
+    public void shutdown() {
+        this.unsubscribe();
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/redis/Redis.java
@@ -80,6 +80,12 @@ public class Redis {
         this.credentials(redisInfo);
     }
 
+    public void shutdown() {
+        if (pool != null) {
+            pool.close();
+        }
+    }
+
     public RedisAgent createAgent() {
         return new RedisAgent(pool);
     }


### PR DESCRIPTION
Changes: 
- Remove [improper asynchronous task shutdown warning](https://cdn.discordapp.com/attachments/695630666775265360/1191317275739951144/image.png?ex=65a4ffac&is=65928aac&hm=deb3121301337eb39f60fdd77873b0df6db0a9bc1f228c71d172c4acb2c066d1&) (@Mykindos) ([Log example](https://mcpaste.io/e185855e2b4ef7a8))
- Fix SQL statement errors introduced in #256 
- Restrict click registration checks to only `ChannelWeapon`s, which are mostly only the legendaries. All other weapons use default fallback behavior using `PlayerInteractEvent`

Changes were all tested.