### PR TITLE
Scythe of the Fallen Lord, Giant's Broadsword nerf, Hyper Axe buff

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/data/ChargeData.java
@@ -7,8 +7,10 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.components.champions.ISkill;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.display.DisplayComponent;
 import me.mykindos.betterpvp.core.utilities.model.display.PermanentComponent;
+import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
@@ -39,6 +41,17 @@ public class ChargeData {
     public void tick() {
         // Divide over 100 to get multiplication factor since it's in 100% scale for display
         this.charge = Math.min(1, this.charge + (chargePerSecond / 20));
+    }
+
+    public void tickSound(SoundEffect sound, Location location, boolean force) {
+        if (!UtilTime.elapsed(lastSound, soundInterval)) {
+            return;
+        }
+
+        if (force || charge < 1) {
+            sound.play(location);
+            lastSound = System.currentTimeMillis();
+        }
     }
 
     public void tickSound(Player player) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/GiantsBroadsword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/GiantsBroadsword.java
@@ -55,7 +55,7 @@ public class GiantsBroadsword extends ChannelWeapon implements InteractWeapon, L
     private double initialEnergyCost;
 
     @Inject
-    @Config(path = "weapons.giants-broadsword.base-damage", defaultValue = "10.0", configName = "weapons/legendaries")
+    @Config(path = "weapons.giants-broadsword.base-damage", defaultValue = "9.0", configName = "weapons/legendaries")
     private double baseDamage;
 
     @Inject

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/HyperAxe.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/HyperAxe.java
@@ -46,7 +46,7 @@ public class HyperAxe extends Weapon implements InteractWeapon, LegendaryWeapon,
     private double baseDamage;
 
     @Inject
-    @Config(path = "weapons.hyper-axe.dealsKnockback", defaultValue = "false", configName = "weapons/legendaries")
+    @Config(path = "weapons.hyper-axe.dealsKnockback", defaultValue = "true", configName = "weapons/legendaries")
     private boolean dealsKnockback;
 
     @Inject
@@ -58,7 +58,7 @@ public class HyperAxe extends Weapon implements InteractWeapon, LegendaryWeapon,
     private int energyPerHit;
 
     @Inject
-    @Config(path = "weapons.hyper-axe.hyperRushCooldown", defaultValue = "16", configName = "weapons/legendaries")
+    @Config(path = "weapons.hyper-axe.hyperRushCooldown", defaultValue = "16.0", configName = "weapons/legendaries")
     private double hyperRushCooldown;
 
     private final EnergyHandler energyHandler;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/BlackHole.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/BlackHole.java
@@ -1,0 +1,174 @@
+package me.mykindos.betterpvp.champions.weapons.impl.legendaries.scythe;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.champions.champions.skills.data.ChargeData;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilLocation;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+import me.mykindos.betterpvp.core.utilities.math.VectorLine;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import org.bukkit.Color;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+public class BlackHole {
+
+    private final Player caster;
+    private final double hitboxSize;
+    private final double size;
+    private final double pullStrength;
+    private final double pullRadius;
+    private final double aliveSeconds;
+    private final double expandSeconds;
+    private double speed = 1;
+    private Location location;
+    private boolean impacted;
+    private final long creationTime = System.currentTimeMillis();
+    private ChargeData chargeData;
+    private List<Location> sphere;
+    private long impactTime;
+    private Vector direction;
+    @Setter
+    private boolean markForRemoval;
+
+    public BlackHole(Player caster, final Location location, double hitboxSize, double size, double pullStrength, double pullRadius, double aliveSeconds, double expandSeconds) {
+        this.caster = caster;
+        this.location = location;
+        this.hitboxSize = hitboxSize;
+        this.size = size;
+        this.pullStrength = pullStrength;
+        this.pullRadius = pullRadius;
+        this.aliveSeconds = aliveSeconds;
+        this.expandSeconds = expandSeconds;
+    }
+
+    public void tick() {
+        if (!impacted) {
+            final Optional<Location> result = tryImpact();
+            move();
+            result.ifPresent(this::impact);
+
+            // Play travel particles
+            Particle.REDSTONE.builder()
+                    .location(location)
+                    .count(1)
+                    .extra(0.5)
+                    .offset(0.1, 0.1, 0.1)
+                    .data(new Particle.DustOptions(Color.BLACK, 2))
+                    .receivers(60)
+                    .spawn();
+            return;
+        }
+
+        if (UtilTime.elapsed(impactTime, (long) ((expandSeconds + aliveSeconds) * 1000L))) {
+            // Expire if it's been alive for too long
+            markForRemoval = true;
+            new SoundEffect(Sound.BLOCK_CONDUIT_DEACTIVATE, 0f, 1f).play(location);
+        } else {
+            // Play impact particles
+            final float charge = chargeData.getCharge();
+            chargeData.tick();
+            chargeData.tickSound(new SoundEffect(Sound.BLOCK_CONDUIT_DEACTIVATE, 2f, 1f), location, true);
+
+            for (Location point : sphere) {
+                final Location direction = location.clone().subtract(point);
+                direction.multiply(1 - charge);
+                Particle.SQUID_INK.builder()
+                        .location(point.clone().add(direction))
+                        .count(1)
+                        .extra(0)
+                        .receivers(60)
+                        .spawn();
+            }
+
+            Particle.DRAGON_BREATH.builder()
+                    .location(location)
+                    .count(1)
+                    .extra(0.2)
+                    .receivers(60)
+                    .spawn();
+
+            // Pull entities
+            for (LivingEntity entity : location.getNearbyLivingEntities(pullRadius)) {
+                if (entity instanceof ArmorStand) {
+                    continue;
+                }
+
+                final Location entityLocation = entity.getLocation();
+                final Vector direction = location.toVector().subtract(entityLocation.toVector()).normalize();
+                entity.setFallDistance(0);
+                entity.setVelocity(direction.multiply(pullStrength));
+
+                // Pull particles
+                for (Location loc : VectorLine.withStepSize(location, entityLocation, 0.2).toLocations()) {
+                    Particle.ASH.builder()
+                            .location(loc)
+                            .count(1)
+                            .extra(0)
+                            .receivers(60)
+                            .spawn();
+                }
+            }
+        }
+    }
+
+    private void move() {
+        if (direction != null) {
+            location = location.add(direction);
+        }
+    }
+
+    private Optional<Location> tryImpact() {
+        if (UtilBlock.solid(location.getBlock()) || UtilTime.elapsed(creationTime, 2_000)) {
+            return Optional.ofNullable(location);
+        }
+
+        final RayTraceResult rayTrace = location.getWorld().rayTrace(location,
+                direction,
+                speed,
+                FluidCollisionMode.NEVER,
+                true,
+                hitboxSize,
+                entity -> entity != caster && entity instanceof LivingEntity);
+        if (rayTrace != null) {
+            return Optional.of(rayTrace.getHitPosition().toLocation(location.getWorld()));
+        }
+
+        return Optional.empty();
+    }
+
+    public void impact(Location location) {
+        Preconditions.checkState(!impacted, "Black hole already impacted");
+        this.location = location;
+        impacted = true;
+        impactTime = System.currentTimeMillis();
+        sphere = UtilLocation.getSphere(location, size, 6);
+        chargeData = new ChargeData((float) (1 / expandSeconds));
+    }
+
+    public void redirect(Vector vector) {
+        this.direction = vector.normalize().multiply(speed);
+        new SoundEffect(Sound.ENTITY_WARDEN_ATTACK_IMPACT, 0f, 1f).play(location);
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+        if (direction != null) {
+            direction = direction.normalize().multiply(speed);
+        }
+    }
+
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/Scythe.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/Scythe.java
@@ -1,0 +1,112 @@
+package me.mykindos.betterpvp.champions.weapons.impl.legendaries.scythe;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.combat.weapon.Weapon;
+import me.mykindos.betterpvp.core.combat.weapon.types.CooldownWeapon;
+import me.mykindos.betterpvp.core.combat.weapon.types.InteractWeapon;
+import me.mykindos.betterpvp.core.combat.weapon.types.LegendaryWeapon;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+
+@Singleton
+@Slf4j
+public class Scythe extends Weapon implements InteractWeapon, CooldownWeapon, LegendaryWeapon {
+
+    protected final WeakHashMap<Player, List<BlackHole>> blackHoles = new WeakHashMap<>();
+
+    @Inject
+    @Config(path = "weapons.scythe.base-damage", defaultValue = "8.0", configName = "weapons/legendaries")
+    protected double baseDamage;
+
+    @Inject
+    @Config(path = "weapons.scythe.heal-per-hit", defaultValue = "1.0", configName = "weapons/legendaries")
+    protected double healPerHit;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-cooldown", defaultValue = "12.0", configName = "weapons/legendaries")
+    protected double blackHoleCooldown;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-radius", defaultValue = "0.8", configName = "weapons/legendaries")
+    protected double blackHoleRadius;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-speed", defaultValue = "3.0", configName = "weapons/legendaries")
+    protected double blackHoleSpeed;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-hitbox", defaultValue = "0.5", configName = "weapons/legendaries")
+    protected double blackHoleHitbox;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-pull-strength", defaultValue = "0.12", configName = "weapons/legendaries")
+    protected double blackHolePullStrength;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-pull-radius", defaultValue = "5.0", configName = "weapons/legendaries")
+    protected double blackHolePullRadius;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-alive-seconds", defaultValue = "1.5", configName = "weapons/legendaries")
+    protected double blackHoleAliveSeconds;
+
+    @Inject
+    @Config(path = "weapons.scythe.black-hole-expand-seconds", defaultValue = "0.75", configName = "weapons/legendaries")
+    protected double blackHoleExpandSeconds;
+
+    @Inject
+    public Scythe(final ClientManager clientManager) {
+        super("scythe");
+    }
+
+    @Override
+    public List<Component> getLore() {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("An old blade fashioned of nothing more", NamedTextColor.WHITE));
+        lore.add(Component.text("stray bones, brave adventurers have", NamedTextColor.WHITE));
+        lore.add(Component.text("imbued it with the remnant powers of a", NamedTextColor.WHITE));
+        lore.add(Component.text("dark and powerful foe.", NamedTextColor.WHITE));
+        lore.add(Component.empty());
+        lore.add(UtilMessage.deserialize("<white>Deals <yellow>%.1f Damage <white>with attack", baseDamage));
+        lore.add(UtilMessage.deserialize("<yellow>Right-Click <white>to use <green>Black Hole"));
+        lore.add(UtilMessage.deserialize("<yellow>Attack <white>to use <green>Life Steal"));
+        return lore;
+    }
+
+    @Override
+    public void activate(Player player) {
+        final Location location = player.getEyeLocation().add(player.getLocation().getDirection().multiply(0.8));
+        final BlackHole hole = new BlackHole(player,
+                location,
+                blackHoleHitbox,
+                blackHoleRadius,
+                blackHolePullStrength,
+                blackHolePullRadius,
+                blackHoleAliveSeconds,
+                blackHoleExpandSeconds);
+        hole.setSpeed(blackHoleSpeed);
+        hole.redirect(player.getLocation().getDirection());
+        blackHoles.computeIfAbsent(player, p -> new ArrayList<>()).add(hole);
+    }
+
+    @Override
+    public boolean canUse(Player player) {
+        return true;
+    }
+
+    @Override
+    public double getCooldown() {
+        return blackHoleCooldown;
+    }
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/ScytheListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/scythe/ScytheListener.java
@@ -1,0 +1,78 @@
+package me.mykindos.betterpvp.champions.weapons.impl.legendaries.scythe;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.combat.damagelog.DamageLogManager;
+import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
+import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("ALL")
+@BPvPListener
+@Singleton
+@Slf4j
+public class ScytheListener implements Listener {
+
+    @Inject
+    private Scythe scythe;
+
+    @Inject
+    private ClientManager clientManager;
+
+    @Inject
+    private DamageLogManager damageLogManager;
+
+    @Inject
+    private CooldownManager cooldownManager;
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onDamage(CustomDamageEvent event) {
+        if (event.isCancelled()) return;
+        if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK) return;
+        if (!(event.getDamager() instanceof Player damager)) return;
+        if (scythe.isHoldingWeapon(damager)) {
+            event.setDamage(scythe.baseDamage);
+            UtilPlayer.health(damager, scythe.healPerHit);
+        }
+    }
+
+    @UpdateEvent
+    public void doBlackHole() {
+        final Iterator<Map.Entry<Player, List<BlackHole>>> iterator = scythe.blackHoles.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            final Map.Entry<Player, List<BlackHole>> cur = iterator.next();
+            final Player player = cur.getKey();
+            final List<BlackHole> blackHoles = cur.getValue();
+            if (player == null || !player.isOnline()) {
+                iterator.remove();
+                continue;
+            }
+
+            final Iterator<BlackHole> holes = blackHoles.iterator();
+            while (holes.hasNext()) {
+                final BlackHole hole = holes.next();
+                if (hole.isMarkForRemoval()) {
+                    holes.remove();
+                    continue;
+                }
+
+                hole.tick();
+            }
+        }
+    }
+
+}

