### PR TITLE
break fall fix

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/BreakFall.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/BreakFall.java
@@ -55,7 +55,6 @@ public class BreakFall extends Skill implements PassiveSkill {
         return SkillType.GLOBAL;
     }
 
-
     @EventHandler
     public void onFall(CustomDamageEvent e) {
         if(!(e.getDamagee() instanceof Player player)) return;
@@ -63,9 +62,13 @@ public class BreakFall extends Skill implements PassiveSkill {
 
         int level = getLevel(player);
         if(level > 0) {
-            e.setDamage(e.getDamage() - getDamageReduction(level));
+            if(e.getDamage() <= getDamageReduction(level)){
+                e.setCancelled(true);
+            }
+            else {
+                e.setDamage(e.getDamage() - getDamageReduction(level));
+            }
         }
-
     }
     public void loadSkillConfig(){
         baseDamageReduction = getConfig("baseDamageReduction", 2.0, Double.class);


### PR DESCRIPTION
Break fall now cancels the event if the damage taken was below its reduction threshold

did this on mineplex

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
