### PR TITLE
Fix Clan Home existing in unclaimed territory

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
@@ -128,6 +128,11 @@ public class ClanEventListener extends ClanListener {
         clanManager.getRepository().deleteClanTerritory(targetClan, chunkString);
         targetClan.getTerritory().removeIf(territory -> territory.getChunk().equals(UtilWorld.chunkToFile(chunk)));
 
+        if (targetClan.getHome().getChunk().equals(chunk)) {
+            targetClan.setHome(null);
+            targetClan.messageClan("Your clan home was destroyed!", null, true);
+        }
+
         log.info("{} ({}) unclaimed {} from {} ({})", event.getPlayer().getName(), event.getPlayer().getUniqueId(),
                         chunkToPrettyString, targetClan.getName(), targetClan.getId())
                 .setAction("CLAN_UNCLAIM").addClientContext(event.getPlayer()).addClanContext(targetClan).

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanEventListener.java
@@ -129,7 +129,12 @@ public class ClanEventListener extends ClanListener {
         targetClan.getTerritory().removeIf(territory -> territory.getChunk().equals(UtilWorld.chunkToFile(chunk)));
 
         if (targetClan.getHome().getChunk().equals(chunk)) {
+            Block block = targetClan.getHome().clone().subtract(0, 0.6, 0).getBlock();
+            if (block.getType() == Material.RED_BED) {
+                block.setType(Material.AIR);
+            }
             targetClan.setHome(null);
+
             targetClan.messageClan("Your clan home was destroyed!", null, true);
         }
 


### PR DESCRIPTION
If the chunk with the clanhome is unclaimed, sets the home to null and alerts the clan

Fixes #773

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
