### PR TITLE
Update Mage Active Toggle Passives

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -10,6 +10,7 @@ import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
+import me.mykindos.betterpvp.champions.champions.skills.types.ActiveToggleSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.CooldownSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.EnergySkill;
 import me.mykindos.betterpvp.champions.effects.types.SkillBoostEffect;
@@ -36,7 +37,9 @@ public abstract class Skill implements IChampionsSkill {
     protected double cooldown;
     protected double cooldownDecreasePerLevel;
     protected int energy;
-    protected Double energyDecreasePerLevel;
+    protected double energyDecreasePerLevel;
+    protected double energyStartCost;
+    protected double energyStartCostDecreasePerLevel;
 
     private boolean canUseWhileSlowed;
 
@@ -147,6 +150,11 @@ public abstract class Skill implements IChampionsSkill {
         if (this instanceof EnergySkill) {
             energy = getConfig("energy", 0, Integer.class);
             energyDecreasePerLevel = getConfig("energyDecreasePerLevel", 1.0, Double.class);
+        }
+
+        if (this instanceof ActiveToggleSkill) {
+            energyStartCost = getConfig("energyStartCost", 10.0, Double.class);
+            energyStartCostDecreasePerLevel = getConfig("energyStartCostDecreasePerLevel", 0.0, Double.class);
         }
 
         canUseWhileSlowed = getConfigObject("canUseWhileSlowed", true, Boolean.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
@@ -202,11 +202,6 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
     }
 
     @Override
-    public float getEnergyStartCost(int level) {
-        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
-    }
-
-    @Override
     public void toggleActive(Player player) {
         if (championsManager.getEnergy().use(player, getName(), getEnergyStartCost(getLevel(player)), false)) {
             UtilMessage.message(player, getClassType().getName(), "Arctic Armour: <green>On");

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
@@ -65,6 +65,7 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
                 "Allies inside this area receive <effect>Resistance " + UtilFormat.getRomanNumeral(resistanceStrength) + "</effect>, and",
                 "enemies inside this area receive <effect>Slowness " + UtilFormat.getRomanNumeral(slownessStrength) + "</effect>",
                 "",
+                "Uses <stat>" + getEnergyStartCost(level) + "</stat> energy on activation",
                 "Energy / Second: <val>" + getEnergy(level)
         };
     }
@@ -93,28 +94,25 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
         }
 
         if (updateCooldowns.getOrDefault("snowAura", 0L) < System.currentTimeMillis()) {
-            if (!snowAura(player)) {
-                return false;
-            }
+            snowAura(player);
             updateCooldowns.put("snowAura", System.currentTimeMillis() + 100);
         }
 
-        return true;
+        return doArcticArmour(player);
     }
 
     private void audio(Player player) {
         player.getWorld().playSound(player.getLocation(), Sound.WEATHER_RAIN, 0.3F, 0.0F);
     }
 
-    private boolean snowAura(Player player) {
-
+    private boolean doArcticArmour(Player player) {
         int level = getLevel(player);
         final int distance = getRadius(level);
         if (level <= 0) {
             return false;
         }
 
-        if (!championsManager.getEnergy().use(player, getName(), getEnergy(level) / 2, true)) {
+        if (!championsManager.getEnergy().use(player, getName(), getEnergy(level) / 20, true)) {
             return false;
         }
 
@@ -131,7 +129,13 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
                 championsManager.getEffects().addEffect(target, player, EffectTypes.SLOWNESS, slownessStrength, 1000);
             }
         }
+        return true;
+    }
 
