### PR TITLE
Sever nerf

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -52,7 +52,7 @@ public class Sever extends Skill implements CooldownSkill, Listener {
                 "Right click with a Sword to activate",
                 "",
                 "Inflict a <val>" + getDuration(level) + "</val> second <effect>Bleed</effect>",
-                "dealing <stat>1</stat> heart per second",
+                "dealing <stat>0.75</stat> hearts per second",
                 "",
                 "Cooldown: <val>" + getCooldown(level)
         };
@@ -136,7 +136,7 @@ public class Sever extends Skill implements CooldownSkill, Listener {
 
     @Override
     public void loadSkillConfig() {
-        baseDuration = getConfig("baseDuration", 1.0, Double.class);
+        baseDuration = getConfig("baseDuration", 2.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 1.0, Double.class);
         hitDistance = getConfig("hitDistance", 4.0, Double.class);
     }

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -16,7 +16,7 @@ skills:
       cooldown: 20.0
       maxlevel: 3
       cooldownDecreasePerLevel: 1.0
-      baseDuration: 1.0
+      baseDuration: 2.0
       durationIncreasePerLevel: 1.0
       hitDistance: 4.0
     shockingstrikes:

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/BleedEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/BleedEffect.java
@@ -46,7 +46,7 @@ public class BleedEffect extends VanillaEffectType {
         if (currentTime - lastBleedTime >= 1000 - marginOfError) {
             // Apply damage to any LivingEntity (including players)
 
-            var cde = new CustomDamageEvent(livingEntity, effect.getApplier(), null, EntityDamageEvent.DamageCause.CUSTOM, 2.0, false, "Bleed");
+            var cde = new CustomDamageEvent(livingEntity, effect.getApplier(), null, EntityDamageEvent.DamageCause.CUSTOM, 1.5, false, "Bleed");
             cde.setIgnoreArmour(true);
             UtilDamage.doCustomDamage(cde);
 


### PR DESCRIPTION
Makes sever deal 0.75 hearts per tick (down from 1)
Lasts 4 seconds (up from 3)
Total damage remains the same
