### PR TITLE
Improve throwable item detection and make Mineplex 1:1 FleshHook replica

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
@@ -35,7 +35,7 @@ public class ChargeData {
             return;
         }
 
-        player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 0.5f, 1f + (0.5f * charge));
+        player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 0.5f, 1f + charge);
         lastSound = System.currentTimeMillis();
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
@@ -1,0 +1,41 @@
+package me.mykindos.betterpvp.champions.champions.skills.data;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+
+/**
+ * Represents the charge data for a player using a charge skill
+ * The charge can be between 0 and 1.
+ * 0 being no charge and 1 being fully charged
+ */
+@Data
+@RequiredArgsConstructor
+public class ChargeData {
+
+    private float charge = 0; // 0 -> 1
+    private final float chargePerSecond; // 0 -> 1
+    private long lastSound = 0;
+    private long lastMessage = 0;
+    private long soundInterval = 150; // In millis
+
+    /**
+     * Gain charge for this skill.
+     * This method assumes that the call is being made every tick (20 times a second)
+     */
+    public void tick() {
+        // Divide over 100 to get multiplication factor since it's in 100% scale for display
+        this.charge = Math.min(1, this.charge + (chargePerSecond / 20));
+    }
+
+    public void tickSound(Player player) {
+        if (!UtilTime.elapsed(lastSound, soundInterval)) {
+            return;
+        }
+
+        player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 0.5f, 1f + (0.5f * charge));
+        lastSound = System.currentTimeMillis();
+    }
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -2,10 +2,11 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.brute.sword;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import lombok.Data;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
+import me.mykindos.betterpvp.champions.champions.skills.data.ChargeData;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
 import me.mykindos.betterpvp.champions.champions.skills.types.ChannelSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.CooldownSkill;
@@ -16,29 +17,31 @@ import me.mykindos.betterpvp.core.combat.throwables.ThrowableItem;
 import me.mykindos.betterpvp.core.combat.throwables.events.ThrowableHitEntityEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.components.champions.events.PlayerCanUseSkillEvent;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilTime;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import org.bukkit.Bukkit;
+import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import me.mykindos.betterpvp.core.utilities.model.display.PermanentComponent;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.UUID;
+import java.util.Iterator;
 import java.util.WeakHashMap;
 
 @Singleton
