### PR TITLE
Fix certain passive abilities activating on killing Swarm bats from a Mage

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Bloodlust.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Bloodlust.java
@@ -75,6 +75,7 @@ public class Bloodlust extends Skill implements PassiveSkill {
 
     @EventHandler
     public void onDeath(EntityDeathEvent event) {
+        if (event.getEntity() instanceof Bat) return;
         DamageLog lastDamager = damageLogManager.getLastDamager(event.getEntity());
         if (lastDamager == null) return;
         if (!(lastDamager.getDamager() instanceof Player player)) return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
@@ -80,6 +80,7 @@ public class Cleave extends Skill implements PassiveSkill, Listener {
     public void onCustomDamage(CustomDamageEvent event) {
         if (event.isCancelled()) return;
         if (event.getCause() != DamageCause.ENTITY_ATTACK) return;
+        if (event.getDamagee() instanceof Bat) return;
         if (!(event.getDamager() instanceof Player damager)) return;
         if (!SkillWeapons.isHolding(damager, SkillType.AXE)) return;
         if (event.hasReason(getName())) return; // Don't get stuck in an endless damage loop

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/NullBlade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/NullBlade.java
@@ -46,6 +46,8 @@ public class NullBlade extends Skill implements PassiveSkill, EnergySkill {
     @EventHandler
     public void onDamage(CustomDamageEvent event) {
         if (event.getCause() != DamageCause.ENTITY_ATTACK) return;
+        
+        if (event.getDamagee() instanceof Bat) return;
 
         if (!(event.getDamager() instanceof Player dam)) return;
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/SoulHarvest.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/SoulHarvest.java
@@ -78,6 +78,7 @@ public class SoulHarvest extends Skill implements PassiveSkill {
 
     @EventHandler
     public void onDeath(EntityDeathEvent event) {
+        if (event.getEntity() instanceof Bat) return;
         souls.add(new SoulData(event.getEntity().getUniqueId(), event.getEntity().getLocation(), System.currentTimeMillis() + 120_000));
     }
 


### PR DESCRIPTION
Added checks within Null Blade, Bloodlust, Soul Harvest, and Cleave to not activate when attacking Bats, therefore removing the bugs where you can kill Swarm bats to activate these abilities.

I decided to not make the bats invincible so players could still theoretically use abilities to break through the swarm of bats to reach mage players.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