+    private void snowAura(Player player) {
+
+        int level = getLevel(player);
+        final int distance = getRadius(level);
         // Apply cue effects
         // Spin particles around the player in the radius
         final int angle = (int) ((System.currentTimeMillis() / 10) % 360);
@@ -141,8 +145,6 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
         playEffects(player, distance, angle + 180f);
 
         convertWaterToIce(player, getDuration(level), distance);
-
-        return true;
     }
 
     private void playEffects(final Player player, float radius, float angle) {
@@ -200,8 +202,20 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill {
     }
 
     @Override
+    public float getEnergyStartCost(int level) {
+        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
+    }
+
+    @Override
     public void toggleActive(Player player) {
-        UtilMessage.message(player, getClassType().getName(), "Arctic Armour: <green>On");
+        if (championsManager.getEnergy().use(player, getName(), getEnergyStartCost(getLevel(player)), false)) {
+            UtilMessage.message(player, getClassType().getName(), "Arctic Armour: <green>On");
+        }
+        else
+        {
+            cancel(player);
+        }
+
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
@@ -110,11 +110,6 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
     }
 
     @Override
-    public float getEnergyStartCost(int level) {
-        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
-    }
-
-    @Override
     public void cancel(Player player, String reason) {
         super.cancel(player, reason);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
@@ -62,6 +62,7 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
                 "You leave a trail of fire, which",
                 "ignites enemies for <stat>" + getFireTickDuration(level) + "</stat> seconds",
                 "",
+                "Uses <stat>" + getEnergyStartCost(level) + "</stat> energy on activation",
                 "Energy / Second: <val>" + getEnergy(level)
 
         };
@@ -101,11 +102,16 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
 
     @Override
     public void toggleActive(Player player) {
-        if (championsManager.getEnergy().use(player, getName(), 10, false)) {
+        if (championsManager.getEnergy().use(player, getName(), getEnergyStartCost(player.getLevel()), false)) {
             UtilMessage.simpleMessage(player, getClassType().getName(), "Immolate: <green>On");
         } else {
             cancel(player);
         }
+    }
+
+    @Override
+    public float getEnergyStartCost(int level) {
+        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
     }
 
     @Override
@@ -144,9 +150,9 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
         int level = getLevel(player);
         if (level <= 0) {
             return false;
-        } else if (!championsManager.getEnergy().use(player, getName(), getEnergy(level) / 5, true)) {
+        } else if (!championsManager.getEnergy().use(player, getName(), getEnergy(level) / 20, true)) {
             return false;
-        } else if (championsManager.getEffects().hasEffect(player, EffectTypes.SILENCE)) {
+        } else if (championsManager.getEffects().hasEffect(player, EffectTypes.SILENCE) && !canUseWhileSilenced()) {
             return false;
         } else {
             championsManager.getEffects().addEffect(player, EffectTypes.SPEED, getName(), speedStrength, 1250, true);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
@@ -103,11 +103,6 @@ public class LifeBonds extends ActiveToggleSkill implements EnergySkill {
         }
     }
 
-    @Override
-    public float getEnergyStartCost(int level) {
-        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
-    }
-
     private void audio(Player player) {
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_AMETHYST_BLOCK_CHIME, 0.3F, 0.0F);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
@@ -64,6 +64,7 @@ public class LifeBonds extends ActiveToggleSkill implements EnergySkill {
                 "radius to transfer their health to the",
                 "lowest health player every <stat>" + getHealCooldown(level) + "</stat> seconds",
                 "",
+                "Uses <stat>" + getEnergyStartCost(level) + "</stat> energy on activation",
                 "Energy / Second: <val>" + getEnergy(level)
 
         };
@@ -97,9 +98,14 @@ public class LifeBonds extends ActiveToggleSkill implements EnergySkill {
 
     @Override
     public void toggleActive(Player player) {
-        if (championsManager.getEnergy().use(player, getName(), 10, false)) {
+        if (championsManager.getEnergy().use(player, getName(), getEnergyStartCost(getLevel(player)), false)) {
             UtilMessage.simpleMessage(player, getClassType().getName(), "Life Bonds: <green>On");
         }
+    }
+
+    @Override
+    public float getEnergyStartCost(int level) {
+        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
     }
 
     private void audio(Player player) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Void.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Void.java
@@ -51,6 +51,7 @@ public class Void extends ActiveToggleSkill implements EnergySkill {
                 "Every point of damage you take will be",
                 "reduced by <val>" + getDamageReduction(level) + "</val> and drain <val>" + getEnergyReduction(level) + "</val> energy",
                 "",
+                "Uses <stat>" + getEnergyStartCost(level) + "</stat> energy on activation",
                 "Energy / Second: <val>" + getEnergy(level)
         };
     }
@@ -82,11 +83,16 @@ public class Void extends ActiveToggleSkill implements EnergySkill {
 
     @Override
     public void toggleActive(Player player) {
-        if (championsManager.getEnergy().use(player, "Void", 5, false)) {
+        if (championsManager.getEnergy().use(player, getName(), getEnergyStartCost(getLevel(player)), false)) {
             UtilMessage.simpleMessage(player, getClassType().getName(), "Void: <green>On");
         } else {
             cancel(player);
         }
+    }
+
+    @Override
+    public float getEnergyStartCost(int level) {
+        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Void.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Void.java
@@ -91,11 +91,6 @@ public class Void extends ActiveToggleSkill implements EnergySkill {
     }
 
     @Override
-    public float getEnergyStartCost(int level) {
-        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
-    }
-
-    @Override
     public void cancel(Player player, String reason) {
         super.cancel(player, reason);
         championsManager.getEffects().removeEffect(player, EffectTypes.INVISIBILITY, getName());

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ActiveToggleSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ActiveToggleSkill.java
@@ -99,6 +99,8 @@ public abstract class ActiveToggleSkill extends Skill implements ToggleSkill, Li
 
     public abstract void toggleActive(Player player);
 
-    public abstract float getEnergyStartCost(int level);
+    public float getEnergyStartCost(int level) {
+        return (float) (energyStartCost - ((level - 1) * energyStartCostDecreasePerLevel));
+    }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ActiveToggleSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ActiveToggleSkill.java
@@ -99,4 +99,6 @@ public abstract class ActiveToggleSkill extends Skill implements ToggleSkill, Li
 
     public abstract void toggleActive(Player player);
 
+    public abstract float getEnergyStartCost(int level);
+
 }

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -38,6 +38,7 @@ skills:
       maxlevel: 3
       damageIncreasePerLevel: 1.5
       baseDamage: 1.5
+      increasePerLevel: 1.5
     smokebomb:
       enabled: true
       cooldown: 50.0
@@ -74,6 +75,7 @@ skills:
       maxlevel: 3
       damageIncrement: 1.0
       duration: 2.0
+      baseDamageIncrement: 1.0
     concussion:
       enabled: true
       cooldown: 16.0
@@ -178,6 +180,8 @@ skills:
       speedDuration: 3.0
       slownessStrength: 3
       speedStrength: 3
+      speedDurationIncreasePerLevel: 0.0
+      slowDurationIncreasePerLevel: 0.0
     fortitude:
       enabled: true
       maxlevel: 3
@@ -193,6 +197,7 @@ skills:
       baseMaxDamage: 2.0
       baseMaxDamageIncreasePerLevel: 1.0
       expirationTime: 5.0
+      maxDamageIncreasePerLevel: 1.0
     levelfield:
       enabled: true
       maxlevel: 3
@@ -266,6 +271,8 @@ skills:
       blocksArrow: false
       energyDecreasePerLevel: 1.0
       internalCooldown: 2.0
+      cooldown: 1.0
+      cooldownDecreasePerLevel: 1.0
     powerchop:
       enabled: true
       maxlevel: 5
@@ -339,7 +346,7 @@ skills:
       enabled: true
       maxlevel: 5
       cooldown: 23.0
-      speed: .15
+      speed: 0.15
       damage: 6.0
       fireDurationIncreasePerLevel: 2.0
       cooldownDecreasePerLevel: 2.0
@@ -348,6 +355,8 @@ skills:
       minFireDuration: 4.0
       radius: 6.0
       radiusIncreasePerLevel: 0.5
+      baseFireDuration: 2.0
+      minFireDurationIncreasePerLevel: 0.5
     iceprison:
       enabled: true
       maxlevel: 5
@@ -357,6 +366,7 @@ skills:
       cooldownDecreasePerLevel: 2.0
       baseDuration: 6.0
       durationIncreasePerLevel: 0.5
+      variance: 0.5
     lightningorb:
       enabled: true
       maxlevel: 5
@@ -384,14 +394,16 @@ skills:
     immolate:
       enabled: true
       maxlevel: 5
-      energy: 11
+      energy: 44
       baseFireTickDuration: 4.0
       fireTickDurationIncreasePerLevel: 0.0
       baseFireTrailDuration: 2.0
       fireTrailDurationIncreasePerLevel: 0.0
       speedStrength: 1
       strengthLevel: 1
-      energyDecreasePerLevel: 1.0
+      energyDecreasePerLevel: 4.0
+      energyStartCost: 10.0
+      energyStartCostDecreasePerLevel: 0.0
     lifebonds:
       enabled: true
       maxlevel: 5
@@ -405,6 +417,8 @@ skills:
       healSpeedIncreasePerLevel: 0.0
       baseHealMultiplier: 0.25
       healMultiplierIncreasePerLevel: 0.0
+      energyStartCost: 10.0
+      energyStartCostDecreasePerLevel: 0.0
     magmablade:
       enabled: true
       maxlevel: 3
@@ -454,6 +468,8 @@ skills:
       damageReduction: 5
       energyReduction: 20
       energyDecreasePerLevel: 2.0
+      energyStartCost: 10.0
+      energyStartCostDecreasePerLevel: 0.0
     fissure:
       enabled: true
       maxLevel: 5
@@ -472,6 +488,8 @@ skills:
       doorCheckEnabled: true
       fissureForbiddenBlocks:
         - TNT
+      maxlevel: 5
+      cooldownDecreasePerLevel: 1.0
     nullblade:
       enabled: true
       maxlevel: 5
@@ -494,7 +512,7 @@ skills:
     arcticarmour:
       enabled: true
       maxlevel: 5
-      energy: 6
+      energy: 24
       canUseInLiquid: true
       baseRadius: 2
       radiusIncreasePerLevel: 1
@@ -504,7 +522,9 @@ skills:
       slownessStrength: 1
       minRadius: 2
       duration: 2.0
-      energyDecreasePerLevel: 0.5
+      energyDecreasePerLevel: 2.0
+      energyStartCost: 10.0
+      energyStartCostDecreasePerLevel: 0.0
     pestilence:
       enabled: true
       maxlevel: 3
@@ -557,6 +577,7 @@ skills:
       cooldownDecreasePerLevel: 2.0
       slamDelay: 500
       fallDamageLimit: 20.0
+      baseRadius: 5.5
     whirlwindsword:
       enabled: true
       maxlevel: 5
@@ -566,6 +587,7 @@ skills:
       distanceIncreasePerLevel: 0.0
       baseDamage: 3.0
       damageIncreasePerLevel: 1.0
+      damage: 3.0
     cripplingblow:
       enabled: true
       maxlevel: 3
@@ -598,7 +620,7 @@ skills:
     colossus:
       enabled: true
       maxlevel: 3
-      reductionPerLevel: 0.20
+      reductionPerLevel: 0.2
     takedown:
       enabled: true
       maxlevel: 5
@@ -653,6 +675,7 @@ skills:
       enabled: true
       maxlevel: 3
       increasePerLevel: 10
+      base: 10
     overwhelm:
       enabled: true
       maxlevel: 3
@@ -769,6 +792,8 @@ skills:
       baseNumArrows: 10
       numArrowsIncreasePerLevel: 0
       damage: 8.0
+      baseDamage: 8.0
+      damageIncreasePerLevel: 0.0
     vitalityspores:
       enabled: true
       maxlevel: 3
@@ -783,6 +808,10 @@ skills:
       maxConsecuteiveHitsIncreasePerLevel: 2
       baseDamage: 1.0
       damageIncreasePerLevel: 0.0
+      baseMaxTimeBetweenShots: 5.0
+      maxTimeBetweenShotsIncreasePerLevel: 0.0
+      maxConsecutiveHits: 2
+      maxConsecutiveHitsIncreasePerLevel: 2
     agility:
       enabled: true
       maxlevel: 5
@@ -856,7 +885,7 @@ skills:
     bloodthirst:
       enabled: true
       maxlevel: 3
-      baseHealthPercent: 0.30
+      baseHealthPercent: 0.3
       healthPercentIncreasePerLevel: 0.05
       speedStrength: 1
     soulharvest:
@@ -956,6 +985,7 @@ skills:
       maxChargesIncreasePerLevel: 0
       rechargeSeconds: 10.0
       rechargeSecondsDecreasePerLevel: 1.0
+      healthPerEnemyHitIncreasePerLevel: 0.0
     frailty:
       enabled: true
       maxlevel: 3
@@ -1004,6 +1034,7 @@ skills:
       enabled: true
       maxlevel: 3
       percentagePerLevel: 0.15
+      basePercentage: 0.2
     resistance:
       enabled: true
       maxlevel: 3


### PR DESCRIPTION
All Mage active toggle passives now correctly use config values in terms of seconds. Energy draining is now consistent across all skills. Config values are updated to keep the same effect they had previously. Add energyStartCost config, which is the cost for activating the skill.

Arctic armour now updates at the same rate as other active toggle passives.
Arctic armour now has a start cost.

Fixes #751

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
