### PR TITLE
Update Agility and Wolfs Fury

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
@@ -110,8 +110,6 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
     @EventHandler
     public void onDamage(CustomDamageEvent event) {
         if (!(event.getDamagee() instanceof Player damagee)) return;
-        if (event.getDamager() == null) return;
-
         if (active.contains(damagee.getUniqueId())) {
             int level = getLevel(damagee);
             event.setDamage(event.getDamage() * (1 - getDamageReduction(level)));

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
@@ -23,7 +23,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -100,9 +99,6 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
 
     @EventHandler
     public void endOnInteract(PlayerInteractEvent event) {
-        if (event.getHand() != EquipmentSlot.HAND) return;
-        if (!event.getAction().isRightClick()) return;
-
         Player player = event.getPlayer();
         if (active.contains(player.getUniqueId())) {
             active.remove(player.getUniqueId());
@@ -114,16 +110,19 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
     @EventHandler
     public void onDamage(CustomDamageEvent event) {
         if (!(event.getDamagee() instanceof Player damagee)) return;
-        if (!(event.getDamager() instanceof Player damager)) return;
+        if (event.getDamager() == null) return;
 
         if (active.contains(damagee.getUniqueId())) {
             int level = getLevel(damagee);
             event.setDamage(event.getDamage() * (1 - getDamageReduction(level)));
             event.setKnockback(false);
-            UtilMessage.message(damager, getClassType().getName(), damagee.getName() + " is using " + getName());
+            if (event.getDamager() instanceof Player damager) {
+                UtilMessage.message(damager, getClassType().getName(), damagee.getName() + " is using " + getName());
+            }
+
             damagee.getWorld().playSound(damagee.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 0.5F, 2.0F);
         }
-
+        if (!(event.getDamager() instanceof Player damager)) return;
         if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_ATTACK) {
             active.remove(damager.getUniqueId());
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
@@ -26,16 +26,13 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.UUID;
-import java.util.WeakHashMap;
+import java.util.*;
 
 @Singleton
 @BPvPListener
 public class Agility extends Skill implements InteractSkill, CooldownSkill, Listener {
 
-    private final WeakHashMap<UUID, Long> active = new WeakHashMap<>();
+    private final HashMap<UUID, Long> active = new HashMap<>();
 
     private double baseDuration;
 
@@ -137,8 +134,8 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
               continue;
            } else {
                if (entry.getValue() - System.currentTimeMillis() <= 0) {
-                   iterator.remove();
                    deactivate(player);
+                   iterator.remove();
                }
            }
        }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolvesFury.java
@@ -103,8 +103,8 @@ public class WolvesFury extends Skill implements InteractSkill, CooldownSkill, L
     @Override
     public void activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_WOLF_HOWL, 1.0f, 1.0f);
-        active.put(player, (long) (System.currentTimeMillis() + ((baseDuration + level) * 1000L)));
-        championsManager.getEffects().addEffect(player, EffectType.STRENGTH, 1, (long) ((baseDuration + level) * 1000L));
+        active.put(player, (long) (System.currentTimeMillis() + (getDuration(level) * 1000L)));
+        championsManager.getEffects().addEffect(player, EffectType.STRENGTH, 1, (long) (getDuration(level) * 1000L));
     }
 
     @Override


### PR DESCRIPTION
Fixes #334
Fixes #335
Fixes #336

Changes wolf fury to use getDuration for duration.

Actually implements agility, which now reduces all damage, but is cancelled on any interaction by user. Agility now correctly ends after its duration.