### PR TITLE
Fix NPE in ItemRetrieveLogFormatter

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
@@ -329,7 +329,7 @@ public class UUIDListener implements Listener {
                 assert location != null;
                 log.info("{} retrieved ({}) from {} at ({})", player.getName(), item.getUuid(),
                                 Objects.requireNonNull(inventory).getType().name(), UtilWorld.locationToString(location))
-                        .setAction("ITEM_RETRIEVE").addClientContext(player).addLocationContext(location).addItemContext(item).submit();
+                        .setAction("ITEM_RETRIEVE").addClientContext(player).addLocationContext(location).addItemContext(item).addBlockContext(location.getBlock()).submit();
 
                 lastHeldUUIDItem.remove(player);
                 lastInventory.remove(player);

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.logging.formatters.items;
 
+import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.framework.annotations.WithReflection;
 import me.mykindos.betterpvp.core.logging.LogContext;
 import me.mykindos.betterpvp.core.logging.formatters.ILogFormatter;
@@ -10,6 +11,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import java.util.HashMap;
 
 @WithReflection
+@Slf4j
 public class ItemRetrieveLogFormatter implements ILogFormatter {
 
     @Override
@@ -17,15 +19,17 @@ public class ItemRetrieveLogFormatter implements ILogFormatter {
         return "ITEM_RETRIEVE";
     }
 
-
     @Override
     public Component formatLog(HashMap<String, String> context) {
+
+        log.info(context.toString());
+        log.info(context.get(LogContext.LOCATION));
         return Component.text(context.get(LogContext.CLIENT_NAME), NamedTextColor.YELLOW)
                 .append(Component.text(" retrieved ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN)
                         .hoverEvent(HoverEvent.showText(Component.text(context.get(LogContext.ITEM)))))
                 .append(Component.text(" from ", NamedTextColor.GRAY))
-                .append(Component.text(context.get(LogContext.BLOCK), NamedTextColor.GREEN))
+                .append(Component.text(context.get(LogContext.BLOCK) == null ? "NULL" : context.get(LogContext.BLOCK), NamedTextColor.GREEN))
                 .append(Component.text(" at ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.LOCATION), NamedTextColor.YELLOW));
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemRetrieveLogFormatter.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.core.logging.formatters.items;
 
-import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.framework.annotations.WithReflection;
 import me.mykindos.betterpvp.core.logging.LogContext;
 import me.mykindos.betterpvp.core.logging.formatters.ILogFormatter;
@@ -11,7 +10,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import java.util.HashMap;
 
 @WithReflection
-@Slf4j
 public class ItemRetrieveLogFormatter implements ILogFormatter {
 
     @Override
@@ -22,8 +20,6 @@ public class ItemRetrieveLogFormatter implements ILogFormatter {
     @Override
     public Component formatLog(HashMap<String, String> context) {
 
-        log.info(context.toString());
-        log.info(context.get(LogContext.LOCATION));
         return Component.text(context.get(LogContext.CLIENT_NAME), NamedTextColor.YELLOW)
                 .append(Component.text(" retrieved ", NamedTextColor.GRAY))
                 .append(Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN)


### PR DESCRIPTION
Fixed there not always being block associated with a retrieve log. Add a fix to allow current logs to be read.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
