### PR TITLE
Smoke Bomb Rework

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -67,7 +67,7 @@ public class SmokeBomb extends Skill implements CooldownToggleSkill, Listener {
                 "Instantly Vanish before your foes",
                 "for <stat>" + duration + "</stat> seconds, inflicting <effect>Blindness",
                 "and <effect>Slowness " + UtilFormat.getRomanNumeral(slownessLevel + 1) + "</effect> to enemies within <stat>" + getRadius(level),
-                "blocks for <val>" + getEffectDuration(level) + "</val seconds",
+                "blocks for <val>" + getEffectDuration(level) + "</val> seconds",
                 "",
                 "Interacting or taking damage will",
                 "cause you to reappear",
@@ -84,8 +84,8 @@ public class SmokeBomb extends Skill implements CooldownToggleSkill, Listener {
     public void loadSkillConfig() {
         duration = getConfig("duration", 3.0, Double.class);
         effectDurationIncreasePerLevel = getConfig("effectDurationIncreasePerLevel", 1, Integer.class);
-        effectDuration = getConfig("effectDuration", 5, Integer.class);
-        effectRadius = getConfig("effectRadius", 5.0, Double.class);
+        effectDuration = getConfig("effectDuration", 3, Integer.class);
+        effectRadius = getConfig("effectRadius", 4.0, Double.class);
         effectRadiusIncreasePerLevel = getConfig("effectRadiusIncreasePerLevel", 1.0, Double.class);
         slownessLevel = getConfig("slownessLevel", 1, Integer.class);
     }

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -41,8 +41,8 @@ skills:
       cooldown: 35.0
       maxlevel: 3
       baseDuration: 3.0
-      effectDuration: 5
-      effectRadius: 5.0
+      effectDuration: 3
+      effectRadius: 4.0
       slownessLevel: 1
       effectRadiusIncreasePerLevel: 1.0
       effectDurationIncreasePerLevel: 1

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -38,13 +38,15 @@ skills:
       baseIncrease: 0.0
     smokebomb:
       enabled: true
-      cooldown: 50.0
-      maxlevel: 5
+      cooldown: 35.0
+      maxlevel: 3
       baseDuration: 3.0
-      blindDuration: 1.75
-      blindRadius: 4.0
+      effectDuration: 5
+      effectRadius: 5.0
+      slownessLevel: 1
+      effectRadiusIncreasePerLevel: 1.0
+      effectDurationIncreasePerLevel: 1
       cooldownDecreasePerLevel: 2.5
-      durationIncreasePerLevel: 1.0
     silencingarrow:
       enabled: true
       maxlevel: 5

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectType.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectType.java
@@ -19,6 +19,7 @@ public enum EffectType {
     INVULNERABILITY(false),
     FRAILTY(true),
     TEXTURELOADING(false),
+    CONFUSED(true),
     IMMUNETOEFFECTS(false),
     LEVITATION(true),
     NO_JUMP(false),

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
@@ -15,6 +15,8 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -85,6 +87,8 @@ public class EffectListener implements Listener {
                 target.addPotionEffect(new PotionEffect(PotionEffectType.POISON, (int) ((effect.getRawLength() / 1000d) * 20), effect.getLevel()));
             } else if (effect.getEffectType() == EffectType.NO_JUMP) {
                 target.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, (int) ((effect.getRawLength() / 1000d) * 20), 128, false, false, false));
+            } else if (effect.getEffectType() == EffectType.CONFUSED) {
+                target.addPotionEffect(new PotionEffect(PotionEffectType.UNLUCK, (int) ((effect.getRawLength() / 1000d) * 20), 0, false, false, false));
             } else if (effect.getEffectType() == EffectType.BLEED) {
                 target.addPotionEffect(new PotionEffect(PotionEffectType.BAD_OMEN, (int) ((effect.getRawLength() / 1000d) * 20), 0, false, false));
                 bleedEntities.put(target.getUniqueId(), System.currentTimeMillis());
@@ -113,6 +117,47 @@ public class EffectListener implements Listener {
             }
             return false;
         });
+    }
+
+    @UpdateEvent(delay = 300)
+    public void playStepSoundsForConfusedPlayers() {
+        Bukkit.getOnlinePlayers().forEach(player -> {
+            if (player.hasPotionEffect(PotionEffectType.UNLUCK)) {
+                int dx = (int) (Math.random() * 11) - 5;
+                int dz = (int) (Math.random() * 11) - 5;
+
+                Location loc = player.getLocation().add(dx, 0, dz);
+                loc.setY(loc.getWorld().getHighestBlockYAt(loc) - 1);
+
+                Material blockType = loc.getBlock().getType();
+
+                if (!blockType.equals(Material.AIR)) {
+                    playStepSoundForBlock(loc, player);
+                }
+            }
+        });
+    }
+
+
+    private void playStepSoundForBlock(Location loc, Player player) {
+        Material blockType = loc.getBlock().getType();
+        Sound soundToPlay = getStepSoundForBlock(blockType);
+
+        if (soundToPlay != null) {
+            player.getWorld().playSound(loc, soundToPlay, 0.6f, 1.0f);
+        }
+    }
+
+    private Sound getStepSoundForBlock(Material blockType) {
+        String blockTypeName = blockType.name();
+
+        if (blockTypeName.contains("STONE")) {
+            return Sound.BLOCK_STONE_STEP;
+        } else if (blockTypeName.contains("SAND")) {
+            return Sound.BLOCK_SAND_STEP;
+        } else {
+            return Sound.BLOCK_GRASS_STEP;
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
- Fixed duration at 3.0 seconds
- Applies Blindness, Slowness, and new Confusion effect to enemies nearby instead of just blindness
- Confusion creates fake player steps all around the player

Goal is to make smokebomb much worse at running away but better at gaining an advantage in the fight

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
