### PR TITLE
fixed issue of Molten/Fire blast being deflected

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
@@ -125,12 +125,12 @@ public class FireBlast extends Skill implements InteractSkill, CooldownSkill, Li
 
     // If damaged by entity do nothing
     @EventHandler
-    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-        if (event.getEntity() instanceof LargeFireball) {
-            LargeFireball fireball = (LargeFireball) event.getEntity();
-            if (event.getDamager() instanceof Player) {
-                Player player = (Player) event.getDamager();
-                event.setCancelled(true);
+    public void onDeflect(EntityDamageByEntityEvent event) {
+        if (event.getEntity() instanceof Projectile && event.getEntity() instanceof LargeFireball ) {
+            if (((LargeFireball) event.getEntity()).getShooter() instanceof Player){
+                if (event.getDamager() instanceof Player  || event.getDamager() instanceof Projectile) {
+                    event.setCancelled(true);
+                }
             }
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
@@ -126,9 +126,9 @@ public class FireBlast extends Skill implements InteractSkill, CooldownSkill, Li
     // If damaged by entity do nothing
     @EventHandler
     public void onDeflect(EntityDamageByEntityEvent event) {
-        if (event.getEntity() instanceof Projectile && event.getEntity() instanceof LargeFireball ) {
-            if (((LargeFireball) event.getEntity()).getShooter() instanceof Player){
-                if (event.getDamager() instanceof Player  || event.getDamager() instanceof Projectile) {
+        if (event.getEntity() instanceof LargeFireball fireball) {
+            if (fireball.getShooter() instanceof Player){
+                if (event.getDamager() instanceof Player || event.getDamager() instanceof Projectile) {
                     event.setCancelled(true);
                 }
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
@@ -32,6 +32,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -118,6 +119,18 @@ public class FireBlast extends Skill implements InteractSkill, CooldownSkill, Li
                 Particle.LAVA.builder().location(fireball.getLocation()).receivers(30).count(1).spawn();
             } else {
                 it.remove();
+            }
+        }
+    }
+
+    // If damaged by entity do nothing
+    @EventHandler
+    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        if (event.getEntity() instanceof LargeFireball) {
+            LargeFireball fireball = (LargeFireball) event.getEntity();
+            if (event.getDamager() instanceof Player) {
+                Player player = (Player) event.getDamager();
+                event.setCancelled(true);
             }
         }
     }


### PR DESCRIPTION
## Describe your changes
Added event handler onEntityDamageByEntity to prevent Fireblast from being deflected by players/entities.

## Link to issue (if applicable)
#707 

## Checklist before requesting a review
- [✓] I have performed a self-review of my code
- [✓] I have tested my changes.
