### PR TITLE
new getNearbyEntities boolean

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -108,7 +108,7 @@ public class SmokeBomb extends Skill implements CooldownToggleSkill, Listener, D
         // Effects
         championsManager.getEffects().addEffect(player, EffectTypes.VANISH, getName(), 1, (long) (getDuration(level) * 1000L));
         smoked.put(player.getUniqueId(), System.currentTimeMillis());
-        for (Player target : UtilPlayer.getNearbyEnemies(player, player.getLocation(), blindRadius)) {
+        for (Player target : UtilPlayer.getNearbyEnemies(player, player.getLocation(), blindRadius, true)) {
             championsManager.getEffects().addEffect(target, player, EffectTypes.BLINDNESS, 1, (long) (blindDuration * 1000L));
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Intimidation.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Intimidation.java
@@ -102,7 +102,7 @@ public class Intimidation extends Skill implements PassiveSkill, DebuffSkill {
 
     public void intimidateNearby(Player player, int level, boolean sounds) {
         double radius = getRadius(level);
-        List<Player> nearbyEnemies = UtilPlayer.getNearbyEnemies(player, player.getLocation(), radius);
+        List<Player> nearbyEnemies = UtilPlayer.getNearbyEnemies(player, player.getLocation(), radius, true);
         trackedEnemies.get(player).removeIf(enemy -> {
             final boolean remove = !nearbyEnemies.contains(enemy);
             if (remove) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Cleave.java
@@ -89,7 +89,7 @@ public class Cleave extends Skill implements PassiveSkill, Listener, OffensiveSk
         int level = getLevel(damager);
         int enemiesHit = 0;
         if (level > 0) {
-            for (var target : UtilEntity.getNearbyEntities(damager, event.getDamagee().getLocation(), getDistance(level), EntityProperty.ENEMY)) {
+            for (var target : UtilEntity.getNearbyEntities(damager, event.getDamagee().getLocation(), getDistance(level), EntityProperty.ENEMY, true)) {
                 if (target.get().equals(event.getDamagee())) continue;
                 if (enemiesHit >= getMaxEnemiesHit(level)) continue;
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
@@ -97,7 +97,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
         player.playSound(player, Sound.ENTITY_VILLAGER_WORK_CLERIC, 1f, 0.8f);
         if (playerMaxHealth != null) {
             UtilPlayer.health(player, 4d * healthBoostStrength);
-            for (Player target : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRadius(level))) {
+            for (Player target : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRadius(level), true)) {
 
                 championsManager.getEffects().addEffect(target, player, EffectTypes.HEALTH_BOOST, healthBoostStrength, (long) (getDuration(level) * 1000L));
                 AttributeInstance targetMaxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
@@ -153,7 +153,7 @@ public class FireBlast extends Skill implements InteractSkill, CooldownSkill, Li
                 return;
             }
 
-            final List<KeyValue<LivingEntity, EntityProperty>> nearby = UtilEntity.getNearbyEntities(shooter, largeFireball.getLocation(), getRadius(level), EntityProperty.ALL);
+            final List<KeyValue<LivingEntity, EntityProperty>> nearby = UtilEntity.getNearbyEntities(shooter, largeFireball.getLocation(), getRadius(level), EntityProperty.ALL, true);
 
             new ParticleBuilder(Particle.EXPLOSION_LARGE)
                     .location(largeFireball.getLocation())

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
@@ -125,7 +125,7 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
         int level = getLevel(playerThrower);
         if (level > 0) {
             int count = 0;
-            for (LivingEntity ent : UtilEntity.getNearbyEnemies(playerThrower, throwableItem.getItem().getLocation(), getSpreadDistance(level))) {
+            for (LivingEntity ent : UtilEntity.getNearbyEnemies(playerThrower, throwableItem.getItem().getLocation(), getSpreadDistance(level), true)) {
 
                 if (count >= maxTargets) continue;
                 throwableItem.getImmunes().add(ent);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Rupture.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Rupture.java
@@ -182,7 +182,7 @@ public class Rupture extends Skill implements Listener, InteractSkill, CooldownS
 
                     stands.put(armourStand, System.currentTimeMillis() + 4000);
 
-                    for (LivingEntity ent : UtilEntity.getNearbyEnemies(player, armourStand.getLocation(), 1)) {
+                    for (LivingEntity ent : UtilEntity.getNearbyEnemies(player, armourStand.getLocation(), 1, true)) {
 
                         if (!cooldownJump.get(player).contains(ent)) {
                             VelocityData velocityData = new VelocityData(player.getLocation().getDirection(), 0.5, false, 0.0, 1.0, 2.0, false);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/ArcticArmour.java
@@ -124,7 +124,7 @@ public class ArcticArmour extends ActiveToggleSkill implements EnergySkill, Defe
         }
 
         // Apply resistance and slow effects
-        final List<KeyValue<Player, EntityProperty>> nearby = UtilPlayer.getNearbyPlayers(player, distance);
+        final List<KeyValue<Player, EntityProperty>> nearby = UtilPlayer.getNearbyPlayers(player, distance, true);
         nearby.add(new KeyValue<>(player, EntityProperty.FRIENDLY));
         for (KeyValue<Player, EntityProperty> nearbyEnt : nearby) {
             final Player target = nearbyEnt.getKey();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/HolyLight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/HolyLight.java
@@ -74,7 +74,7 @@ public class HolyLight extends Skill implements PassiveSkill, HealthSkill, TeamS
 
     private void activate(Player player, int level) {
         championsManager.getEffects().addEffect(player, EffectTypes.REGENERATION, getName(), regenerationStrength, (long) getDuration(level) * 1000, true);
-        for (var target : UtilPlayer.getNearbyPlayers(player, player.getLocation(), getRadius(level), EntityProperty.FRIENDLY)) {
+        for (var target : UtilPlayer.getNearbyPlayers(player, player.getLocation(), getRadius(level), EntityProperty.FRIENDLY, true)) {
             championsManager.getEffects().addEffect(target.getKey(), player, EffectTypes.REGENERATION, getName(), regenerationStrength, (long) getDuration(level) * 1000, true);
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/LifeBonds.java
@@ -135,7 +135,7 @@ public class LifeBonds extends ActiveToggleSkill implements EnergySkill, HealthS
     }
 
     private void findAndHealLowestHealthPlayer(Player caster, int level, double distance) {
-        List<KeyValue<Player, EntityProperty>> nearbyPlayerKeyValues = UtilPlayer.getNearbyPlayers(caster, caster.getLocation(), distance, EntityProperty.FRIENDLY);
+        List<KeyValue<Player, EntityProperty>> nearbyPlayerKeyValues = UtilPlayer.getNearbyPlayers(caster, caster.getLocation(), distance, EntityProperty.FRIENDLY, true);
         createParticlesForPlayers(caster, nearbyPlayerKeyValues);
 
         Player highestHealthPlayer = caster;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
@@ -194,7 +194,7 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
 
         boolean playerHasRole = championsManager.getRoles().hasRole(player);
         shieldDataMap.put(player.getUniqueId(), new ShieldData((long) (getDuration(level) * 1000), numAttacksToReduce(level), getDamageReduction(level), playerHasRole));
-        for (Player ally : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRange(level))) {
+        for (Player ally : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRange(level), true)) {
             boolean allyHasRole = championsManager.getRoles().hasRole(ally);
             shieldDataMap.put(ally.getUniqueId(), new ShieldData((long) (getDuration(level) * 1000), numAttacksToReduce(level), getDamageReduction(level), allyHasRole));
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -97,7 +97,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_RAVAGER_ROAR, 2.0f, 0.3f);
         player.playSound(player.getLocation(), Sound.BLOCK_CONDUIT_AMBIENT, 2.0f, 2.0f);
 
-        for (Player target : UtilPlayer.getNearbyAllies(player, player.getLocation(), (radius + level))) {
+        for (Player target : UtilPlayer.getNearbyAllies(player, player.getLocation(), (radius + level), true)) {
             championsManager.getEffects().addEffect(target, EffectTypes.SPEED, speedStrength, (long) (duration * 1000));
             UtilMessage.simpleMessage(target, getName(), "<yellow>%s</yellow> gave you <white>Speed "+ UtilFormat.getRomanNumeral(speedStrength) + "</white> for <green>%s</green> seconds.", player.getName(), getDuration(level));
             player.playSound(player.getLocation(), Sound.BLOCK_CONDUIT_AMBIENT, 2.0f, 2.0f);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -111,7 +111,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_EVOKER_PREPARE_WOLOLO, 1.0f, 0.9f);
         championsManager.getEffects().addEffect(player, EffectTypes.IMMUNE, (long) (getDuration(level) * 1000L));
 
-        for (Player ally : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRange(level))) {
+        for (Player ally : UtilPlayer.getNearbyAllies(player, player.getLocation(), getRange(level), true)) {
             championsManager.getEffects().addEffect(ally, EffectTypes.IMMUNE, (long) (getDuration(level) * 1000L));
             UtilMessage.simpleMessage(ally, "Cleanse", "You were cleansed of negative by <alt>" + player.getName());
             UtilServer.callEvent(new EffectClearEvent(ally));

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
@@ -106,7 +106,7 @@ public class TormentedSoil extends Skill implements InteractSkill, CooldownSkill
             if (!torment.getLocation().getWorld().equals(event.getDamagee().getLocation().getWorld())) {
                 return;
             }
-            for (LivingEntity target : UtilEntity.getNearbyEnemies(torment.getCaster(), torment.getLocation(), getRange(torment.getLevel()))) {
+            for (LivingEntity target : UtilEntity.getNearbyEnemies(torment.getCaster(), torment.getLocation(), getRange(torment.getLevel()), true)) {
                 if (target.equals(event.getDamagee())) {
                     event.setDamage(event.getDamage() * (1 + getDamageIncrease(torment.getLevel())));
                     return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Siphon.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/Siphon.java
@@ -80,7 +80,7 @@ public class Siphon extends Skill implements PassiveSkill, MovementSkill, BuffSk
         for (Player player : Bukkit.getOnlinePlayers()) {
             int level = getLevel(player);
             if (level > 0) {
-                for (LivingEntity target : UtilEntity.getNearbyEnemies(player, player.getLocation(), getRadius(level))) {
+                for (LivingEntity target : UtilEntity.getNearbyEnemies(player, player.getLocation(), getRadius(level), true)) {
                     if (target instanceof Player playerTarget) {
                         championsManager.getEnergy().degenerateEnergy(playerTarget, ((float) getEnergySiphoned(level)) / 10.0f);
                     }


### PR DESCRIPTION
## Describe your changes
Added extra boolean variable for all variations of getNearbyEntities(including player methods), that prevents the check from counting players behind walls. Also added this restriction to quite a few skills. This boolean is false by default.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
