### PR TITLE
Update ice prison (and lightning orb sound)

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -13,13 +13,13 @@ import me.mykindos.betterpvp.core.combat.throwables.ThrowableItem;
 import me.mykindos.betterpvp.core.combat.throwables.ThrowableListener;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
-import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
@@ -119,11 +119,10 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         }
     }
 
-    @UpdateEvent
-    public void doSound() {
-        for (ThrowableItem throwableItem : championsManager.getThrowables().getThrowablesOfName(getName())) {
-            throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.6f, 1.6f);
-        }
+    @Override
+    public void onTick(ThrowableItem throwableItem) {
+        throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.6f, 1.6f);
+        throwableItem.getLastLocation().getWorld().spawnParticle(Particle.SNOW_SHOVEL, throwableItem.getLastLocation(), 1);
     }
 
     @Override
@@ -134,6 +133,7 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         throwableItem.setCollideGround(true);
         championsManager.getThrowables().addThrowable(throwableItem);
         throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.ENTITY_SILVERFISH_HURT, 2f, 1f);
+
     }
     @Override
     public void loadSkillConfig(){

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -38,7 +38,6 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
     private double baseDuration;
     private double durationIncreasePerLevel;
     private double speed;
-
     private double variance;
 
     @Inject

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -39,6 +39,8 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
     private double durationIncreasePerLevel;
     private double speed;
 
+    private double variance;
+
     @Inject
     public IcePrison(Champions champions, ChampionsManager championsManager, WorldBlockHandler blockHandler) {
         super(champions, championsManager);
@@ -108,7 +110,8 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
             if (loc.getBlock().getType() == Material.AIR || UtilBlock.airFoliage(loc.getBlock())) {
                 int level = getLevel((Player) throwableItem.getThrower());
                 if (throwableItem.getThrower() instanceof Player player) {
-                    blockHandler.addRestoreBlock(player, loc.getBlock(), Material.ICE, (long) (getDuration(level) * 1000), true);
+                    double duration = getDuration(level) + (((double) (center.getBlockY() - loc.getBlockY()) / sphereSize) * variance);
+                    blockHandler.addRestoreBlock(player, loc.getBlock(), Material.ICE, (long) (duration * 1000), true);
                 }
                 loc.getBlock().setType(Material.ICE);
                 loc.getWorld().playSound(loc, Sound.BLOCK_GLASS_STEP, 1f, 1f);
@@ -139,6 +142,7 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         baseDuration = getConfig("baseDuration", 6.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 0.5, Double.class);
         speed = getConfig("speed", 1.5, Double.class);
+        variance = getConfig("variance", 0.5, Double.class);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.mage.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -12,12 +13,14 @@ import me.mykindos.betterpvp.core.combat.throwables.ThrowableItem;
 import me.mykindos.betterpvp.core.combat.throwables.ThrowableListener;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -25,6 +28,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;
 
+@Slf4j
 @Singleton
 @BPvPListener
 public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Listener, ThrowableListener {
@@ -107,10 +111,18 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
                     blockHandler.addRestoreBlock(player, loc.getBlock(), Material.ICE, (long) (getDuration(level) * 1000), true);
                 }
                 loc.getBlock().setType(Material.ICE);
+                loc.getWorld().playSound(loc, Sound.BLOCK_GLASS_STEP, 1f, 1f);
+                loc.getWorld().playSound(loc, Sound.BLOCK_GLASS_BREAK, 1f, 0.8f);
             }
         }
     }
 
+    @UpdateEvent
+    public void doSound() {
+        for (ThrowableItem throwableItem : championsManager.getThrowables().getThrowablesOfName(getName())) {
+            throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.6f, 1.6f);
+        }
+    }
 
     @Override
     public void activate(Player player, int level) {
@@ -119,8 +131,8 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         ThrowableItem throwableItem = new ThrowableItem(this, item, player, getName(), 10000, true);
         throwableItem.setCollideGround(true);
         championsManager.getThrowables().addThrowable(throwableItem);
+        throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.ENTITY_SILVERFISH_HURT, 2f, 1f);
     }
-
     @Override
     public void loadSkillConfig(){
         sphereSize = getConfig("sphereSize", 4, Integer.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
@@ -20,6 +20,8 @@ import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -134,6 +136,11 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
         throwableItem.getItem().remove();
     }
 
+    @Override
+    public void onTick(ThrowableItem throwableItem) {
+        throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.6f, 1.6f);
+        throwableItem.getLastLocation().getWorld().spawnParticle(Particle.FIREWORKS_SPARK, throwableItem.getLastLocation(), 1);
+    }
 
     @Override
     public void activate(Player player, int level) {
@@ -141,8 +148,9 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
         orb.setVelocity(player.getLocation().getDirection());
         orb.setCanPlayerPickup(false);
         orb.setCanMobPickup(false);
-        ThrowableItem throwableItem = new ThrowableItem(this, orb, player, "Lightning Orb", 10000, false);
+        ThrowableItem throwableItem = new ThrowableItem(this, orb, player, "Lightning Orb", 5000, false);
         championsManager.getThrowables().addThrowable(throwableItem);
+        throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.ENTITY_SILVERFISH_HURT, 2f, 1f);
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
@@ -34,6 +34,10 @@ public class ThrowableHandler {
         return throwables.stream().filter(throwable -> throwable.getItem().equals(item)).findFirst();
     }
 
+    public List<ThrowableItem> getThrowablesOfName(String name) {
+        return throwables.stream().filter(throwableItem -> throwableItem.getName().equals(name)).toList();
+    }
+
     public void processThrowableHitEntity(ThrowableItem throwableItem, ThrowableHitEntityEvent event) {
         ThrowableHitEntityEvent throwableHitEntityEvent = UtilServer.callEvent(event);
         if (!throwableHitEntityEvent.isCancelled()) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableHandler.java
@@ -34,10 +34,6 @@ public class ThrowableHandler {
         return throwables.stream().filter(throwable -> throwable.getItem().equals(item)).findFirst();
     }
 
-    public List<ThrowableItem> getThrowablesOfName(String name) {
-        return throwables.stream().filter(throwableItem -> throwableItem.getName().equals(name)).toList();
-    }
-
     public void processThrowableHitEntity(ThrowableItem throwableItem, ThrowableHitEntityEvent event) {
         ThrowableHitEntityEvent throwableHitEntityEvent = UtilServer.callEvent(event);
         if (!throwableHitEntityEvent.isCancelled()) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/ThrowableListener.java
@@ -10,4 +10,8 @@ public interface ThrowableListener {
     default void onThrowableHitGround(ThrowableItem throwableItem, LivingEntity thrower, Location location) {
 
     }
+
+    default void onTick(ThrowableItem throwableItem) {
+
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/listeners/ThrowableItemListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/throwables/listeners/ThrowableItemListener.java
@@ -53,6 +53,7 @@ public class ThrowableItemListener implements Listener {
             checkGroundCollision(throwable);
             checkEntityCollision(throwable);
             throwable.setLastLocation(throwable.getItem().getLocation());
+            throwable.getListener().onTick(throwable);
         });
     }
 


### PR DESCRIPTION
Add sounds on throw and travel from ice prison and lightning orb
Change ice prison to decay from top to bottom instead of all at once. The speed is now controlled by the variance variable

Fixes #612

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
