### PR TITLE
Punishment temp changes

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/Punishment.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/Punishment.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.core.client.punishments.types.IPunishmentType;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.Date;
@@ -60,7 +61,7 @@ public class Punishment {
         Component component = Component.empty().append(currentComp).appendSpace()
                 .append(Component.text(this.type.getName(), NamedTextColor.WHITE)).appendSpace()
                 .append(Component.text(reason == null ? "No Reason" : reason, NamedTextColor.GRAY)).appendSpace()
-                .append(Component.text(punisher == null ? "SERVER" : punisher, NamedTextColor.AQUA));
+                .append(Component.text(punisher == null ? "SERVER" : Bukkit.getOfflinePlayer(UUID.fromString(punisher)).getName(), NamedTextColor.AQUA));
         return component;
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentAddCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentAddCommand.java
@@ -129,7 +129,7 @@ public class PunishmentAddCommand extends Command implements IConsoleCommand {
             reason = String.join(" ", Arrays.copyOfRange(args, 4, args.length));
         }
 
-        if (reason.equals("")) {
+        if (reason.isEmpty()) {
             UtilMessage.message(sender, "Punish", "You must include a reason for a punishment");
             return;
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentAddCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/commands/PunishmentAddCommand.java
@@ -14,6 +14,7 @@ import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.IConsoleCommand;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -47,13 +48,13 @@ public class PunishmentAddCommand extends Command implements IConsoleCommand {
 
     @Override
     public String getDescription() {
-        return "Base punishment command";
+        return "Add a punishment to a player";
     }
 
     @Override
     public void execute(Player player, Client client, String... args) {
         if (args.length < 3) {
-            UtilMessage.message(player, "Command", "Usage: /punish add <type> <player> <time> [unit] [reason...]");
+            UtilMessage.message(player, "Command", "Usage: /punish add <type> <player> [<time> <unit> | perm] <reason...>");
             return;
         }
 
@@ -128,6 +129,11 @@ public class PunishmentAddCommand extends Command implements IConsoleCommand {
             reason = String.join(" ", Arrays.copyOfRange(args, 4, args.length));
         }
 
+        if (reason.equals("")) {
+            UtilMessage.message(sender, "Punish", "You must include a reason for a punishment");
+            return;
+        }
+
         String formattedTime = new PrettyTime().format(new Date(time)).replace(" from now", "");
 
         Punishment punishment = new Punishment(UUID.randomUUID(), target.getUniqueId(), type, time, reason, punisher != null ? punisher.getUniqueId().toString() : null);
@@ -159,7 +165,15 @@ public class PunishmentAddCommand extends Command implements IConsoleCommand {
         }
 
         if (!reason.isEmpty()) {
-            UtilMessage.broadcast("Punish", "<red>Reason<reset>: <reset>%s", reason);
+            Player targetPlayer = Bukkit.getPlayer(target.getUniqueId());
+            Component reasonComponent = UtilMessage.deserialize("<red>Reason<reset>: <reset>%s", reason);
+
+            if (targetPlayer != null) {
+                UtilMessage.message(targetPlayer, "Punish", reasonComponent);
+            }
+
+            clientManager.sendMessageToRank("Punish", reasonComponent, Rank.HELPER);
+
         }
 
     }


### PR DESCRIPTION
Some temporary QOL changes for punishment. Now show player name instead of UUID in punish history. Prevent players from seeing reason on punish (allows for exact reasons for punishments, specifically for mutes), force a reason to be added for punishments (for later use).

Fixes #839
Fixes #840

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
