### PR TITLE
smokebomb cooldown reduction

### DIFF
--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -41,7 +41,7 @@ skills:
       increasePerLevel: 1.5
     smokebomb:
       enabled: true
-      cooldown: 50.0
+      cooldown: 40.0
       maxlevel: 5
       baseDuration: 3.0
       blindDuration: 1.75


### PR DESCRIPTION
- Sets smokebomb cooldown to 40 (down from 50)
- This seems like a buff but its honestly more of a QOL, frequently you'll use the ability and finish a fight, go store and go back outside and then its still on cooldown