### PR TITLE
Fix Container Break logs

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
@@ -444,7 +444,7 @@ public class UUIDListener implements Listener {
                 log.info("{} caused ({}) to be dropped from block {} at ({})", event.getPlayer().getName(),
                                 uuidItem.getUuid(), event.getBlockState().getType().name(), UtilWorld.locationToString(location))
                         .setAction("ITEM_CONTAINER_BREAK").addItemContext(uuidItem).addLocationContext(location)
-                        .addBlockContext(event.getBlock()).submit();
+                        .addBlockContext(event.getBlockState()).addClientContext(event.getPlayer()).submit();
             });
         });
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/PendingLog.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/PendingLog.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.core.items.uuiditem.UUIDItem;
 import me.mykindos.betterpvp.core.utilities.UtilWorld;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -85,6 +86,12 @@ public class PendingLog {
     public PendingLog addBlockContext(Block block) {
         context.put(LogContext.BLOCK, block.getType().name());
         context.put(LogContext.LOCATION, UtilWorld.locationToString(block.getLocation(), true, true));
+        return this;
+    }
+
+    public PendingLog addBlockContext(BlockState blockState) {
+        context.put(LogContext.BLOCK, blockState.getType().name());
+        context.put(LogContext.LOCATION, UtilWorld.locationToString(blockState.getLocation(), true, true));
         return this;
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ContainerBreakLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ContainerBreakLogFormatter.java
@@ -24,7 +24,7 @@ public class ContainerBreakLogFormatter implements ILogFormatter {
                 .append(Component.text(" caused ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN)
                         .hoverEvent(HoverEvent.showText(Component.text(context.get(LogContext.ITEM)))))
-                .append(Component.text("to be dropped from a ", NamedTextColor.GRAY))
+                .append(Component.text(" to be dropped from ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.YELLOW))
                 .append(Component.text(" at ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.LOCATION), NamedTextColor.YELLOW));

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ContainerStoreItemLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ContainerStoreItemLogFormatter.java
@@ -25,7 +25,7 @@ public class ContainerStoreItemLogFormatter implements ILogFormatter {
                 .append(Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN)
                         .hoverEvent(HoverEvent.showText(Component.text(context.get(LogContext.ITEM)))))
                 .append(Component.text(" in ", NamedTextColor.GRAY))
-                .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.GREEN))
+                .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.YELLOW))
                 .append(Component.text(" at ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.LOCATION), NamedTextColor.YELLOW));
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
@@ -27,7 +27,7 @@ public class ItemRetrieveLogFormatter implements ILogFormatter {
                 .append(Component.text(" from ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.GREEN))
                 .append(Component.text(" at ", NamedTextColor.GRAY))
-                .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.YELLOW));
+                .append(Component.text(context.get(LogContext.LOCATION), NamedTextColor.YELLOW));
 
     }
 }


### PR DESCRIPTION
Fix container break logs to include client context. Add BlockState overload for adding a block context. Using this, now correctly gets the block that was broken.

Also fixes Item retrieve logs to include location

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
