### PR TITLE
Add Frozen effect and Punishment

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansWorldListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansWorldListener.java
@@ -667,7 +667,9 @@ public class ClansWorldListener extends ClanListener {
     @UpdateEvent(delay = 250)
     public void checkGamemode() {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+            if (player.getGameMode() == GameMode.CREATIVE
+                    || player.getGameMode() == GameMode.SPECTATOR
+                    || effectManager.hasEffect(player, EffectTypes.FROZEN)) {
                 continue;
             }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/FreezeCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/FreezeCommand.java
@@ -1,0 +1,73 @@
+package me.mykindos.betterpvp.core.command.commands.admin;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.Rank;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class FreezeCommand extends Command implements IConsoleCommand {
+
+    private final ClientManager clientManager;
+    private final EffectManager effectManager;
+
+    @Inject
+    public FreezeCommand(ClientManager clientManager, EffectManager effectManager) {
+        this.clientManager = clientManager;
+        this.effectManager = effectManager;
+    }
+
+    @Override
+    public String getName() {
+        return "freeze";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Freeze another player";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        execute(player, args);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length < 1) {
+            UtilMessage.message(sender, "Freeze", "You must specify a player ");
+            return;
+        }
+
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            UtilMessage.message(sender, "Freeze", "<yellow>%s</yellow> is not a valid player name", args[0]);
+            return;
+        }
+
+        UtilMessage.message(target, "Freeze", "You have been frozen by a staff member");
+
+        effectManager.addEffect(target, null, EffectTypes.FROZEN, "Freeze", 1, 1000, true, true);
+        clientManager.sendMessageToRank("Freeze", UtilMessage.deserialize("<yellow>%s</yellow> froze <yellow>%s</yellow>", sender.getName(), target.getName()), Rank.HELPER);
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        if(argCount == 1){
+            return ArgumentType.PLAYER.name();
+        }
+        return ArgumentType.NONE.name();
+    }
+
+
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/UnfreezeCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/UnfreezeCommand.java
@@ -1,0 +1,74 @@
+package me.mykindos.betterpvp.core.command.commands.admin;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.Rank;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class UnfreezeCommand extends Command implements IConsoleCommand {
+
+    private final ClientManager clientManager;
+    private final EffectManager effectManager;
+
+    @Inject
+    public UnfreezeCommand(ClientManager clientManager, EffectManager effectManager) {
+        this.clientManager = clientManager;
+        this.effectManager = effectManager;
+    }
+
+    @Override
+    public String getName() {
+        return "unfreeze";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Unfreeze another player";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        execute(player, args);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length < 1) {
+            UtilMessage.message(sender, "Freeze", "You must specify a player ");
+            return;
+        }
+
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            UtilMessage.message(sender, "Freeze", "<yellow>%s</yellow> is not a valid player name", args[0]);
+            return;
+        }
+
+        UtilMessage.message(target, "Freeze", "You have been unfrozen by a staff member");
+
+        effectManager.removeEffect(target, EffectTypes.FROZEN);
+        clientManager.sendMessageToRank("Freeze", UtilMessage.deserialize("<yellow>%s</yellow> unfroze <yellow>%s</yellow>", sender.getName(), target.getName()), Rank.HELPER);
+
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        if(argCount == 1){
+            return ArgumentType.PLAYER.name();
+        }
+        return ArgumentType.NONE.name();
+    }
+
+
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectTypes.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectTypes.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import me.mykindos.betterpvp.core.effects.types.negative.BleedEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.BlindnessEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.DarknessEffect;
+import me.mykindos.betterpvp.core.effects.types.negative.FrozenEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.LevitationEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.NoJumpEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.NoSprintEffect;
@@ -54,6 +55,7 @@ public class EffectTypes {
     public static final EffectType SHOCK = createEffectType(new ShockEffect());
     public static final EffectType WITHER = createEffectType(new WitherEffect());
     public static final EffectType DARKNESS = createEffectType(new DarknessEffect());
+    public static final EffectType FROZEN = createEffectType(new FrozenEffect());
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Positive Effect Types">

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
@@ -109,7 +109,8 @@ public class EffectListener implements Listener {
         if(!event.isAllowed()) return;
 
         if(effectManager.hasEffect(event.getDamagee(), EffectTypes.PROTECTION)
-                || effectManager.hasEffect(event.getDamagee(), EffectTypes.INVISIBILITY)) {
+                || effectManager.hasEffect(event.getDamagee(), EffectTypes.INVISIBILITY)
+                || effectManager.hasEffect(event.getDamagee(), EffectTypes.FROZEN)) {
             event.setResult(Event.Result.DENY);
         }
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
@@ -1,0 +1,97 @@
+package me.mykindos.betterpvp.core.effects.listeners.effects;
+
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerAttemptPickupItemEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@BPvPListener
+@Singleton
+public class FrozenListener implements Listener {
+
+    private final EffectManager effectManager;
+
+    @Inject
+    public FrozenListener(EffectManager effectManager) {
+        this.effectManager = effectManager;
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (event.hasChangedPosition()) {
+            if (effectManager.hasEffect(event.getPlayer(), EffectTypes.FROZEN)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onDropItem(PlayerDropItemEvent event) {
+        if (event.isCancelled()) return;
+        if (effectManager.hasEffect(event.getPlayer(), EffectTypes.FROZEN)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPickupItem(PlayerAttemptPickupItemEvent event) {
+        if (event.isCancelled()) return;
+        if (effectManager.hasEffect(event.getPlayer(), EffectTypes.FROZEN)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onInteractEvent(PlayerInteractEvent event) {
+        if (effectManager.hasEffect(event.getPlayer(), EffectTypes.FROZEN)) {
+            event.setCancelled(true);
+            event.setUseInteractedBlock(Event.Result.DENY);
+            event.setUseItemInHand(Event.Result.DENY);
+            UtilMessage.message(event.getPlayer(), "Frozen", "You cannot do this while frozen");
+        }
+    }
+
+    @EventHandler
+    public void entityDamageEvent(EntityDamageEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            if (effectManager.hasEffect(player, EffectTypes.FROZEN)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void entDamage(EntityDamageByEntityEvent event) {
+        if (event.getEntity() instanceof LivingEntity damagee) {
+            if (effectManager.hasEffect(damagee, EffectTypes.FROZEN)) {
+                UtilMessage.message(event.getDamager(), "Frozen", "<yellow>%s</yellow> is frozen and cannot receive damage!", damagee.getName());
+                event.setCancelled(true);
+            }
+        }
+
+        if (event.getDamager() instanceof LivingEntity damager) {
+            if (effectManager.hasEffect(damager, EffectTypes.FROZEN)) {
+                UtilMessage.message(damager, "Frozen", "You cannot damage anything while you are Frozen!");
+                event.setCancelled(true);
+            }
+        }
+    }
+
+
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
@@ -58,6 +58,11 @@ public class FrozenListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onInteractEvent(PlayerInteractEvent event) {
+        if (event.useInteractedBlock() == Event.Result.DENY
+                && event.useItemInHand() == Event.Result.DENY) {
+            //Both events are denied, this is a cancelled event
+            return;
+        }
         if (effectManager.hasEffect(event.getPlayer(), EffectTypes.FROZEN)) {
             event.setCancelled(true);
             event.setUseInteractedBlock(Event.Result.DENY);

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/FrozenEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/FrozenEffect.java
@@ -1,0 +1,50 @@
+package me.mykindos.betterpvp.core.effects.types.negative;
+
+import me.mykindos.betterpvp.core.effects.Effect;
+import me.mykindos.betterpvp.core.effects.EffectType;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.GameMode;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class FrozenEffect extends EffectType {
+
+    HashMap<UUID, GameMode> previousGamemode = new HashMap<>();
+
+    @Override
+    public String getName() {
+        return "Frozen";
+    }
+
+    @Override
+    public String getDescription(int level) {
+        return "Freezes the player, preventing movement, damage, and other actions";
+    }
+
+    @Override
+    public boolean isNegative() {
+        return true;
+    }
+
+    @Override
+    public void onReceive(LivingEntity livingEntity, Effect effect) {
+        super.onReceive(livingEntity, effect);
+        if (livingEntity instanceof Player player) {
+            previousGamemode.putIfAbsent(player.getUniqueId(), player.getGameMode());
+            player.setGameMode(GameMode.ADVENTURE);
+            UtilMessage.message(player, "Frozen", "You have been frozen");
+        }
+    }
+
+    @Override
+    public void onExpire(LivingEntity livingEntity, Effect effect) {
+        super.onExpire(livingEntity, effect);
+        if (livingEntity instanceof Player player) {
+            player.setGameMode(previousGamemode.remove(player.getUniqueId()));
+            UtilMessage.message(player, "Frozen", "You are unfrozen");
+        }
+    }
+}


### PR DESCRIPTION
Adds the frozen effect. While frozen, players cannot moving, attack, take damage, drop items, pickup items, break blocks, use skills, or anything else. They can chat.

The frozen punishment allows for staff to quickly prevent rule breaking players from continuing to act, before applying the appropriate punishment (a lot easier to freeze someone bunny hopping on someone, then type out the correct reason/time, rather than skip the frozen step).

Also allows staff to freeze a player and talk with them, for whatever reason.

- [x] Add frozen effect
- [x] Add frozen punishment

Fixes #722

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
