### PR TITLE
Fix dominance using default value if size offset was too high

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -88,6 +88,10 @@ public class ClanManager extends Manager<Clan> {
     private boolean dominanceEnabled;
 
     @Inject
+    @Config(path = "clans.members.max", defaultValue = "8")
+    private int maxClanMembers;
+
+    @Inject
     public ClanManager(Clans clans, ClanRepository repository, ClientManager clientManager, PillageHandler pillageHandler, LeaderboardManager leaderboardManager) {
         this.repository = repository;
         this.clientManager = clientManager;
@@ -399,8 +403,7 @@ public class ClanManager extends Manager<Clan> {
 
     public double getDominanceForKill(int killedSquadSize, int killerSquadSize) {
 
-        int sizeOffset = Math.min(6, 6 - Math.min(killerSquadSize - killedSquadSize, 6));
-
+        int sizeOffset = Math.min(maxClanMembers, maxClanMembers - Math.min(killerSquadSize - killedSquadSize, maxClanMembers));
         return dominanceScale.getOrDefault(sizeOffset, 6D);
 
     }

--- a/clans/src/main/resources/clans-migrations/V1_1__Initial_clans.sql
+++ b/clans/src/main/resources/clans-migrations/V1_1__Initial_clans.sql
@@ -72,6 +72,7 @@ create table if not exists clans_dominance_scale
         primary key (ClanSize)
 );
 
+INSERT IGNORE INTO clans_dominance_scale VALUES (0, 3.5);
 INSERT IGNORE INTO clans_dominance_scale VALUES (1, 3.5);
 INSERT IGNORE INTO clans_dominance_scale VALUES (2, 3.5);
 INSERT IGNORE INTO clans_dominance_scale VALUES (3, 4);


### PR DESCRIPTION
Change getDominanceForKill to use the config for maxClanMembers, instead of using hardcoded 6


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
