### PR TITLE
Fix clan rename

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -101,6 +101,12 @@ public class ClanManager extends Manager<Clan> {
         ClanPerkManager.getInstance().init();
     }
 
+    public void updateClanName(String oldClan, Clan clan) {
+        getRepository().updateClanName(clan);
+        objects.remove(oldClan);
+        addObject(clan.getName(), clan);
+    }
+
     public Optional<Clan> getClanById(UUID id) {
         return objects.values().stream().filter(clan -> clan.getId().equals(id)).findFirst();
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/RenameSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/RenameSubCommand.java
@@ -68,7 +68,7 @@ public class RenameSubCommand extends ClanSubCommand {
             clan.setName(clanName);
             clientManager.sendMessageToRank("Clans", UtilMessage.deserialize("<yellow>%s<gray> has renamed a clan from <yellow>%s<gray> to <yellow>%s<gray>!",
                     client.getName(), oldName, clanName), Rank.ADMIN);
-            clanManager.getRepository().updateClanName(clan);
+            clanManager.updateClanName(oldName, clan);
 
             log.info("{} has renamed a clan from {} to {}!", client.getName(), oldName, clanName)
                     .setAction("CLAN_RENAME").addClientContext(client, false).addClanContext(clan).submit();


### PR DESCRIPTION
Fix clan rename by removing the old clan in the manager, and adding it back under the new name

Fixes #749

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