--- a/champions/src/main/resources/champions-migrations/V4__Add_items.sql
+++ b/champions/src/main/resources/champions-migrations/V4__Add_items.sql
@@ -310,6 +310,9 @@ INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, H
     ('MUSIC_DISC_WAIT', 'champions', 'knights_greatlance', '<orange>Knight''s Greatlance', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
+    ('MUSIC_DISC_STAL', 'champions', 'scythe', '<orange>Scythe of the Fallen Lord', 1, 0, 1);
+
+INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
     ('MUSIC_DISC_FAR', 'champions', 'magnetic_maul', '<orange>Magnetic Maul', 1, 0, 1);
 
 INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES

--- a/champions/src/main/resources/configs/weapons/legendaries.yml
+++ b/champions/src/main/resources/configs/weapons/legendaries.yml
@@ -19,7 +19,7 @@ weapons:
     pull-fov: 80.3
     pull-range: 10.0
   giants-broadsword:
-    base-damage: 10.0
+    base-damage: 9.0
     energy-per-tick: 1.5
     initial-energy-cost: 10.0
     regen-amplifier: 3
@@ -28,9 +28,21 @@ weapons:
     energy-per-tick: 1.0
     initial-energy-cost: 10.0
     strength: 0.7
+  scythe:
+    base-damage: 8.0
+    black-hole-cooldown: 12.0
+    black-hole-hitbox: 0.5
+    black-hole-pull-radius: 5.0
+    black-hole-radius: 0.8
+    black-hole-speed: 3.0
+    black-hole-alive-seconds: 1.5
+    black-hole-expand-seconds: 0.75
+    black-hole-pull-strength: 0.12
+    heal-per-hit: 1.0
   hyper-axe:
+    baseDamage: 4.0
     damageDelay: 200
-    baseDamage: 4
-    dealsKnockback: false
+    dealsKnockback: true
+    energyPerHit: 10
+    hyperRushCooldown: 16.0
     usesEnergy: false
-    energyPerHit: 2

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
@@ -81,6 +81,41 @@ public class UtilLocation {
     }
 
     /**
+     * Get a specified number of points on the circumference of a circle with the given radius and center.
+     *
+     * @param center The center of the circle
+     * @param radius The radius of the circle
+     * @param points The number of points to get
+     * @return A list of locations on the circumference of the circle
+     */
+    public static List<Location> getCircumference(final Location center, final double radius, final int points) {
+        Preconditions.checkState(radius > 0, "Radius must be greater than 0");
+        final List<Location> circle = new ArrayList<>();
+        final int increment = 360 / points;
+        for (int i = 0; i < 360; i += increment) {
+            circle.add(fromFixedAngleDistance(center, radius, i));
+        }
+        return circle;
+    }
+
+    public static List<Location> getSphere(final Location location, final double radius, final int points) {
+        Preconditions.checkState(radius > 0, "Radius must be greater than 0");
+        final List<Location> sphere = new ArrayList<>();
+        for (double i = 0; i <= Math.PI; i += Math.PI / points) {
+            double currentRadius = Math.sin(i) * radius;
+            double y = Math.cos(i) * radius;
+            for (double a = 0; a < Math.PI * 2; a+= Math.PI / points) {
+                double x = Math.cos(a) * currentRadius;
+                double z = Math.sin(a) * currentRadius;
+                location.add(x, y, z);
+                sphere.add(location.clone());
+                location.subtract(x, y, z);
+            }
+        }
+        return sphere;
+    }
+
+    /**
      * Check if a location is in front of an entity's screen, even if there's an obstacle between.
      *
      * @param entity The entity to check.


### PR DESCRIPTION
## Describe your changes
- Add `Scythe of the Fallen Lord`
    - Life steal on hit
    - Black hole skill shot
- Make `Hyper Axe` do 5 damage instead of 4
- Make `Giant's Broadsword` do 9 damage instead of 10

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
