### PR TITLE
#417 - Fix movement legends

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChannelSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChannelSkill.java
@@ -56,6 +56,8 @@ public abstract class ChannelSkill extends Skill implements Listener {
 
     @EventHandler
     public void onEnterWater(PlayerMoveEvent event) {
+        if(!event.hasChangedPosition()) return;
+
         if (UtilBlock.isInWater(event.getPlayer()) && !canUseInLiquid()) {
             cancel(event.getPlayer());
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
@@ -25,21 +25,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
-import java.util.HashSet;
-import java.util.Set;
 
 @Singleton
 @BPvPListener
@@ -49,6 +44,7 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
 
     private double bonusDamage;
     private double velocityStrength;
+    private double skimmingEnergyMultiplier;
 
     private final EnergyHandler energyHandler;
     private final ClientManager clientManager;
@@ -111,7 +107,12 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
                 return false;
             }
 
-            if (!energyHandler.use(player, ABILITY_NAME, energyPerTick, true)) {
+            var energyToUse = energyPerTick;
+            if(!UtilBlock.isWater(player.getEyeLocation().getBlock().getRelative(BlockFace.DOWN))) {
+                energyToUse *= skimmingEnergyMultiplier;
+            }
+
+            if (!energyHandler.use(player, ABILITY_NAME, energyToUse, true)) {
                 activeUsageNotifications.remove(player.getUniqueId());
                 return true;
             }
@@ -178,5 +179,6 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
     public void loadWeaponConfig() {
         bonusDamage = getConfig("bonusDamage", 4.0, Double.class);
         velocityStrength = getConfig("velocityStrength", 1.0, Double.class);
+        skimmingEnergyMultiplier = getConfig("skimmingEnergyMultiplier", 3.0, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
@@ -98,7 +98,6 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
             }
 
             if (!canUse(player)) {
-                iterator.remove();
                 continue;
             }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
@@ -47,8 +47,6 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
 
     private static final String ABILITY_NAME = "Gator Stroke";
 
-    private final Set<UUID> activeUsageNotifications = new HashSet<>();
-
     private double bonusDamage;
     private double velocityStrength;
 
@@ -79,20 +77,6 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
     @Override
     public void activate(Player player) {
         active.add(player.getUniqueId());
-    }
-
-    @Override
-    @EventHandler
-    public void onDeath(PlayerDeathEvent event) {
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
-        active.remove(event.getPlayer().getUniqueId());
-    }
-
-    @Override
-    @EventHandler
-    public void onQuit(PlayerQuitEvent event) {
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
-        active.remove(event.getPlayer().getUniqueId());
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
@@ -47,7 +47,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.RayTraceResult;
@@ -58,9 +57,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -234,7 +230,7 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
         UtilVelocity.velocity(hit, caster, velocityData);
     }
 
-    @UpdateEvent
+    @UpdateEvent (priority = 100)
     public void doThunderclapAegis() {
         if (!enabled) {
             return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
@@ -272,7 +272,6 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
             }
 
             if (!canUse(player)) {
-                iterator.remove();
                 deactivate(data);
                 continue;
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
@@ -72,7 +72,6 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
     private static final String COLLISION_NAME = "Voltic Bash";
     private static final String ABILITY_NAME = "Charge";
 
-    private final Set<UUID> activeUsageNotifications = new HashSet<>();
     private final WeakHashMap<Player, AegisData> cache = new WeakHashMap<>();
     private final Champions champions;
     private final ClientManager clientManager;
@@ -366,13 +365,6 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
         if (remove != null) {
             deactivate(remove);
         }
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
-    }
-
-    @Override
-    @EventHandler
-    public void onDeath(PlayerDeathEvent event) {
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.LOW)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/ThunderclapAegis.java
@@ -47,6 +47,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.RayTraceResult;
@@ -57,6 +58,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -66,7 +70,9 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
 
     private static final String PULSE_NAME = "Pulsating Surge";
     private static final String COLLISION_NAME = "Voltic Bash";
+    private static final String ABILITY_NAME = "Charge";
 
+    private final Set<UUID> activeUsageNotifications = new HashSet<>();
     private final WeakHashMap<Player, AegisData> cache = new WeakHashMap<>();
     private final Champions champions;
     private final ClientManager clientManager;
@@ -115,7 +121,7 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
         lore.add(Component.text("their fury, rends adversaries with", NamedTextColor.WHITE));
         lore.add(Component.text("divine energy.", NamedTextColor.WHITE));
         lore.add(Component.text(""));
-        lore.add(UtilMessage.deserialize("<yellow>Right-Click <white>to use <green>Charge"));
+        lore.add(UtilMessage.deserialize("<yellow>Right-Click <white>to use <green>%s", ABILITY_NAME));
         return lore;
     }
 
@@ -229,8 +235,8 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
         UtilVelocity.velocity(hit, caster, velocityData);
     }
 
-    @UpdateEvent (priority = 100)
-    public void doCharge() {
+    @UpdateEvent
+    public void doThunderclapAegis() {
         if (!enabled) {
             return;
         }
@@ -245,9 +251,10 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
                 continue;
             }
 
-            if (!matches(player.getInventory().getItemInMainHand())) {
+            if (!isHoldingWeapon(player)) {
                 iterator.remove();
                 deactivate(data);
+                activeUsageNotifications.remove(player.getUniqueId());
                 continue;
             }
 
@@ -255,6 +262,7 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
             if (!gamer.isHoldingRightClick()) {
                 iterator.remove();
                 deactivate(data);
+                activeUsageNotifications.remove(player.getUniqueId());
                 continue;
             }
 
@@ -262,6 +270,7 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
             if (checkUsageEvent.isCancelled()) {
                 iterator.remove();
                 deactivate(data);
+                activeUsageNotifications.remove(player.getUniqueId());
                 UtilMessage.simpleMessage(player, "Restriction", "You cannot use this weapon here.");
                 continue;
             }
@@ -276,9 +285,10 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
                 continue;
             }
 
-            if (!energyHandler.use(player, "Charge", energyPerTick, true)) {
+            if (!energyHandler.use(player, ABILITY_NAME, energyPerTick, true)) {
                 iterator.remove();
                 deactivate(data);
+                activeUsageNotifications.remove(player.getUniqueId());
                 return;
             }
 
@@ -287,16 +297,16 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
             // Get all enemies that collide with the player from the last location to the new location
             final Location newLocation = UtilPlayer.getMidpoint(player);
             final List<LivingEntity> collisions = UtilEntity.interpolateMultiCollision(data.getLastLocation(),
-                            newLocation,
-                            0.6f,
-                            ent -> {
-                                if (ent instanceof LivingEntity livingEntity) {
-                                    EntityCanHurtEntityEvent entityCanHurtEntityEvent = UtilServer.callEvent(new EntityCanHurtEntityEvent(player, livingEntity));
-                                    return entityCanHurtEntityEvent.isAllowed();
-                                }
+                    newLocation,
+                    0.6f,
+                    ent -> {
+                        if (ent instanceof LivingEntity livingEntity) {
+                            EntityCanHurtEntityEvent entityCanHurtEntityEvent = UtilServer.callEvent(new EntityCanHurtEntityEvent(player, livingEntity));
+                            return entityCanHurtEntityEvent.isAllowed();
+                        }
 
-                                return false;
-                            })
+                        return false;
+                    })
                     .stream()
                     .flatMap(MultiRayTraceResult::stream)
                     .map(RayTraceResult::getHitEntity)
@@ -356,6 +366,13 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
         if (remove != null) {
             deactivate(remove);
         }
+        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
+    }
+
+    @Override
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.LOW)
@@ -375,9 +392,13 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
     @Override
     public boolean canUse(Player player) {
         if (UtilBlock.isInLiquid(player)) {
-            UtilMessage.simpleMessage(player, "Thunderclap Aegis", "You cannot use this weapon while in water!");
+            if (!activeUsageNotifications.contains(player.getUniqueId())) {
+                UtilMessage.simpleMessage(player, getSimpleName(), String.format("You cannot use <green>%s <gray>while in water", ABILITY_NAME));
+                activeUsageNotifications.add(player.getUniqueId());
+            }
             return false;
         }
+        activeUsageNotifications.remove(player.getUniqueId());
         return true;
     }
 
@@ -388,15 +409,15 @@ public class ThunderclapAegis extends ChannelWeapon implements InteractWeapon, L
 
     @Override
     public void loadWeaponConfig() {
-        baseVelocity = getConfig("baseVelocity", 0.6, Double.class);
-        maxVelocity = getConfig("maxVelocity", 0.9, Double.class);
+        baseVelocity = getConfig("baseVelocity", 0.5, Double.class);
+        maxVelocity = getConfig("maxVelocity", 0.8, Double.class);
         maxChargeTicks = getConfig("maxChargeTicks", 60, Integer.class);
         pulseIntervalSeconds = getConfig("pulseIntervalSeconds", 1.0, Double.class);
         pulseDamage = getConfig("pulseDamage", 5.0, Double.class);
         pulseShockSeconds = getConfig("pulseShockSeconds", 0.5, Double.class);
         pulseRadius = getConfig("pulseRadius", 6.0, Double.class);
         collidePulseRadius = getConfig("collidePulseRadius", 7.0, Double.class);
-        energyOnCollide = getConfig("energyOnCollide", 12.5, Double.class);
+        energyOnCollide = getConfig("energyOnCollide", 25.0, Double.class);
         chargeDamage = getConfig("chargeDamage", 7.0, Double.class);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
@@ -45,8 +45,6 @@ public class WindBlade extends ChannelWeapon implements InteractWeapon, Legendar
 
     private static final String ABILITY_NAME = "Flight";
 
-    private final Set<UUID> activeUsageNotifications = new HashSet<>();
-
     private double velocityStrength;
     private final EnergyHandler energyHandler;
     private final ClientManager clientManager;
@@ -75,20 +73,6 @@ public class WindBlade extends ChannelWeapon implements InteractWeapon, Legendar
     @Override
     public void activate(Player player) {
         active.add(player.getUniqueId());
-    }
-
-    @Override
-    @EventHandler
-    public void onDeath(PlayerDeathEvent event) {
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
-        active.remove(event.getPlayer().getUniqueId());
-    }
-
-    @Override
-    @EventHandler
-    public void onQuit(PlayerQuitEvent event) {
-        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
-        active.remove(event.getPlayer().getUniqueId());
     }
 
     @UpdateEvent (priority = 99)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
@@ -29,15 +29,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -75,7 +70,7 @@ public class WindBlade extends ChannelWeapon implements InteractWeapon, Legendar
         active.add(player.getUniqueId());
     }
 
-    @UpdateEvent (priority = 99)
+    @UpdateEvent (priority = 100)
     public void doWindBlade() {
         if (!enabled) {
             return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/WindBlade.java
@@ -95,7 +95,7 @@ public class WindBlade extends ChannelWeapon implements InteractWeapon, Legendar
             }
 
             if (!canUse(player)) {
-                return true;
+                return false;
             }
 
             if (!energyHandler.use(player, "Wind Blade", energyPerTick, true)) {

--- a/champions/src/main/resources/configs/weapons/legendaries.yml
+++ b/champions/src/main/resources/configs/weapons/legendaries.yml
@@ -1,10 +1,11 @@
 alligators_tooth:
   enabled: true
   baseDamage: 8.0
-  energyPerTick: 1.5
+  energyPerTick: 1.0
   initialEnergyCost: 10.0
   bonusDamage: 4.0
-  velocityStrength: 1.0
+  velocityStrength: 0.7
+  skimmingEnergyMultiplier: 3.0
 wind_blade:
   enabled: true
   baseDamage: 7.0

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/weapon/types/ChannelWeapon.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/weapon/types/ChannelWeapon.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 public abstract class ChannelWeapon extends Weapon implements IWeapon, Listener {
 
+    protected final Set<UUID> activeUsageNotifications = new HashSet<>();
     protected final Set<UUID> active = new HashSet<>();
 
     public ChannelWeapon(BPvPPlugin plugin, String key) {
@@ -36,11 +37,13 @@ public abstract class ChannelWeapon extends Weapon implements IWeapon, Listener 
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
         active.remove(event.getEntity().getUniqueId());
+        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         active.remove(event.getPlayer().getUniqueId());
+        activeUsageNotifications.remove(event.getPlayer().getUniqueId());
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
@@ -78,6 +78,7 @@ public class UtilBlock {
      */
     public static boolean isInWater(Player player) {
         Block block = player.getLocation().getBlock();
+
         return isWater(block)  || player.isSwimming();
     }
 


### PR DESCRIPTION
## Describe your changes
[Before](https://youtu.be/Rv4YYhUfX_c)
[After](https://youtu.be/g8aTTsNKnjo)

Updated movements to prevent canUse from removing players from the active set. Now it just returns before draining energy/applying abilities.
Since the player is still holding right click, the channel weapon check in [WeaponListener.java](https://github.com/Mykindos/BetterPvP/blob/master/core/src/main/java/me/mykindos/betterpvp/core/combat/weapon/listeners/WeaponListener.java) prevents them from becoming active again until they toggle right-click.

Relevant code from WeaponListener:

```
if (weapon instanceof ChannelWeapon channelWeapon) {
            if (clicked.get(event.getPlayer().getUniqueId()) == weapon) {
                return; // Skip if we're currently holding click on this weapon
            }

            if (channelWeapon.getEnergy() > 0) {
                if (!energyHandler.use(player, name, channelWeapon.getEnergy(), true)) {
                    return;
                }
            }

            clicked.put(player.getUniqueId(), weapon); // Log this weapon as clicked
}

if (weapon instanceof InteractWeapon interactWeapon) {
        interactWeapon.activate(player);
}
```

To-Do:
- [x] Reduce the number of logs produced by `canUse()`
- [x] Review gameplay change for Windblade, players can now fly out the of water if they enter swim mode (Same behavior seen in other skills so I think this is a non-issue)

## Link to issue (if applicable)
Fixes #417

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
