### PR TITLE
Fix cannons throwing errors in unloaded chunks

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/listener/CannonListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/weapons/impl/cannon/listener/CannonListener.java
@@ -417,6 +417,10 @@ public class CannonListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onRemove(final EntityRemoveFromWorldEvent event) {
+        if (!UtilEntity.isRemoved(event.getEntity()) || !UtilEntity.getRemovalReason(event.getEntity()).isDestroy()) {
+            return;
+        }
+
         this.cannonManager.of(event.getEntity()).ifPresent(cannon -> {
             this.cannonManager.remove(cannon);
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -5,11 +5,13 @@ import me.mykindos.betterpvp.core.framework.customtypes.CustomArmourStand;
 import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
 import me.mykindos.betterpvp.core.utilities.events.FetchNearbyEntityEvent;
+import me.mykindos.betterpvp.core.utilities.model.EntityRemovalReason;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
@@ -22,11 +24,28 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class UtilEntity {
+
+    public static boolean isRemoved(@NotNull Entity entity) {
+        return ((CraftEntity) entity).getHandle().isRemoved();
+    }
+
+    public static EntityRemovalReason getRemovalReason(@NotNull Entity entity) {
+        final net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
+        Preconditions.checkArgument(handle.isRemoved(), "Entity must be removed");
+        return switch(Objects.requireNonNull(handle.getRemovalReason())) {
+            case KILLED -> EntityRemovalReason.KILLED;
+            case DISCARDED -> EntityRemovalReason.DISCARDED;
+            case UNLOADED_TO_CHUNK -> EntityRemovalReason.UNLOADED_TO_CHUNK;
+            case UNLOADED_WITH_PLAYER -> EntityRemovalReason.UNLOADED_TO_PLAYER;
+            case CHANGED_DIMENSION -> EntityRemovalReason.DIMENSION_CHANGED;
+        };
+    }
 
     public static final BiPredicate<Player, Entity> IS_ENEMY = (player, entity) -> {
         if (!(entity instanceof LivingEntity) || entity.equals(player)) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/EntityRemovalReason.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/EntityRemovalReason.java
@@ -1,0 +1,26 @@
+package me.mykindos.betterpvp.core.utilities.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Represents a wrapper for the reason for an entity being removed
+ */
+@Getter
+@AllArgsConstructor
+public enum EntityRemovalReason {
+
+    KILLED(true, false),
+
+    DISCARDED(true, false),
+
+    UNLOADED_TO_CHUNK(false, true),
+
+    UNLOADED_TO_PLAYER(false, false),
+
+    DIMENSION_CHANGED(false, false);
+
+    private final boolean isDestroy;
+    private final boolean isSave;
+
+}


### PR DESCRIPTION
## Describe your changes
- Fix cannons throwing errors in unloaded chunks. 
- This is done by checking the removal reason of the entity to see if the entity was destroyed on removal (death or plugin removal) or not (chunk unloading, dimension changes, player unloading)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
