### PR TITLE
Add Basic Punish History Command

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/Punishment.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/Punishment.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import me.mykindos.betterpvp.core.client.punishments.types.IPunishmentType;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.Date;
@@ -33,7 +34,6 @@ public class Punishment {
     }
 
     /**
-     *
      * @return The formatted information about the punishment
      */
     public Component getInformation() {
@@ -44,4 +44,23 @@ public class Punishment {
         return UtilMessage.deserialize("You are <red>%s</red> for <green>%s</green> for <yellow>%s</yellow>", this.type.getChatLabel(), formattedTime, this.getReason());
     }
 
+    /**
+     * @return the formatted punishment information
+     */
+    public Component getPunishmentInformation() {
+        Component currentComp;
+        if (this.isActive()) {
+            currentComp = Component.text("ACTIVE", NamedTextColor.GREEN);
+        } else if (revoked) {
+            currentComp = Component.text("REVOKED", NamedTextColor.LIGHT_PURPLE);
+        } else {
+            currentComp = Component.text("INACTIVE", NamedTextColor.RED);
+        }
+
+        Component component = Component.empty().append(currentComp).appendSpace()
+                .append(Component.text(this.type.getName(), NamedTextColor.WHITE)).appendSpace()
+                .append(Component.text(reason == null ? "No Reason" : reason, NamedTextColor.GRAY)).appendSpace()
+                .append(Component.text(punisher == null ? "SERVER" : punisher, NamedTextColor.AQUA));
+        return component;
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentHistoryCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentHistoryCommand.java
@@ -1,0 +1,93 @@
+package me.mykindos.betterpvp.core.client.punishments.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.punishments.Punishment;
+import me.mykindos.betterpvp.core.client.punishments.PunishmentRepository;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Comparator;
+
+@Singleton
+@CustomLog
+@SubCommand(PunishCommand.class)
+public class PunishmentHistoryCommand extends Command implements IConsoleCommand {
+
+    private final ClientManager clientManager;
+
+    @Inject
+    public PunishmentHistoryCommand(ClientManager clientManager, PunishmentRepository punishmentRepository) {
+        this.clientManager = clientManager;
+        aliases.add("h");
+    }
+
+    @Override
+    public String getName() {
+        return "history";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Punish History Command";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        if (args.length < 1) {
+            UtilMessage.message(player, "Punish", "Usage: /punish history <name>");
+            return;
+        }
+
+        clientManager.search().offline(args[0], clientOptional -> {
+            if (clientOptional.isPresent()) {
+                Client target = clientOptional.get();
+
+                processHistory(player, target);
+            } else {
+                UtilMessage.message(player, "Punish", "Could not find a client with this name.");
+            }
+        });
+
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length < 1) {
+            UtilMessage.message(sender, "Punish", "Usage: /punish add <type> <player> <time> <unit> [reason...]");
+            return;
+        }
+
+        clientManager.search().offline(args[0], clientOptional -> {
+            if (clientOptional.isPresent()) {
+                Client target = clientOptional.get();
+
+                processHistory(sender, target);
+            } else {
+                UtilMessage.message(sender, "Punish", "Could not find a client with this name.");
+            }
+        });
+    }
+
+    protected void processHistory(CommandSender sender, Client target) {
+        UtilMessage.message(sender, "Punish", "Punishment History for <yellow>%s</yellow>", target.getName());
+        target.getPunishments().sort(Comparator.comparingLong(Punishment::getExpiryTime).reversed());
+        target.getPunishments().forEach(punishment -> {
+            UtilMessage.message(sender, "", punishment.getPunishmentInformation());
+        });
+    }
+    @Override
+    public String getArgumentType(int i) {
+        if (i == 1) {
+            return ArgumentType.PLAYER.name();
+        }
+        return ArgumentType.NONE.name();
+    }
+}


### PR DESCRIPTION
Add basic punish history command. There isn't as much information as I'd like in it, but it's not worth adding that in during kit map. This will allow a temporary solution to allow admins to easily view the punish history of an account.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
