### PR TITLE
Slash QoL, fix target selection, fix Sever

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -120,7 +120,7 @@ public class Sever extends Skill implements CooldownSkill, Listener, OffensiveSk
         }
 
         boolean withinRange = UtilMath.offset(player, ent) <= hitDistance;
-        if (UtilPlayer.isCreativeOrSpectator(ent) || UtilEntity.getRelation(player, ent) != EntityProperty.ENEMY || !withinRange) {
+        if (UtilPlayer.isCreativeOrSpectator(ent) || UtilEntity.getRelation(player, ent) == EntityProperty.FRIENDLY || !withinRange) {
             UtilMessage.simpleMessage(player, getClassType().getName(), "You failed <green>%s %s", getName(), level);
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 0.5F);
         } else {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -56,7 +56,7 @@ public class UtilEntity {
     }
 
     public static final BiPredicate<Player, Entity> IS_ENEMY = (player, entity) -> {
-        if (!(entity instanceof LivingEntity) || entity.equals(player)) {
+        if (!(entity instanceof LivingEntity) || entity.equals(player) || UtilPlayer.isCreativeOrSpectator(entity)) {
             return false;
         }
 


### PR DESCRIPTION
## Describe your changes
- [Make UtilEntity.IS_ENEMY ignore players in creative/spectator](https://github.com/Mykindos/BetterPvP/commit/b9ded139ea8ef0b2e64f4d2cdd943de40750ded8)
- [QoL slash changes and fix target selection](https://github.com/Mykindos/BetterPvP/commit/79069b00a8fb041bee4c75fbe5591082f50ea759)
- [Allow sever to hit entities](https://github.com/Mykindos/BetterPvP/commit/6fd015d94d804a005968a6d278d2c8cb6e21098e)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
