### PR TITLE
Blood Barrier Nerf

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
@@ -215,14 +215,14 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
         baseHealthReduction = getConfig("baseHealthReduction", 0.5, Double.class);
         healthReductionDecreasePerLevel = getConfig("healthReductionDecreasePerLevel", 0.05, Double.class);
 
-        baseDuration = getConfig("baseDuration", 60.0, Double.class);
+        baseDuration = getConfig("baseDuration", 30.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 0.0, Double.class);
 
-        baseDamageReduction = getConfig("damageReduction", 0.30, Double.class);
+        baseDamageReduction = getConfig("damageReduction", 0.90, Double.class);
         damageReductionPerLevel = getConfig("damageReductionPerLevel", 0.0, Double.class);
 
 
-        baseNumAttacksToReduce = getConfig("baseNumAttacksToReduce", 3, Integer.class);
+        baseNumAttacksToReduce = getConfig("baseNumAttacksToReduce", 1, Integer.class);
         numAttacksToReducePerLevel = getConfig("numAttacksToReducePerLevel", 0, Integer.class);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
@@ -212,7 +212,7 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
         baseRange = getConfig("baseRange", 8.0, Double.class);
         rangeIncreasePerLevel = getConfig("rangeIncreasePerLevel", 1.0, Double.class);
 
-        baseHealthReduction = getConfig("baseHealthReduction", 0.5, Double.class);
+        baseHealthReduction = getConfig("baseHealthReduction", 0.4, Double.class);
         healthReductionDecreasePerLevel = getConfig("healthReductionDecreasePerLevel", 0.05, Double.class);
 
         baseDuration = getConfig("baseDuration", 30.0, Double.class);

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -856,20 +856,17 @@ skills:
       enabled: true
       maxlevel: 5
       cooldown: 30.0
-      damageReduction: 0.3
-      numAttacksToReduce: 3
+      damageReduction: 0.9
       cooldownDecreasePerLevel: 2.0
       baseRange: 8.0
       rangeIncreasePerLevel: 1.0
-      baseHealthReduction: 0.5
+      baseHealthReduction: 0.4
       healthReductionDecreasePerLevel: 0.05
-      baseDuration: 60.0
+      baseDuration: 30.0
       durationIncreasePerLevel: 0.0
       damageReductionPerLevel: 0.0
-      baseNumAttacksToReduce: 3
+      baseNumAttacksToReduce: 1
       numAttacksToReducePerLevel: 0
-      range: 8
-      duration: 60.0
     bloodshed:
       enabled: true
       maxlevel: 5


### PR DESCRIPTION
- Make it reduce 1 hit by 90% instead of 3 hits by 30%
- Reduce duration to 30 seconds (down from 60)
- Decrease base health consumed to 4 hearts (down from 5 hearts)