@@ -46,19 +49,30 @@ import java.util.WeakHashMap;
 @Slf4j
 public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSkill {
 
-    private final List<ChargeData> charges = new ArrayList<>();
-    private final WeakHashMap<Player, Long> delay = new WeakHashMap<>();
-    private final WeakHashMap<Player, ChargeData> playerChargeMap = new WeakHashMap<>();
+    private final WeakHashMap<Player, ChargeData> charging = new WeakHashMap<>();
+    private final WeakHashMap<Player, Hook> hooks = new WeakHashMap<>();
 
-    public double damage;
-    public double damageIncreasePerLevel;
-    public double cooldownDecreasePerLevel;
+    private double damage;
+    private double damageIncreasePerLevel;
+    private double cooldownDecreasePerLevel;
+    private double velocitySrengthPerLevel;
+    private double baseVelocityStrength;
+
+    private final PermanentComponent actionBarComponent = new PermanentComponent(gamer -> {
+        final Player player = gamer.getPlayer();
+        if (player == null || !charging.containsKey(player) || !isHolding(player)) {
+            return null; // Skip if not online or not charging
+        }
+
+        final ChargeData charge = charging.get(player);
+        ProgressBar progressBar = ProgressBar.withProgress(charge.getCharge());
+        return progressBar.build();
+    });
 
     @Inject
     public FleshHook(Champions champions, ChampionsManager championsManager) {
         super(champions, championsManager);
     }
-
 
     @Override
     public String getName() {
@@ -67,20 +81,37 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
 
     @Override
     public String[] getDescription(int level) {
-
-        return new String[]{
+        return new String[] {
                 "Hold right click with a Sword to channel",
                 "",
-                "Charge a hook that latches onto enemies, pulling them towards you",
-                "and dealing <val>" + getFinalDamage(level) + "</val> damage",
-                "",
-                "Higher Charge time = faster hook",
+                "Charge a hook that latches onto enemies,",
+                "pulling them towards you with a strength",
+                "of <val>" + UtilFormat.formatNumber(getVelocityStrength(level)) + "</val> and dealing <val>"
+                        + UtilFormat.formatNumber(getDamage(level)) + "</val> damage.",
                 "",
                 "Cooldown: <val>" + getCooldown(level),
         };
     }
 
-    public double getFinalDamage(int level){
+    @Override
+    public void trackPlayer(Player player) {
+        // Action bar
+        Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
+        gamer.getActionBar().add(900, actionBarComponent);
+    }
+
+    @Override
+    public void invalidatePlayer(Player player) {
+        // Action bar
+        Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
+        gamer.getActionBar().remove(actionBarComponent);
+    }
+
+    private float getVelocityStrength(int level) {
+        return (float) (baseVelocityStrength + (velocitySrengthPerLevel * (level - 1)));
+    }
+
+    public double getDamage(int level){
         return (damage + (damageIncreasePerLevel * (level-1)));
     }
 
@@ -89,104 +120,14 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
         return Role.BRUTE;
     }
 
-    @UpdateEvent
-    public void updateFleshHook() {
-        ListIterator<ChargeData> iterator = charges.listIterator();
-        while (iterator.hasNext()) {
-            ChargeData data = iterator.next();
-            Player player = Bukkit.getPlayer(data.getUuid());
-            if (player != null) {
-                int level = getLevel(player);
-                if (level <= 0) {
-                    iterator.remove();
-                    continue;
-                }
-                if (delay.containsKey(player)) {
-                    if (!UtilTime.elapsed(delay.get(player), 250)) {
-                        continue;
-                    }
-                }
-
-                Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
-                if (gamer.isHoldingRightClick()) {
-
-                    if (!isHolding(player)) {
-                        iterator.remove();
-                    }
-
-                    if (UtilTime.elapsed(data.getLastCharge(), 400L)) {
-                        if (data.getCharge() < data.getMaxCharge()) {
-                            data.addCharge();
-                            playerChargeMap.put(player, data);
-                            UtilMessage.simpleMessage(player, getClassType().getName(), getName() + ": <alt2>+ " + data.getCharge() + "% Strength");
-                            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.4F, 1.0F + 0.05F * data.getCharge());
-                        }
-                    }
-                } else {
-                    if (isHolding(player)) {
-                        double base = 0.8D;
-                        Location loc = player.getLocation();
-
-                        Item item = player.getWorld().dropItem(player.getEyeLocation(), new ItemStack(Material.TRIPWIRE_HOOK));
-                        ThrowableItem throwable = new ThrowableItem(item, player, getName(), 10000L, true);
-                        throwable.setCollideGround(true);
-                        championsManager.getThrowables().addThrowable(throwable);
-
-                        Vector v = loc.getDirection();
-                        UtilVelocity.velocity(item, v, base + (data.getCharge() / 20f) * (0.25D * base), false, 0.0D, 0.2D, 20.0D, false);
-
-                        UtilMessage.simpleMessage(player, getClassType().getName(), "You used <alt>" + getName() + "</alt>.");
-                        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 2.0F, 0.8F);
-
-                        iterator.remove();
-
-                        championsManager.getCooldowns().removeCooldown(player, getName(), true);
-                        championsManager.getCooldowns().use(player, getName(), getCooldown(level), showCooldownFinished());
-                    }
-                }
-            }
-        }
-    }
-
-    @EventHandler
-    public void onCollide(ThrowableHitEntityEvent event) {
-        if (event.getThrowable().getName().equalsIgnoreCase(getName())) {
-            LivingEntity target = event.getCollision();
-
-            Player source = (Player) event.getThrowable().getThrower();
-            int level = getLevel(source);
-
-            ChargeData chargeData = playerChargeMap.get(source);
-            int chargePercent = (chargeData != null) ? chargeData.getCharge() : 0;
-            double scaledDamage = getFinalDamage(level) * (chargePercent / 100.0);
-
-            CustomDamageEvent ev = new CustomDamageEvent(target, source, null, DamageCause.CUSTOM, scaledDamage, false, getName());
-            UtilDamage.doCustomDamage(ev);
-
-            UtilVelocity.velocity(target, UtilVelocity.getTrajectory(target.getLocation(), event.getThrowable().getThrower().getLocation()), 2.0D, false, 0.0D, 0.8D, 1.0D, true);
-            event.getThrowable().getItem().remove();
-        }
-    }
-
     @Override
     public SkillType getType() {
-
         return SkillType.SWORD;
     }
 
     @Override
     public double getCooldown(int level) {
-
         return (cooldown - (cooldownDecreasePerLevel * (level - 1)));
-    }
-
-    @Override
-    public void activate(Player player, int level) {
-        ChargeData chargeData = new ChargeData(player.getUniqueId(), 25, 100);
-        charges.add(chargeData);
-        delay.put(player, System.currentTimeMillis());
-
-        playerChargeMap.put(player, chargeData);
     }
 
     @Override
@@ -194,37 +135,149 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
         return SkillActions.RIGHT_CLICK;
     }
 
