### PR TITLE
Fix some runes having incorrect tier in code

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/fortune/FortuneT2.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/fortune/FortuneT2.java
@@ -14,7 +14,7 @@ public class FortuneT2 extends FortuneBase {
 
     @Override
     public int getTier() {
-        return 1;
+        return 2;
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/fortune/FortuneT3.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/fortune/FortuneT3.java
@@ -14,7 +14,7 @@ public class FortuneT3 extends FortuneBase {
 
     @Override
     public int getTier() {
-        return 1;
+        return 3;
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/frost/FrostT4.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/frost/FrostT4.java
@@ -14,7 +14,7 @@ public class FrostT4 extends FrostBase {
 
     @Override
     public int getTier() {
-        return 3;
+        return 4;
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/scorching/ScorchingT4.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/scorching/ScorchingT4.java
@@ -14,7 +14,7 @@ public class ScorchingT4 extends ScorchingBase {
 
     @Override
     public int getTier() {
-        return 3;
+        return 4;
     }
 
 


### PR DESCRIPTION
Some runes had an incorrect value for getTier, this now corrects the value that matches the name.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
