### PR TITLE
Fix force-shutdown cannon unload bug

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/utilities/ClansNamespacedKeys.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/utilities/ClansNamespacedKeys.java
@@ -7,6 +7,7 @@ public class ClansNamespacedKeys {
     public static final NamespacedKey FIELDS_GOLD_CHUNK = new NamespacedKey("clans", "fields-gold-chunk");
     public static final NamespacedKey CANNON_LOADED = new NamespacedKey("clans", "cannon_loaded");
     public static final NamespacedKey CANNON_CLAN = new NamespacedKey("clans", "cannon_clan");
-    public static final NamespacedKey CANNON_NAMETAG = new NamespacedKey("clans", "cannon_nametag");
+    public static final NamespacedKey CANNON_HEALTHBAR = new NamespacedKey("clans", "cannon_healthbar");
+    public static final NamespacedKey CANNON_LEGEND = new NamespacedKey("clans", "cannon_legend");
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/Cannon.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/Cannon.java
@@ -134,8 +134,7 @@ public final class Cannon implements SoundProvider {
 
     public @Nullable TextDisplay getHealthBar() {
         if ((this.healthBar == null || this.healthBar.isDead() || !this.healthBar.isValid())) {
-            final Location location = this.activeModel.getBone("text_healthbar").orElseThrow().getLocation();
-            this.healthBar = getOrCreateDisplay(this, location, 40, ClansNamespacedKeys.CANNON_HEALTHBAR);
+            this.healthBar = getOrCreateDisplay(this, backingEntity.getLocation(), 40, ClansNamespacedKeys.CANNON_HEALTHBAR);
             this.healthBar.setTextOpacity((byte) 160);
         }
         return this.healthBar;
@@ -143,8 +142,7 @@ public final class Cannon implements SoundProvider {
 
     public @Nullable TextDisplay getInstructions() {
         if ((this.instructions == null || this.instructions.isDead() || !this.instructions.isValid())) {
-            final Location location = this.activeModel.getBone("text_legend").orElseThrow().getLocation();
-            this.instructions = getOrCreateDisplay(this, location, 5, ClansNamespacedKeys.CANNON_LEGEND);
+            this.instructions = getOrCreateDisplay(this, backingEntity.getLocation(), 5, ClansNamespacedKeys.CANNON_LEGEND);
         }
         return this.instructions;
     }
@@ -154,8 +152,12 @@ public final class Cannon implements SoundProvider {
             return;
         }
 
-        Objects.requireNonNull(getHealthBar()).text(healthBar());
-        Objects.requireNonNull(getInstructions()).text(instructions());
+        final TextDisplay health = Objects.requireNonNull(getHealthBar());
+        health.teleport(this.activeModel.getBone("text_healthbar").orElseThrow().getLocation());
+        health.text(healthBar());
+        final TextDisplay instructions = Objects.requireNonNull(getInstructions());
+        instructions.teleport(this.activeModel.getBone("text_legend").orElseThrow().getLocation());
+        instructions.text(instructions());
     }
 
     private TextComponent healthBar() {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/Cannon.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/Cannon.java
@@ -7,20 +7,28 @@ import lombok.Setter;
 import me.mykindos.betterpvp.clans.utilities.ClansNamespacedKeys;
 import me.mykindos.betterpvp.core.combat.data.SoundProvider;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
 import me.mykindos.betterpvp.core.utilities.model.ProgressColor;
+import me.mykindos.betterpvp.core.utilities.model.data.CustomDataType;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.entity.TextDisplay;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -32,8 +40,32 @@ import java.util.UUID;
 @Getter
 public final class Cannon implements SoundProvider {
 
-    public static final long COOLDOWN_LERP_OUT = 5_000L;
+    private static TextDisplay getOrCreateDisplay(final Cannon cannon, @NotNull final Location location, float viewBlocks, final NamespacedKey key) {
+        final Entity backingEntity = cannon.getBackingEntity();
+        final PersistentDataContainer pdc = backingEntity.getPersistentDataContainer();
+        // If the entity already has a display, return it
+        if (pdc.has(key)) {
+            final UUID entId = pdc.get(key, CustomDataType.UUID);
+            final Entity found = Bukkit.getEntity(Objects.requireNonNull(entId));
+            if (found instanceof TextDisplay display && display.isValid()) {
+                return (TextDisplay) found;
+            }
+        }
 
+        // Otherwise, create a new display
+        final TextDisplay display = location.getWorld().spawn(location, TextDisplay.class, ent -> {
+            ent.setBackgroundColor(Color.fromARGB(0, 1, 1, 1));
+            ent.setBrightness(new Display.Brightness(15, 15));
+            ent.setAlignment(TextDisplay.TextAlignment.CENTER);
+            ent.setBillboard(Display.Billboard.CENTER);
+            ent.setPersistent(true);
+        });
+        UtilEntity.setViewRangeBlocks(display, viewBlocks);
+        pdc.set(key, CustomDataType.UUID, display.getUniqueId());
+        return display;
+    }
+
+    public static final long COOLDOWN_LERP_OUT = 5_000L;
     @Setter private long lastFuseTime = 0L;
     @Setter private long lastShotTime = 0L;
     private final @NotNull CannonManager cannonManager;
@@ -42,7 +74,9 @@ public final class Cannon implements SoundProvider {
     private final @NotNull IronGolem backingEntity;
     private final @NotNull ModeledEntity modeledEntity;
     private final @NotNull ActiveModel activeModel;
-    private final @NotNull TextDisplay healthBar;
+    private TextDisplay healthBar;
+    private TextDisplay instructions;
+
     private boolean loaded;
 
     public Cannon(@NotNull CannonManager cannonManager,
@@ -51,7 +85,6 @@ public final class Cannon implements SoundProvider {
                   @NotNull IronGolem backingEntity,
                   @NotNull ModeledEntity modeledEntity,
                   @NotNull ActiveModel activeModel,
-                  @NotNull TextDisplay healthBar,
                   boolean loaded) {
         this.cannonManager = cannonManager;
         this.placedBy = placedBy;
@@ -59,9 +92,7 @@ public final class Cannon implements SoundProvider {
         this.backingEntity = backingEntity;
         this.modeledEntity = modeledEntity;
         this.activeModel = activeModel;
-        this.healthBar = healthBar;
         this.loaded = loaded;
-        updateHealthBar();
     }
 
     @Override
@@ -101,20 +132,41 @@ public final class Cannon implements SoundProvider {
         return this.backingEntity.getPersistentDataContainer().getOrDefault(ClansNamespacedKeys.CANNON_LOADED, PersistentDataType.BOOLEAN, false);
     }
 
-    public void updateHealthBar() {
+    public @Nullable TextDisplay getHealthBar() {
+        if ((this.healthBar == null || this.healthBar.isDead() || !this.healthBar.isValid())) {
+            final Location location = this.activeModel.getBone("text_healthbar").orElseThrow().getLocation();
+            this.healthBar = getOrCreateDisplay(this, location, 40, ClansNamespacedKeys.CANNON_HEALTHBAR);
+            this.healthBar.setTextOpacity((byte) 160);
+        }
+        return this.healthBar;
+    }
+
+    public @Nullable TextDisplay getInstructions() {
+        if ((this.instructions == null || this.instructions.isDead() || !this.instructions.isValid())) {
+            final Location location = this.activeModel.getBone("text_legend").orElseThrow().getLocation();
+            this.instructions = getOrCreateDisplay(this, location, 5, ClansNamespacedKeys.CANNON_LEGEND);
+        }
+        return this.instructions;
+    }
+
+    public void updateTag() {
         if (this.backingEntity.isDead() || !this.backingEntity.isValid()) {
             return;
         }
 
-        this.healthBar.teleport(this.backingEntity.getLocation());
+        Objects.requireNonNull(getHealthBar()).text(healthBar());
+        Objects.requireNonNull(getInstructions()).text(instructions());
+    }
 
-        // Update text
+    private TextComponent healthBar() {
         final double health = getHealth();
         final double maxHealth = Objects.requireNonNull(backingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH)).getValue();
         final ProgressBar progressBar = new ProgressBar((float) (health / maxHealth), 15);
+        return progressBar.build();
+    }
+
+    public TextComponent instructions() {
         final TextComponent.Builder component = Component.text()
-                .append(progressBar.build())
-                .appendNewline()
                 .append(Component.text("Hold ", NamedTextColor.AQUA)
                         .append(Component.text("Right Click", NamedTextColor.WHITE, TextDecoration.BOLD))
                         .append(Component.text(" to ", NamedTextColor.AQUA))
@@ -147,6 +199,6 @@ public final class Cannon implements SoundProvider {
             component.append(Component.text("READY", NamedTextColor.GREEN, TextDecoration.BOLD));
         }
 
-        this.healthBar.text(component.build());
+        return component.build();
     }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/CannonManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/model/CannonManager.java
@@ -3,8 +3,6 @@ package me.mykindos.betterpvp.clans.weapons.impl.cannon.model;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.ticxo.modelengine.api.ModelEngineAPI;
-import com.ticxo.modelengine.api.animation.ModelState;
-import com.ticxo.modelengine.api.animation.handler.IPriorityHandler;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
 import lombok.Getter;
@@ -16,20 +14,15 @@ import me.mykindos.betterpvp.core.framework.manager.Manager;
 import me.mykindos.betterpvp.core.utilities.model.data.CustomDataType;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.NotNull;
-import org.joml.AxisAngle4f;
-import org.joml.Vector3f;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -37,7 +30,7 @@ import java.util.UUID;
 
 @Getter
 @Singleton
-@PluginAdapter("ModelEngine")
+@PluginAdapter(value = "ModelEngine", loadMethodName = "ignored")
 public class CannonManager extends Manager<Cannon> {
 
     @Inject
@@ -56,14 +49,73 @@ public class CannonManager extends Manager<Cannon> {
     @Config(path = "cannon.health", defaultValue = "200.0", configName = "weapons/cannon")
     private double cannonHealth;
 
-    public void remove(@NotNull Cannon cannon) {
-        if (cannon.getHealthBar().isValid() && !cannon.getHealthBar().isDead()) {
-            cannon.getHealthBar().remove();
+    @Inject
+    @Config(path = "cannon.size", defaultValue = "1.0", configName = "weapons/cannon")
+    private double cannonScale;
+
+    public boolean isCannonPart(@NotNull Entity entity) {
+        final String type = entity.getPersistentDataContainer().getOrDefault(CoreNamespaceKeys.ENTITY_TYPE, PersistentDataType.STRING, "|");
+        return type.equals("cannon") || type.equals("cannon_health_bar");
+    }
+
+    public void load() {
+        for (World world : Bukkit.getServer().getWorlds()) {
+            for (IronGolem golem : world.getEntitiesByClass(IronGolem.class)) {
+                if (isCannonPart(golem)) {
+                    setupEntity(golem);
+                    ModelEngineAPI.getOrCreateModeledEntity(golem, this::setupModel);
+                }
+            }
         }
+    }
+
+    public void remove(@NotNull Cannon cannon) {
+        removeObject(cannon.getUuid().toString());
+        final TextDisplay healthBar = cannon.getHealthBar();
+        if (healthBar != null && healthBar.isValid()) {
+            healthBar.remove();
+        }
+
+        final TextDisplay info = cannon.getInstructions();
+        if (info != null && info.isValid()) {
+            info.remove();
+        }
+
         if (!cannon.getModeledEntity().isDestroyed()) {
             cannon.getModeledEntity().destroy();
         }
-        removeObject(cannon.getUuid().toString());
+
+        final IronGolem backingEntity = cannon.getBackingEntity();
+        if (backingEntity.isValid()) {
+            backingEntity.remove();
+        }
+    }
+
+    private ActiveModel setupModel(@NotNull final ModeledEntity modeledEntity) {
+        // Setup model
+        final ActiveModel activeModel = ModelEngineAPI.createActiveModel("cannon");
+        activeModel.setScale(cannonScale);
+        activeModel.setHitboxScale(cannonScale + 0.4);
+        activeModel.setShadowVisible(true);
+        // Attach model and setup entity
+        modeledEntity.addModel(activeModel, true);
+        modeledEntity.setBaseEntityVisible(false);
+        modeledEntity.setModelRotationLocked(false);
+        modeledEntity.setSaved(true);
+        return activeModel;
+    }
+
+    private void setupEntity(@NotNull IronGolem golem) {
+        golem.setAggressive(false);
+        golem.setPersistent(true);
+        golem.setGravity(true);
+        golem.customName(Component.text("Cannon"));
+        golem.setCustomNameVisible(false);
+        golem.setAware(false);
+        golem.setVisualFire(false);
+        golem.setCollidable(false);
+        Objects.requireNonNull(golem.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).setBaseValue(0D);
+        Objects.requireNonNull(golem.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(cannonHealth);
     }
 
     public Optional<Cannon> of(@NotNull Entity entity) {
@@ -81,119 +133,46 @@ public class CannonManager extends Manager<Cannon> {
                 throw new IllegalStateException("Cannon entity does not have an original owner key!");
             }
 
-            if (!pdc.has(ClansNamespacedKeys.CANNON_NAMETAG, CustomDataType.UUID)) {
-                throw new IllegalStateException("Cannon entity does not have a nametag key!");
-            }
-
+            setupEntity(golem);
             final UUID placedBy = Objects.requireNonNull(pdc.get(CoreNamespaceKeys.ORIGINAL_OWNER, CustomDataType.UUID));
-            final ModeledEntity modeledEntity = ModelEngineAPI.getModeledEntity(golem);
-            if (modeledEntity == null || modeledEntity.isDestroyed()) {
+            ModeledEntity modeledEntity = ModelEngineAPI.getModeledEntity(golem);
+            final ActiveModel activeModel;
+            if (modeledEntity != null && modeledEntity.isDestroyed()) {
                 return Optional.empty();
+            } else if (modeledEntity == null) {
+                modeledEntity = ModelEngineAPI.createModeledEntity(golem);
+                activeModel = setupModel(modeledEntity);
+            } else {
+                activeModel = modeledEntity.getModel("cannon").orElseThrow();
             }
 
             final boolean loaded = pdc.getOrDefault(ClansNamespacedKeys.CANNON_LOADED, PersistentDataType.BOOLEAN, false);
-            final ActiveModel activeModel = modeledEntity.getModel("cannon").orElseThrow(() -> new IllegalStateException("Cannon entity does not have a cannon model!"));
-            final UUID nametagId = Objects.requireNonNull(pdc.get(ClansNamespacedKeys.CANNON_NAMETAG, CustomDataType.UUID));
-            final Optional<TextDisplay> healthBarOpt = Optional.ofNullable(entity.getWorld().getEntity(nametagId)).map(TextDisplay.class::cast);
-            if (healthBarOpt.isEmpty()) {
-                throw new IllegalStateException("Cannon nametag was despawned!");
-            }
-
-            final Optional<Cannon> created = Optional.of(new Cannon(
-                    this,
-                    entity.getUniqueId(),
-                    placedBy,
-                    golem,
-                    modeledEntity,
-                    activeModel,
-                    healthBarOpt.get(),
-                    loaded
-            ));
-            addObject(entity.getUniqueId().toString(), created.get());
-            setupEntity(golem);
-            return created;
+            final Cannon created = new Cannon(this, entity.getUniqueId(), placedBy, golem, modeledEntity, activeModel, loaded);
+            addObject(entity.getUniqueId().toString(), created);
+            return Optional.of(created);
         });
-    }
-
-    private void setupEntity(@NotNull IronGolem golem) {
-        golem.setAggressive(false);
-        golem.setPersistent(true);
-        golem.setGravity(true);
-        golem.customName(Component.text("Cannon"));
-        golem.setCustomNameVisible(false);
-        golem.setAware(false);
-        golem.setVisualFire(false);
-        golem.setCollidable(false);
-    }
-
-    public boolean isCannonPart(@NotNull Entity entity) {
-        final String type = entity.getPersistentDataContainer().getOrDefault(CoreNamespaceKeys.ENTITY_TYPE, PersistentDataType.STRING, "|");
-        return type.equals("cannon") || type.equals("cannon_health_bar");
     }
 
     public Cannon spawn(@NotNull UUID placedBy, @NotNull Location location) {
-        // name tags
-        final TextDisplay healthBar = location.getWorld().spawn(location, TextDisplay.class, ent -> {
-            ent.getPersistentDataContainer().set(CoreNamespaceKeys.ENTITY_TYPE, PersistentDataType.STRING, "cannon_health_bar");
-            ent.setAlignment(TextDisplay.TextAlignment.CENTER);
-            ent.setViewRange(1);
-            ent.setBackgroundColor(Color.fromARGB(0, 255, 255, 255));
-            ent.customName(Component.text("Cannon"));
-            ent.setBillboard(Display.Billboard.CENTER);
-            ent.setBrightness(new Display.Brightness(15, 15));
-            ent.setShadowRadius(1.2f);
-            ent.setShadowStrength(0.4f);
-            ent.setPersistent(true);
-            ent.setTransformation(new Transformation(
-                    new Vector3f(0, 3f, 0),
-                    new AxisAngle4f(),
-                    new Vector3f(1, 1, 1),
-                    new AxisAngle4f()
-            ));
-        });
-
         // entity
         final IronGolem entity = location.getWorld().spawn(location, IronGolem.class, ent -> {
-            Objects.requireNonNull(ent.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).setBaseValue(0D);
-            Objects.requireNonNull(ent.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(cannonHealth);
-            ent.setHealth(cannonHealth);
-            ent.setRotation(location.getYaw(), location.getPitch());
             ent.getPersistentDataContainer().set(CoreNamespaceKeys.ENTITY_TYPE, PersistentDataType.STRING, "cannon");
             ent.getPersistentDataContainer().set(CoreNamespaceKeys.ORIGINAL_OWNER, CustomDataType.UUID, placedBy);
-            ent.getPersistentDataContainer().set(ClansNamespacedKeys.CANNON_NAMETAG, CustomDataType.UUID, healthBar.getUniqueId());
             setupEntity(ent);
+            ent.setRotation(location.getYaw(), location.getPitch());
+            ent.setHealth(cannonHealth);
         });
 
-        // model engine
-        final ActiveModel activeModel = ModelEngineAPI.createActiveModel("cannon");
-        activeModel.setHitboxScale(1.3D);
-        activeModel.setShadowVisible(true);
-        final IPriorityHandler animationHandler = (IPriorityHandler) activeModel.getAnimationHandler();
-        animationHandler.playState(ModelState.IDLE);
-        final ModeledEntity modeledEntity = ModelEngineAPI.createModeledEntity(entity, ent -> {
-            ent.addModel(activeModel, true);
-            ent.setBaseEntityVisible(false);
-            ent.setModelRotationLocked(false);
-            ent.setSaved(true);
-        });
-
-        return new Cannon(this,
+        final ModeledEntity modeledEntity = ModelEngineAPI.createModeledEntity(entity);
+        final ActiveModel activeModel = setupModel(modeledEntity);
+        final Cannon cannon = new Cannon(this,
                 entity.getUniqueId(),
                 placedBy,
                 entity,
                 modeledEntity,
                 activeModel,
-                healthBar,
                 false);
-    }
-
-    public void load() {
-        for (World world : Bukkit.getServer().getWorlds()) {
-            for (IronGolem golem : world.getEntitiesByClass(IronGolem.class)) {
-                if (isCannonPart(golem)) {
-                    setupEntity(golem);
-                }
-            }
-        }
+        addObject(entity.getUniqueId().toString(), cannon);
+        return cannon;
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -10,6 +10,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -99,5 +100,21 @@ public class UtilEntity {
         armorStand.setPersistent(false); // We don't want them to be saved in the world
         armorStand.setCollidable(false); // We don't want them to collide with anything
         return armorStand;
+    }
+
+    /**
+     * Changes the view range of the display to the specified amount of blocks
+     * @param display The display to change the view range of
+     * @param blocks The amount of blocks to change the view range to
+     */
+    public static void setViewRangeBlocks(@NotNull Display display, float blocks) {
+        display.setViewRange((float) (blocks / (net.minecraft.world.entity.Entity.getViewScale() * 64.0)));
+    }
+
+    /**
+     * Gets the view range of the display in blocks
+     */
+    public static float getViewRangeBlocks(@NotNull Display display) {
+        return display.getViewRange() * (float) (net.minecraft.world.entity.Entity.getViewScale() * 64.0);
     }
 }


### PR DESCRIPTION
- Fix cannons loading improperly after a server crash.
- Separate instruction and healthbar text displays on cannons.
- Cannon healthbar moved right ontop of cannons and lowered its text opacity.
- Text displays on cannons are now placed on the `text_legend` and `text_healthbar` location of the model bone.
- Create utility methods to set/get view range of Display entities in block units