+    @Override
+    public void activate(Player player, int level) {
+        charging.put(player, new ChargeData((float) (0.1 + (level - 1) * 0.05) * 5));
+    }
 
-    @Data
-    private static class ChargeData {
-
-
-        private final UUID uuid;
-        private int charge;
-        private long lastCharge;
-        private final int increment;
-        private final int maxCharge;
-
-        public ChargeData(UUID uuid, int increment, int maxCharge) {
-            this.uuid = uuid;
-            this.charge = 0;
-            this.lastCharge = System.currentTimeMillis();
-            this.increment = increment;
-            this.maxCharge = maxCharge;
-        }
-
-        public void addCharge() {
-            if (charge < maxCharge) {
-                charge += increment;
-                lastCharge = System.currentTimeMillis();
+    @UpdateEvent
+    public void updateFleshHook() {
+        final Iterator<Player> iterator = charging.keySet().iterator();
+        while (iterator.hasNext()) {
+            final Player player = iterator.next();
+            final ChargeData data = charging.get(player);
+            if (player == null) {
+                iterator.remove();
+                continue;
             }
+
+            // Remove if they no longer have the skill
+            final int level = getLevel(player);
+            if (level <= 0) {
+                iterator.remove();
+                continue;
+            }
+
+            // Check if they still are blocking and charge
+            Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
+            if (isHolding(player) && gamer.isHoldingRightClick()) {
+                championsManager.getCooldowns().removeCooldown(player, getName(), true);
+
+                data.tick();
+                data.tickSound(player);
+                continue;
+            }
+
+            shoot(player, data, level);
+            UtilMessage.simpleMessage(player, getClassType().getName(), "You used <alt>" + getName() + "</alt>.");
+            new SoundEffect(Sound.ENTITY_SPLASH_POTION_THROW, 2F, 0.8F).play(player.getLocation());
+            iterator.remove();
         }
+
+        // Hook particles
+        final Iterator<Player> hookIterator = hooks.keySet().iterator();
+        while (hookIterator.hasNext()) {
+            final Player player = hookIterator.next();
+            final Hook data = hooks.get(player);
+            if (player == null) {
+                hookIterator.remove();
+                continue;
+            }
+
+            final ThrowableItem hook = data.getThrowable();
+            final int level = getLevel(player);
+            if (hook == null || hook.getItem() == null || !hook.getItem().isValid() || level <= 0) {
+                hookIterator.remove();
+                continue;
+            }
+
+            final Location location = hook.getItem().getLocation();
+            Particle.CRIT.builder()
+                    .count(3)
+                    .extra(0)
+                    .offset(0.2, 0.2, 0.2)
+                    .location(location)
+                    .receivers(60)
+                    .spawn();
+
+            new SoundEffect(Sound.ITEM_FLINTANDSTEEL_USE, 1.4F, 0.8F).play(location);
+        }
+    }
+
+    private void shoot(Player player, ChargeData data, int level) {
+        final Item item = player.getWorld().dropItem(player.getEyeLocation(), new ItemStack(Material.TRIPWIRE_HOOK));
+        final ThrowableItem throwable = new ThrowableItem(item, player, getName(), 10_000L, true);
+        throwable.setCollideGround(true);
+        championsManager.getThrowables().addThrowable(throwable);
+        UtilVelocity.velocity(item,
+                player.getLocation().getDirection(),
+                1 + data.getCharge(),
+                false,
+                0,
+                0.2,
+                20,
+                false);
+
+        championsManager.getCooldowns().removeCooldown(player, getName(), true);
+        championsManager.getCooldowns().use(player, getName(), getCooldown(level), showCooldownFinished());
+        hooks.put(player, new Hook(throwable, data, level));
+    }
+
+    @EventHandler
+    public void onCollide(ThrowableHitEntityEvent event) {
+        if (!event.getThrowable().getName().equals(getName())) {
+            return; // Not our throwable
+        }
+
+        final LivingEntity target = event.getCollision();
+        final Player player = (Player) event.getThrowable().getThrower();
+        if (!hooks.containsKey(player)) {
+            return;
+        }
+
+        final Hook hookData = hooks.get(player);
+        final int level = hookData.getLevel();
+
+        final PlayerCanUseSkillEvent useEvent = new PlayerCanUseSkillEvent(player, this);
+        UtilServer.callEvent(useEvent);
+        if (useEvent.isCancelled()) {
+            return;
+        }
+
+        // Velocity
+        final Vector direction = player.getLocation().toVector().subtract(target.getLocation().toVector()).normalize();
+        final double strength = hookData.getThrowable().getItem().getVelocity().length();
+        UtilVelocity.velocity(target, direction, strength, false, 0, 0.7, 1.2, true);
+        target.setFallDistance(0); // Reset their fall distance
+
+        // Damage
+        final double damage = getDamage(level);
+        CustomDamageEvent ev = new CustomDamageEvent(target, player, null, EntityDamageEvent.DamageCause.CUSTOM, damage, false, getName());
+        UtilDamage.doCustomDamage(ev);
+
+        // Cues
+        UtilMessage.message(target, getClassType().getName(), "<alt2>" + player.getName() + "</alt2> pulled you with <alt>" + getName() + "</alt>.");
+        UtilMessage.message(player, getClassType().getName(), "You hit <alt2>" + target.getName() + "</alt2> with <alt>" + getName() + "</alt>.");
+        new SoundEffect(Sound.BLOCK_NOTE_BLOCK_PLING, 2f, 1f).play(player);
+
+        event.getThrowable().getItem().remove();
+        charging.remove(player);
+        hooks.remove(player);
     }
 
     @Override
     public void loadSkillConfig() {
-        damage = getConfig("damage", 7.0, Double.class);
-        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 2.0, Double.class);
+        damage = getConfig("damage", 5.0, Double.class);
+        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
         cooldownDecreasePerLevel = getConfig("cooldownDecreasePerLevel", 2.0, Double.class);
+        baseVelocityStrength = getConfig("baseVelocityStrength", 1.2, Double.class);
+        velocitySrengthPerLevel = getConfig("velocityStrengthPerLevel", 0.3, Double.class);
+    }
+
+    @Value
+    private class Hook {
+        ThrowableItem throwable;
+        ChargeData data;
+        int level;
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -258,7 +258,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
         // Cues
         UtilMessage.message(target, getClassType().getName(), "<alt2>" + player.getName() + "</alt2> pulled you with <alt>" + getName() + "</alt>.");
         UtilMessage.message(player, getClassType().getName(), "You hit <alt2>" + target.getName() + "</alt2> with <alt>" + getName() + "</alt>.");
-        new SoundEffect(Sound.BLOCK_NOTE_BLOCK_PLING, 2f, 1f).play(player);
+        new SoundEffect(Sound.ENTITY_ARROW_HIT_PLAYER, 2f, 2f).play(player);
 
         event.getThrowable().getItem().remove();
         charging.remove(player);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillActions;
-import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
 import me.mykindos.betterpvp.champions.champions.skills.types.ChannelSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.CooldownSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
@@ -23,8 +22,6 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
-import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
-import me.mykindos.betterpvp.core.utilities.model.display.PermanentComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -33,7 +30,6 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.ItemStack;
@@ -49,10 +45,10 @@ import java.util.WeakHashMap;
 @BPvPListener
 @Slf4j
 public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSkill {
+
     private final List<ChargeData> charges = new ArrayList<>();
     private final WeakHashMap<Player, Long> delay = new WeakHashMap<>();
     private final WeakHashMap<Player, ChargeData> playerChargeMap = new WeakHashMap<>();
-
 
     public double damage;
     public double damageIncreasePerLevel;
@@ -132,7 +128,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
                         Location loc = player.getLocation();
 
                         Item item = player.getWorld().dropItem(player.getEyeLocation(), new ItemStack(Material.TRIPWIRE_HOOK));
-                        ThrowableItem throwable = new ThrowableItem(item, player, getName(), 10000L, true, true);
+                        ThrowableItem throwable = new ThrowableItem(item, player, getName(), 10000L, true);
                         throwable.setCollideGround(true);
                         championsManager.getThrowables().addThrowable(throwable);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
@@ -20,7 +20,6 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -144,7 +143,7 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
         orb.setVelocity(player.getLocation().getDirection());
         orb.setCanPlayerPickup(false);
         orb.setCanMobPickup(false);
-        ThrowableItem throwableItem = new ThrowableItem(orb, player, "Lightning Orb", 10000, true, true);
+        ThrowableItem throwableItem = new ThrowableItem(orb, player, "Lightning Orb", 10000, true);
         championsManager.getThrowables().addThrowable(throwableItem);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/GlacialPrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/GlacialPrison.java
@@ -109,7 +109,7 @@ public class GlacialPrison extends Skill implements InteractSkill, CooldownSkill
     public void activate(Player player, int level) {
         Item item = player.getWorld().dropItem(player.getEyeLocation(), new ItemStack(Material.ICE));
         item.setVelocity(player.getLocation().getDirection().multiply(speed));
-        ThrowableItem throwableItem = new ThrowableItem(item, player, getName(), 10000, true, true);
+        ThrowableItem throwableItem = new ThrowableItem(item, player, getName(), 10000, true);
         throwableItem.setCollideGround(true);
         championsManager.getThrowables().addThrowable(throwableItem);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/ThrowingWeb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/ThrowingWeb.java
@@ -74,7 +74,7 @@ public class ThrowingWeb extends Weapon implements Listener, InteractWeapon, Coo
         item.getItemStack().getItemMeta().getPersistentDataContainer().set(CoreNamespaceKeys.UUID_KEY, PersistentDataType.STRING, UUID.randomUUID().toString());
         item.setVelocity(player.getLocation().getDirection().multiply(1.8));
 
-        ThrowableItem throwableItem = new ThrowableItem(item, player, "Throwing Web", (long) (throwableExpiry * 1000L), true, true);
+        ThrowableItem throwableItem = new ThrowableItem(item, player, "Throwing Web", (long) (throwableExpiry * 1000L), true);
         throwableItem.setCollideGround(true);
         throwableItem.getImmunes().add(player);
         championsManager.getThrowables().addThrowable(throwableItem);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/legendaries/KnightsGreatlance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/weapons/legendaries/KnightsGreatlance.java
@@ -1,7 +1,6 @@
 package me.mykindos.betterpvp.champions.weapons.weapons.legendaries;
 
 import com.destroystokyo.paper.ParticleBuilder;
-import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.AllArgsConstructor;
@@ -25,6 +24,7 @@ import me.mykindos.betterpvp.core.items.BPVPItem;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
@@ -207,7 +207,18 @@ public class KnightsGreatlance extends ChannelWeapon implements InteractWeapon, 
 
             // Get all enemies that collide with the player from the last location to the new location
             final Location newLocation = getMidpoint(player);
-            final Optional<LivingEntity> hit = trace(player, data.getLastLocation(), newLocation);
+            final Optional<LivingEntity> hit = UtilEntity.interpolateCollision(data.getLastLocation(), newLocation, 0.6f, entity -> {
+                if (!(entity instanceof LivingEntity) || entity.equals(player)) {
+                    return false;
+                }
+
+                if (!(entity instanceof Player other)) {
+                    return true;
+                }
+
+                return UtilPlayer.getRelation(player, other) != EntityProperty.FRIENDLY;
+            }).map(RayTraceResult::getHitEntity).map(LivingEntity.class::cast);
+
             final int charge = data.getTicksCharged();
             final double percentage = (float) charge / maxChargeTicks;
             if (hit.isPresent()) {
@@ -263,32 +274,6 @@ public class KnightsGreatlance extends ChannelWeapon implements InteractWeapon, 
                     .receivers(60)
                     .spawn();
         }
-    }
-
-    private Optional<LivingEntity> trace(@NotNull Player player, @NotNull Location lastLocation, @NotNull Location location) {
-        Preconditions.checkNotNull(player, "Player cannot be null");
-        Preconditions.checkNotNull(lastLocation, "Last location cannot be null");
-        Preconditions.checkNotNull(location, "Location cannot be null");
-        Preconditions.checkArgument(location.getWorld() == lastLocation.getWorld(), "Locations must be in the same world");
-
-        final Vector direction = location.getDirection();
-        final RayTraceResult result = lastLocation.getWorld().rayTraceEntities(lastLocation, direction, direction.length(), 0.6, entity -> {
-            if (!(entity instanceof LivingEntity) || entity.equals(player)) {
-                return false;
-            }
-
-            if (!(entity instanceof Player other)) {
-                return true;
-            }
-
-            return UtilPlayer.getRelation(player, other) != EntityProperty.FRIENDLY;
-        });
-
-        if (result == null) {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable((LivingEntity) result.getHitEntity());
     }
 
     @EventHandler

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Getter
 @Singleton
 public class ThrowableHandler {
 
-    @Getter
     private final List<ThrowableItem> throwables = new ArrayList<>();
 
     public void addThrowable(Item item, LivingEntity entity, String name, long expire){
@@ -24,17 +24,15 @@ public class ThrowableHandler {
     }
 
     public void addThrowable(Item item, LivingEntity entity, String name, long expire, boolean checkHead, boolean removeOnCollision){
-        addThrowable(new ThrowableItem(item, entity, name, expire, checkHead, removeOnCollision));
+        addThrowable(new ThrowableItem(item, entity, name, expire, removeOnCollision));
     }
 
     public void addThrowable(ThrowableItem throwableItem){
         throwables.add(throwableItem);
     }
 
-
     public Optional<ThrowableItem> getThrowable(Item item) {
         return throwables.stream().filter(throwable -> throwable.getItem().equals(item)).findFirst();
-
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableItem.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Data
 public class ThrowableItem {
 
-    private final List<LivingEntity> immune = new ArrayList<>();
+    private final List<LivingEntity> immunes = new ArrayList<>();
     private final Item item;
     private final LivingEntity thrower;
     private final String name;

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableItem.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.combat.throwables;
 
 import lombok.Data;
+import org.bukkit.Location;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 
@@ -10,47 +11,33 @@ import java.util.List;
 @Data
 public class ThrowableItem {
 
+    private final List<LivingEntity> immune = new ArrayList<>();
     private final Item item;
     private final LivingEntity thrower;
     private final String name;
     private final long expireTime;
-    private final List<LivingEntity> immune;
-    private final boolean checkHead;
-
-    private int chargePercent;
 
     private boolean collideGround;
     private boolean removeOnCollision;
     private boolean singleCollision;
-    private double collisionRadius = 1.5;
+    private double collisionRadius = 0.4;
+
+    private Location lastLocation;
 
     public ThrowableItem(Item item, LivingEntity thrower, String name, long expireTime) {
-        this(item, thrower, name, expireTime, false, false);
+        this(item, thrower, name, expireTime, false);
     }
 
-    public ThrowableItem(Item item, LivingEntity thrower, String name, long expireTime, boolean checkHead){
-        this(item, thrower, name, expireTime, checkHead, false);
-    }
-
-    public ThrowableItem(Item item, LivingEntity thrower, String name, long expireTime, boolean checkHead, boolean removeOnCollision){
+    public ThrowableItem(Item item, LivingEntity thrower, String name, long expireTime, boolean removeOnCollision) {
         this.item = item;
         this.thrower = thrower;
         this.name = name;
         this.expireTime = System.currentTimeMillis() + expireTime;
-        this.checkHead = checkHead;
         this.removeOnCollision = removeOnCollision;
         this.singleCollision = true;
         this.collideGround = false;
+        this.lastLocation = item.getLocation();
         item.setPickupDelay(Integer.MAX_VALUE);
-        immune = new ArrayList<>();
-    }
-
-    public boolean isCheckingHead() {
-        return checkHead;
-    }
-
-    public List<LivingEntity> getImmunes() {
-        return immune;
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/listeners/ThrowableListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/listeners/ThrowableListener.java
@@ -94,7 +94,7 @@ public class ThrowableListener implements Listener {
         // Attempt collision by nearby entities
         final List<LivingEntity> targets = UtilEntity.getNearbyEnemies(throwable.getThrower(), location, size);
         for (LivingEntity entity : targets) {
-            if (throwable.getImmune().contains(entity)) continue;
+            if (throwable.getImmunes().contains(entity)) continue;
             UtilServer.callEvent(new ThrowableHitEntityEvent(throwable, entity));
             if (throwable.isSingleCollision()) {
                 break;
@@ -111,7 +111,7 @@ public class ThrowableListener implements Listener {
                 return false;
             }
 
-            return !throwable.getImmune().contains(living);
+            return !throwable.getImmunes().contains(living);
         }).map(RayTraceResult::getHitEntity).map(LivingEntity.class::cast).ifPresent(entity -> {
             UtilServer.callEvent(new ThrowableHitEntityEvent(throwable, entity));
         });

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.utilities;
 
+import com.google.common.base.Preconditions;
 import me.mykindos.betterpvp.core.framework.customtypes.CustomArmourStand;
 import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
@@ -9,13 +10,34 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 public class UtilEntity {
+
+    public static Optional<RayTraceResult> interpolateCollision(@NotNull Location lastLocation, @NotNull Location destination, float raySize, @Nullable Predicate<Entity> entityFilter) {
+        Preconditions.checkNotNull(lastLocation, "Last location cannot be null");
+        Preconditions.checkNotNull(destination, "Destination cannot be null");
+        Preconditions.checkArgument(destination.getWorld() == lastLocation.getWorld(), "Locations must be in the same world");
+
+        final Vector directionRaw = destination.toVector().subtract(lastLocation.toVector());
+        final double distance = directionRaw.length();
+        final Vector direction = distance < 1e-6 ? lastLocation.getDirection() : directionRaw.normalize();
+        return Optional.ofNullable(lastLocation.getWorld().rayTraceEntities(lastLocation,
+                direction,
+                distance,
+                raySize,
+                entityFilter));
+    }
 
     public static List<KeyValue<LivingEntity, EntityProperty>> getNearbyEntities(LivingEntity source, double radius) {
         return getNearbyEntities(source, source.getLocation(), radius, EntityProperty.ALL);


### PR DESCRIPTION
Changes:
- Improve throwable item detection using interpolation if nearby checks fail.
- Fix issue were Flesh Hook would have a 250 millisecond delay before firing.
- [Make Flesh Hook work like in Mineplex](https://youtu.be/tqHpIMMT5F0)

Fixes #292 
Fixes #231 
Changes were tested