### PR TITLE
Promptable Build Menu

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/BuildManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/BuildManager.java
@@ -42,23 +42,12 @@ public class BuildManager extends Manager<GamerBuilds> {
         });
     }
 
-    /**
-     * Generates a random build for the specified role
-     * This is a destructive option, it replaces the build for the specified Role/ID
-     * @param player the player generating the build
-     * @param role the role to generate the build for
-     * @param id the id of the build to generate the build for
-     */
-    public RoleBuild generateRandomBuild(Player player, Role role, int id) {
+    public RoleBuild getRandomBuild(Player player, Role role, int id) {
         //First, generate a set of valid skills
         List<Skill> elligibleSkills = new java.util.ArrayList<>(championsSkillManager.getSkillsForRole(role).stream().filter(Skill::isEnabled).toList());
 
         //player should already have a valid build
-        RoleBuild build = getObject(player.getUniqueId()).orElseThrow().getBuild(role, id).orElseThrow();
-        //this is a destructive option, delete the current build
-        build.deleteBuild();
-        //while we still have tokens, get a new skill
-
+        RoleBuild build = new RoleBuild(player.getUniqueId().toString(), role, id);
         for (int i = build.getPoints(); i > 0; i--) {
             //choose an eligible skill
             Skill skill = elligibleSkills.get(UtilMath.randomInt(0, elligibleSkills.size()));
@@ -83,9 +72,21 @@ public class BuildManager extends Manager<GamerBuilds> {
             }
             build.takePoint();
         }
-        //now, we need to update the build
-        getBuildRepository().update(build);
         return build;
+    }
+
+    /**
+     * Generates a random build for the specified role
+     * This is a destructive option, it replaces the build for the specified Role/ID
+     * @param player the player generating the build
+     * @param role the role to generate the build for
+     * @param id the id of the build to generate the build for
+     */
+    public RoleBuild generateRandomBuild(Player player, Role role, int id) {
+        RoleBuild newRoleBuld = generateRandomBuild(player, role, id);
+        this.getObject(player.getUniqueId()).orElseThrow().setBuild(newRoleBuld, role, id);
+        getBuildRepository().update(newRoleBuld);
+        return newRoleBuld;
     }
 
     public void reloadBuilds() {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/GamerBuilds.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/GamerBuilds.java
@@ -18,4 +18,13 @@ public class GamerBuilds {
     public Optional<RoleBuild> getBuild(Role role, int id){
         return builds.stream().filter(build -> build.getRole() == role && build.getId() == id).findFirst();
     }
+
+    public void setBuild(RoleBuild newRoleBuild, Role role, int id) {
+        builds.replaceAll(roleBuild -> {
+            if (roleBuild.getRole() == role && roleBuild.getId() == id){
+                return newRoleBuild;
+            }
+            return roleBuild;
+        });
+    }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/RoleBuild.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/RoleBuild.java
@@ -145,4 +145,35 @@ public class RoleBuild {
         return component;
     }
 
+    /**
+     * Returns true if the role and BuildSkills are all equal
+     * @param o the object to check against
+     * @return true if this object has the same build
+     */
+    public boolean buildEquals(Object o) {
+        if (super.equals(o)) {
+            return true;
+        }
+        if (!(o instanceof RoleBuild r2)) {
+            return false;
+        }
+
+        if (this.role != r2.getRole()) {
+            return false;
+        }
+
+        for (SkillType skillType : SkillType.values()) {
+            BuildSkill r1BuildSkill = this.getBuildSkill(skillType);
+            BuildSkill r2BuildSkill = r2.getBuildSkill(skillType);
+
+            if (r1BuildSkill == null && r2BuildSkill != null) {
+                return false;
+            }
+            // still must check for null, because 2 null skills are valid
+            if (r1BuildSkill != null && (!r1BuildSkill.equals(r2BuildSkill))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/listeners/BuildListener.java
@@ -9,6 +9,7 @@ import me.mykindos.betterpvp.champions.champions.builds.menus.events.ApplyBuildE
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.DeleteBuildEvent;
 import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.client.events.ClientJoinEvent;
+import me.mykindos.betterpvp.core.combat.armour.ArmourManager;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Material;
@@ -35,7 +36,7 @@ public class BuildListener implements Listener {
     private ChampionsSkillManager skillManager;
 
     @Inject
-    private ClassSelectionMenu classSelectionMenu;
+    private ArmourManager armourManager;
 
     @EventHandler
     public void onClientJoin(ClientJoinEvent event) {
@@ -58,7 +59,7 @@ public class BuildListener implements Listener {
             if (block.getType() == Material.ENCHANTING_TABLE) {
                 Optional<GamerBuilds> gamerBuildsOptional = buildManager.getObject(event.getPlayer().getUniqueId());
                 gamerBuildsOptional.ifPresent(builds -> {
-                    classSelectionMenu.show(event.getPlayer());
+                    new ClassSelectionMenu(buildManager, skillManager, armourManager, null).show(event.getPlayer());
                     event.setCancelled(true);
                 });
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
@@ -20,12 +20,22 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BuildMenu extends AbstractGui implements Windowed {
 
     private final Role role;
 
-    public BuildMenu(GamerBuilds builds, Role role, BuildManager buildManager, ChampionsSkillManager skillManager, RoleBuild roleBuild, Windowed previous) {
+    /**
+     * A menu that shows the options to manage different builds for the specified roel
+     * @param builds The builds for the player looking at the menu
+     * @param role The role that the builds are being managed for
+     * @param buildManager The buildManager
+     * @param skillManager The champions SkillManager
+     * @param roleBuild The optional rolebuild to prompt the player to create. Null if empty
+     * @param previous the previous window
+     */
+    public BuildMenu(GamerBuilds builds, Role role, BuildManager buildManager, ChampionsSkillManager skillManager, @Nullable RoleBuild roleBuild, Windowed previous) {
         super(9, 6);
         this.role = role;
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/BuildMenu.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.builds.menus;
 
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
+import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.buttons.ApplyBuildButton;
 import me.mykindos.betterpvp.champions.champions.builds.menus.buttons.DeleteBuildButton;
 import me.mykindos.betterpvp.champions.champions.builds.menus.buttons.EditBuildButton;
@@ -24,11 +25,18 @@ public class BuildMenu extends AbstractGui implements Windowed {
 
     private final Role role;
 
-    public BuildMenu(GamerBuilds builds, Role role, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
+    public BuildMenu(GamerBuilds builds, Role role, BuildManager buildManager, ChampionsSkillManager skillManager, RoleBuild roleBuild, Windowed previous) {
         super(9, 6);
         this.role = role;
 
-        setItem(0, new BackButton(previous));
+        BackButton backButton = new BackButton(previous);
+        if (roleBuild != null) {
+            if (roleBuild.getRole() != role) {
+                backButton.setFlashing(true);
+            }
+        }
+
+        setItem(((this.getWidth() * this.getHeight()) - 1), backButton);
         setItem(9, new SimpleItem(getItemView(role.getHelmet(), role, " Helmet")));
         setItem(18, new SimpleItem(getItemView(role.getChestplate(), role, " Chestplate")));
         setItem(27, new SimpleItem(getItemView(role.getLeggings(), role, " Leggings")));
@@ -37,9 +45,9 @@ public class BuildMenu extends AbstractGui implements Windowed {
         for (int build = 1; build < 5; build++) {
 
             setItem(slot, new ApplyBuildButton(builds, role, build));
-            setItem(slot + 9, new EditBuildButton(builds, role, build, buildManager, skillManager, this));
-            setItem(slot + 18, new DeleteBuildButton(builds, role, build, buildManager, skillManager, this));
-            setItem(slot + 27, new RandomBuildButton(builds, role, build, buildManager, skillManager, this));
+            setItem(slot + 9, new EditBuildButton(builds, role, build, roleBuild, buildManager, skillManager, this));
+            setItem(slot + 18, new DeleteBuildButton(builds, role, build, buildManager, skillManager, roleBuild, this));
+            setItem(slot + 27, new RandomBuildButton(builds, role, build, buildManager, skillManager, roleBuild, this));
 
             slot += 2;
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/ClassSelectionMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/ClassSelectionMenu.java
@@ -1,8 +1,7 @@
 package me.mykindos.betterpvp.champions.champions.builds.menus;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
+import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.buttons.ClassSelectionButton;
 import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.combat.armour.ArmourManager;
@@ -12,22 +11,20 @@ import me.mykindos.betterpvp.core.menu.Menu;
 import me.mykindos.betterpvp.core.menu.Windowed;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Iterator;
 
-@Singleton
 public class ClassSelectionMenu extends AbstractGui implements Windowed {
-
-    @Inject
-    public ClassSelectionMenu(BuildManager buildManager, ChampionsSkillManager skillManager, ArmourManager armourManager) {
+    public ClassSelectionMenu(BuildManager buildManager, ChampionsSkillManager skillManager, ArmourManager armourManager, @Nullable RoleBuild roleBuild) {
         super(9, 3);
 
         int[] slots = new int[] {10, 11, 12, 14, 15, 16};
         final Iterator<Role> iterator = Arrays.stream(Role.values()).iterator();
         for (int slot : slots) {
             final Role role = iterator.next();
-            setItem(slot, new ClassSelectionButton(buildManager, skillManager, role, armourManager, this));
+            setItem(slot, new ClassSelectionButton(buildManager, skillManager, role, armourManager, roleBuild, this));
         }
 
         setBackground(Menu.BACKGROUND_ITEM);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/ClassSelectionMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/ClassSelectionMenu.java
@@ -17,6 +17,13 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 public class ClassSelectionMenu extends AbstractGui implements Windowed {
+    /**
+     * The menu used to choose which role to manage builds for
+     * @param buildManager the BuildManager
+     * @param skillManager the ChampionsSkillManager
+     * @param armourManager the ArmourManager
+     * @param roleBuild The optional rolebuild to prompt the player to create. Null if empty
+     */
     public ClassSelectionMenu(BuildManager buildManager, ChampionsSkillManager skillManager, ArmourManager armourManager, @Nullable RoleBuild roleBuild) {
         super(9, 3);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
@@ -43,15 +43,25 @@ public class SkillMenu extends AbstractGui implements Windowed {
     );
 
     private final RoleBuild roleBuild;
+    private final RoleBuild promptBuild;
     private final BuildManager buildManager;
 
-    public SkillMenu(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
+    public SkillMenu(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous, RoleBuild promptBuild) {
         super(9, 6);
+        this.promptBuild = promptBuild;
         this.roleBuild = builds.getBuilds().stream().filter(b -> b.getRole() == role && b.getId() == build).findFirst().orElseThrow();
         this.buildManager = buildManager;
 
+        BackButton backButton = new BackButton(previous);
+        if (promptBuild != null) {
+            if (promptBuild.getRole() != role) {
+                backButton.setFlashing(true);
+            }
+        }
+
+        setItem(((this.getWidth() * this.getHeight()) - 1), backButton);
+
         // Indicator items
-        setItem(53, new BackButton(previous));
         setItem(0, getSkillType(Material.IRON_SWORD, "Sword Skills"));
         setItem(9, getSkillType(Material.IRON_AXE, "Axe Skills"));
         setItem(18, getSkillType(Material.BOW, "Bow Skills"));
@@ -117,7 +127,7 @@ public class SkillMenu extends AbstractGui implements Windowed {
             }
 
 
-            setItem(slotNumber, new SkillButton(skill, roleBuild));
+            setItem(slotNumber, new SkillButton(skill, roleBuild, promptBuild));
         }
 
         setBackground(Menu.BACKGROUND_ITEM);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/SkillMenu.java
@@ -54,7 +54,7 @@ public class SkillMenu extends AbstractGui implements Windowed {
 
         BackButton backButton = new BackButton(previous);
         if (promptBuild != null) {
-            if (promptBuild.getRole() != role) {
+            if (promptBuild.getRole() != role || promptBuild.getId() != build) {
                 backButton.setFlashing(true);
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
@@ -23,7 +23,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import xyz.xenondevs.invui.item.ItemProvider;
 
 import java.util.List;
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
@@ -15,12 +15,15 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.xenondevs.invui.item.ItemProvider;
 
 import java.util.List;
 
@@ -34,7 +37,16 @@ public class ClassSelectionButton extends FlashingButton<ClassSelectionMenu> {
     private final ArmourManager armourManager;
     private final Windowed parent;
 
-    public ClassSelectionButton(BuildManager buildManager, ChampionsSkillManager skillManager, Role role, ArmourManager armourManager, RoleBuild roleBuild, Windowed parent) {
+    /**
+     *
+     * @param buildManager
+     * @param skillManager
+     * @param role
+     * @param armourManager
+     * @param roleBuild The optional rolebuild to prompt the player to create. Null if empty
+     * @param parent
+     */
+    public ClassSelectionButton(BuildManager buildManager, ChampionsSkillManager skillManager, Role role, ArmourManager armourManager, @Nullable RoleBuild roleBuild, Windowed parent) {
         super();
         this.buildManager = buildManager;
         this.role = role;
@@ -59,8 +71,10 @@ public class ClassSelectionButton extends FlashingButton<ClassSelectionMenu> {
 
     @Override
     public ItemProvider getItemProvider(ClassSelectionMenu gui) {
+        final Component standardComponent = Component.text(role.getName(), role.getColor(), TextDecoration.BOLD);
+        final Component flashComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.GREEN)).appendSpace().append(standardComponent);
         return ItemView.builder().material(role.getChestplate())
-                .displayName(Component.text(role.getName(), role.getColor(), TextDecoration.BOLD))
+                .displayName(this.isFlashing() ? flashComponent : standardComponent)
                 .lore(List.of(UtilMessage.deserialize("Class Damage Reduction: <yellow>" + this.armourManager.getReductionForArmourSet(role.getChestplate().name().replace("_CHESTPLATE", "")) + "%"),
                         UtilMessage.deserialize("Effective Health: <red>" + (int) Math.floor(20 / (1 - this.armourManager.getReductionForArmourSet(role.getChestplate().name().replace("_CHESTPLATE", "")) / 100))),
                         Component.text(""),

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/ClassSelectionButton.java
@@ -53,7 +53,7 @@ public class ClassSelectionButton extends FlashingButton<ClassSelectionMenu> {
     @Override
     public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
         final GamerBuilds builds = buildManager.getObject(player.getUniqueId()).orElseThrow();
-        new BuildMenu(builds, role, buildManager, skillManager, parent).show(player);
+        new BuildMenu(builds, role, buildManager, skillManager, roleBuild, parent).show(player);
         SoundEffect.HIGH_PITCH_PLING.play(player);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/DeleteBuildButton.java
@@ -30,9 +30,10 @@ public class DeleteBuildButton extends SimpleItem {
     private final int buildNumber;
     private final BuildManager buildManager;
     private final ChampionsSkillManager skillManager;
+    private final RoleBuild roleBuild;
     private final Windowed parent;
 
-    public DeleteBuildButton(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed parent) {
+    public DeleteBuildButton(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager skillManager, RoleBuild roleBuild, Windowed parent) {
         super(ItemView.builder().material(Material.RED_CONCRETE)
                 .displayName(Component.text("Delete Build " + build , NamedTextColor.RED))
                 .build());
@@ -41,6 +42,7 @@ public class DeleteBuildButton extends SimpleItem {
         this.buildNumber = build;
         this.buildManager = buildManager;
         this.skillManager = skillManager;
+        this.roleBuild = roleBuild;
         this.parent = parent;
     }
 
@@ -55,7 +57,7 @@ public class DeleteBuildButton extends SimpleItem {
                     player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 0.6f);
                 });
             }
-            new BuildMenu(builds, role, buildManager, skillManager, parent).show(player);
+            new BuildMenu(builds, role, buildManager, skillManager, roleBuild, parent).show(player);
         }).show(player);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -3,12 +3,14 @@ package me.mykindos.betterpvp.champions.champions.builds.menus.buttons;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
 import me.mykindos.betterpvp.champions.champions.builds.GamerBuilds;
 import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
+import me.mykindos.betterpvp.champions.champions.builds.menus.BuildMenu;
 import me.mykindos.betterpvp.champions.champions.builds.menus.SkillMenu;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.ApplyBuildEvent;
 import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.components.champions.Role;
-import me.mykindos.betterpvp.core.inventory.item.impl.SimpleItem;
+import me.mykindos.betterpvp.core.inventory.item.ItemProvider;
 import me.mykindos.betterpvp.core.menu.Windowed;
+import me.mykindos.betterpvp.core.menu.button.FlashingButton;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
@@ -22,25 +24,31 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 
-public class EditBuildButton extends SimpleItem {
+public class EditBuildButton extends FlashingButton<BuildMenu> {
 
     private final Role role;
     private final int build;
     private final GamerBuilds builds;
     private final ChampionsSkillManager skillManager;
+    private final RoleBuild roleBuild;
     private final Windowed previous;
     private final BuildManager buildManager;
 
-    public EditBuildButton(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
-        super(ItemView.builder().material(Material.ANVIL)
-                .displayName(Component.text("Edit Build " + build, NamedTextColor.GRAY))
-                .build());
+    public EditBuildButton(GamerBuilds builds, Role role, int build, RoleBuild roleBuild, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
+        super();
         this.role = role;
         this.build = build;
         this.builds = builds;
+        this.roleBuild = roleBuild;
         this.buildManager = buildManager;
         this.skillManager = skillManager;
         this.previous = previous;
+
+        if (roleBuild != null) {
+            if (roleBuild.getRole() == role && roleBuild.getId() == build) {
+                this.setFlashing(true);
+            }
+        }
     }
 
     @Override
@@ -57,7 +65,15 @@ public class EditBuildButton extends SimpleItem {
             notifyWindows();
         });
 
-        new SkillMenu(builds, role, build, buildManager, skillManager, previous).show(player);
+        new SkillMenu(builds, role, build, buildManager, skillManager, previous, roleBuild).show(player);
         SoundEffect.HIGH_PITCH_PLING.play(player);
+    }
+
+    @Override
+    public ItemProvider getItemProvider(BuildMenu gui) {
+        return ItemView.builder().material(Material.ANVIL)
+                .displayName(Component.text("Edit Build " + build, NamedTextColor.GRAY))
+                .glow(this.isFlash())
+                .build();
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -22,8 +22,6 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import xyz.xenondevs.invui.gui.Gui;
-import xyz.xenondevs.invui.item.ItemProvider;
 
 import java.util.Optional;
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -21,6 +21,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.ItemProvider;
 
 import java.util.Optional;
 
@@ -34,7 +37,17 @@ public class EditBuildButton extends FlashingButton<BuildMenu> {
     private final Windowed previous;
     private final BuildManager buildManager;
 
-    public EditBuildButton(GamerBuilds builds, Role role, int build, RoleBuild roleBuild, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
+    /**
+     *
+     * @param builds
+     * @param role
+     * @param build
+     * @param roleBuild The optional rolebuild to prompt the player to create. Null if empty
+     * @param buildManager
+     * @param skillManager
+     * @param previous
+     */
+    public EditBuildButton(GamerBuilds builds, Role role, int build, @Nullable RoleBuild roleBuild, BuildManager buildManager, ChampionsSkillManager skillManager, Windowed previous) {
         super();
         this.role = role;
         this.build = build;
@@ -71,8 +84,10 @@ public class EditBuildButton extends FlashingButton<BuildMenu> {
 
     @Override
     public ItemProvider getItemProvider(BuildMenu gui) {
+        final Component standardComponent = Component.text("Edit Build " + build, NamedTextColor.GRAY);
+        final Component flashComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.GREEN)).appendSpace().append(standardComponent);
         return ItemView.builder().material(Material.ANVIL)
-                .displayName(Component.text("Edit Build " + build, NamedTextColor.GRAY))
+                .displayName(this.isFlashing() ? flashComponent : standardComponent)
                 .glow(this.isFlash())
                 .build();
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/RandomBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/RandomBuildButton.java
@@ -31,14 +31,16 @@ public class RandomBuildButton extends ControlItem<BuildMenu> {
     private final int build;
     private final BuildManager buildManager;
     private final ChampionsSkillManager championsSkillManager;
+    private final RoleBuild roleBuild;
     private final Windowed parent;
 
-    public RandomBuildButton(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager championsSkillManager, Windowed parent) {
+    public RandomBuildButton(GamerBuilds builds, Role role, int build, BuildManager buildManager, ChampionsSkillManager championsSkillManager, RoleBuild roleBuild, Windowed parent) {
         this.builds = builds;
         this.role = role;
         this.build = build;
         this.buildManager = buildManager;
         this.championsSkillManager = championsSkillManager;
+        this.roleBuild = roleBuild;
         this.parent = parent;
     }
 
@@ -65,7 +67,7 @@ public class RandomBuildButton extends ControlItem<BuildMenu> {
                 notifyWindows();
                 getGui().updateControlItems();
             }
-            new BuildMenu(builds, role, buildManager, championsSkillManager, parent).show(player);
+            new BuildMenu(builds, role, buildManager, championsSkillManager, roleBuild, parent).show(player);
         }).show(player);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
@@ -7,9 +7,8 @@ import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillDequip
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillEquipEvent;
 import me.mykindos.betterpvp.champions.champions.builds.menus.events.SkillUpdateEvent;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
-import me.mykindos.betterpvp.core.menu.button.FlashingButton;
 import me.mykindos.betterpvp.core.inventory.item.ItemProvider;
-import me.mykindos.betterpvp.core.inventory.item.impl.controlitem.ControlItem;
+import me.mykindos.betterpvp.core.menu.button.FlashingButton;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilSound;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
@@ -55,6 +55,7 @@ public class SkillButton extends FlashingButton<SkillMenu> {
 
         builder.lore(Arrays.stream(skill.parseDescription(displayLevel)).toList());
 
+        int desiredLevel = 0;
 
         //if this is the correct role and build
         if (promptBuild != null && promptBuild.getRole() == roleBuild.getRole()) {
@@ -65,14 +66,17 @@ public class SkillButton extends FlashingButton<SkillMenu> {
                 //if this is a skill we want
                 if (promptBuild.getActiveSkills().contains(this.skill)) {
                     //we have it, set flashing if not correct level
-                    if (promptBuildSkill != null && currentBuildSkill != null &&
+                    if (currentBuildSkill != null &&
                             promptBuildSkill.getSkill().equals(currentBuildSkill.getSkill())) {
                         this.setFlashing(promptBuildSkill.getLevel() != currentBuildSkill.getLevel());
+                        desiredLevel = promptBuildSkill.getLevel();
                     } else { //we do not have this skill, but want it
                         this.setFlashing(true);
+                        desiredLevel = promptBuildSkill.getLevel();
                     }
                 } else { //we don't want this skill, flash if we have it
                     this.setFlashing(currentBuildSkill != null && currentBuildSkill.getSkill().equals(this.skill));
+                    desiredLevel = 0;
                 }
             }
         }
@@ -82,10 +86,20 @@ public class SkillButton extends FlashingButton<SkillMenu> {
             Material flashMaterial = this.isFlash() ? Material.WRITTEN_BOOK : Material.BOOK;
             builder.material(this.isFlashing() ? flashMaterial : Material.WRITTEN_BOOK);
             builder.amount(displayLevel);
-            builder.displayName(Component.text(skill.getName() + " (" + displayLevel + " / " + skill.getMaxLevel() + ")", NamedTextColor.GREEN, TextDecoration.BOLD));
+
+            Component standardComponent = Component.text(skill.getName() + " (" + displayLevel + " / " + skill.getMaxLevel() + ")", NamedTextColor.GREEN, TextDecoration.BOLD);
+            Component flashingComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.RED).appendSpace())
+                                            .append(standardComponent).appendSpace()
+                                            .append(Component.text("(" + desiredLevel + ")", NamedTextColor.GOLD));
+
+            builder.displayName(isFlashing() ? flashingComponent : standardComponent);
         } else {
             builder.material(Material.BOOK);
-            builder.displayName(Component.text(skill.getName(), NamedTextColor.RED));
+            Component standardComponent = Component.text(skill.getName(), NamedTextColor.RED);
+            Component flashingComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.GREEN).appendSpace())
+                    .append(standardComponent).appendSpace()
+                    .append(Component.text("(" + desiredLevel + ")", NamedTextColor.GOLD));
+            builder.displayName(isFlashing() ? flashingComponent : standardComponent);
         }
 
         if (displayLevel < skill.getMaxLevel()) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/SkillButton.java
@@ -26,7 +26,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.jetbrains.annotations.NotNull;
-import xyz.xenondevs.invui.item.ItemProvider;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
@@ -36,7 +36,13 @@ public class SkillButton extends FlashingButton<SkillMenu> {
     private final RoleBuild roleBuild;
     private final RoleBuild promptBuild;
 
-    public SkillButton(Skill skill, RoleBuild roleBuild, RoleBuild promptBuild) {
+    /**
+     *
+     * @param skill
+     * @param roleBuild
+     * @param promptBuild The optional rolebuild to prompt the player to create. Null if empty
+     */
+    public SkillButton(Skill skill, RoleBuild roleBuild, @Nullable RoleBuild promptBuild) {
         this.skill = skill;
         this.roleBuild = roleBuild;
         this.promptBuild = promptBuild;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/BuildCommand.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/BuildCommand.java
@@ -2,16 +2,29 @@ package me.mykindos.betterpvp.champions.champions.commands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
+import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.ClassSelectionMenu;
+import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.combat.armour.ArmourManager;
 import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.components.champions.Role;
 import org.bukkit.entity.Player;
 
 @Singleton
 public class BuildCommand extends Command {
 
+    private final BuildManager buildManager;
+    private final ChampionsSkillManager championsSkillManager;
+    private final ArmourManager armourManager;
+
     @Inject
-    private ClassSelectionMenu classSelectionMenu;
+    public BuildCommand(BuildManager buildManager, ChampionsSkillManager championsSkillManager, ArmourManager armourManager) {
+        this.buildManager = buildManager;
+        this.championsSkillManager = championsSkillManager;
+        this.armourManager = armourManager;
+    }
 
     @Override
     public String getName() {
@@ -25,6 +38,7 @@ public class BuildCommand extends Command {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        classSelectionMenu.show(player);
+        RoleBuild promptBuild = buildManager.getRandomBuild(player, Role.BRUTE, 1);
+        new ClassSelectionMenu(buildManager, championsSkillManager, armourManager, promptBuild).show(player);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/BuildCommand.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/BuildCommand.java
@@ -3,13 +3,11 @@ package me.mykindos.betterpvp.champions.champions.commands;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
-import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
 import me.mykindos.betterpvp.champions.champions.builds.menus.ClassSelectionMenu;
 import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.combat.armour.ArmourManager;
 import me.mykindos.betterpvp.core.command.Command;
-import me.mykindos.betterpvp.core.components.champions.Role;
 import org.bukkit.entity.Player;
 
 @Singleton
@@ -38,7 +36,6 @@ public class BuildCommand extends Command {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        RoleBuild promptBuild = buildManager.getRandomBuild(player, Role.BRUTE, 1);
-        new ClassSelectionMenu(buildManager, championsSkillManager, armourManager, promptBuild).show(player);
+        new ClassSelectionMenu(buildManager, championsSkillManager, armourManager, null).show(player);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/admin/PromptBuildCommand.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/commands/admin/PromptBuildCommand.java
@@ -1,0 +1,78 @@
+package me.mykindos.betterpvp.champions.champions.commands.admin;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.champions.champions.builds.BuildManager;
+import me.mykindos.betterpvp.champions.champions.builds.RoleBuild;
+import me.mykindos.betterpvp.champions.champions.builds.menus.ClassSelectionMenu;
+import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.combat.armour.ArmourManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Singleton
+public class PromptBuildCommand extends Command {
+
+    private final BuildManager buildManager;
+    private final ChampionsSkillManager championsSkillManager;
+    private final ArmourManager armourManager;
+
+    @Inject
+    public PromptBuildCommand(BuildManager buildManager, ChampionsSkillManager championsSkillManager, ArmourManager armourManager) {
+        this.buildManager = buildManager;
+        this.championsSkillManager = championsSkillManager;
+        this.armourManager = armourManager;
+    }
+
+    @Override
+    public String getName() {
+        return "promptbuild";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Open a prompt build (for testing)";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        Role role = Role.values()[UtilMath.randomInt(0, Role.values().length)];
+        if (args.length > 0) {
+            try {
+                role = Role.valueOf(args[0]);
+            } catch (IllegalArgumentException ignored) {
+
+            }
+
+        }
+        RoleBuild promptBuild = buildManager.getRandomBuild(player, role, 4);
+        new ClassSelectionMenu(buildManager, championsSkillManager, armourManager, promptBuild).show(player);
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? "ROLE" : ArgumentType.NONE.name();
+    }
+
+    public List<String> processTabComplete(CommandSender sender, String[] args) {
+        List<String> tabCompletions = new ArrayList<>();
+        if (args.length == 0) return tabCompletions;
+
+        String lowercaseArg = args[args.length - 1].toLowerCase();
+        if (getArgumentType(args.length).equals("ROLE")) {
+            tabCompletions.addAll(Arrays.stream(Role.values())
+                    .map(role -> role.getName().toLowerCase())
+                    .filter(name -> name.startsWith(lowercaseArg)).toList());
+        }
+        tabCompletions.addAll(super.processTabComplete(sender, args));
+        return tabCompletions;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
@@ -14,10 +14,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.ItemProvider;
 
 @RequiredArgsConstructor
 @AllArgsConstructor
-public class BackButton extends ControlItem<Gui> {
+public class BackButton extends FlashingButton<Gui> {
 
     private final Windowed previousMenu;
     private Runnable onBack;
@@ -29,6 +31,7 @@ public class BackButton extends ControlItem<Gui> {
                 .customModelData(10003)
                 .fallbackMaterial(Material.ARROW)
                 .displayName(Component.text(previousMenu == null ? "Close" : "Back", NamedTextColor.RED))
+                .glow(this.isFlash())
                 .build();
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
@@ -26,11 +26,13 @@ public class BackButton extends FlashingButton<Gui> {
 
     @Override
     public ItemProvider getItemProvider(Gui gui) {
+        final Component standardComponent = Component.text(previousMenu == null ? "Close" : "Back", NamedTextColor.RED);
+        final Component flashComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.GREEN)).appendSpace().append(standardComponent);
         return ItemView.builder()
                 .material(Material.PAPER)
                 .customModelData(10003)
                 .fallbackMaterial(Material.ARROW)
-                .displayName(Component.text(previousMenu == null ? "Close" : "Back", NamedTextColor.RED))
+                .displayName(this.isFlashing() ? flashComponent : standardComponent)
                 .glow(this.isFlash())
                 .build();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/BackButton.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import me.mykindos.betterpvp.core.inventory.gui.Gui;
 import me.mykindos.betterpvp.core.inventory.item.ItemProvider;
-import me.mykindos.betterpvp.core.inventory.item.impl.controlitem.ControlItem;
 import me.mykindos.betterpvp.core.menu.Windowed;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 import net.kyori.adventure.text.Component;
@@ -14,8 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
-import xyz.xenondevs.invui.gui.Gui;
-import xyz.xenondevs.invui.item.ItemProvider;
+
 
 @RequiredArgsConstructor
 @AllArgsConstructor

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
@@ -40,13 +40,21 @@ public abstract class FlashingButton<G extends Gui> extends ControlItem<G> {
         this.flashPeriod = (long) (period * 1000L);
     }
 
+    /**
+     * Returns true if isFlashing and it is flash, false otherwise
+     */
+    public boolean isFlash() {
+        if (isFlashing()) {
+            return this.flash;
+        }
+        return false;
+    }
+
     public void handleFlash() {
-        if (flashing) {
-            if (UtilTime.elapsed(lastSwitch, this.getFlashPeriod())) {
-                this.flash = !this.flash;
-                this.lastSwitch = System.currentTimeMillis();
-                this.notifyWindows();
-            }
+        if (UtilTime.elapsed(lastSwitch, this.getFlashPeriod())) {
+            this.flash = !this.flash;
+            this.lastSwitch = System.currentTimeMillis();
+            this.notifyWindows();
         }
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.menu.button;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import me.mykindos.betterpvp.core.inventory.gui.Gui;
+import me.mykindos.betterpvp.core.inventory.item.impl.controlitem.ControlItem;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+
+@Slf4j
+@BPvPListener
+public abstract class FlashingButton<G extends Gui> extends ControlItem<G> {
+    private long lastSwitch;
+    @Getter
+    private boolean flash;
+    @Getter
+    @Setter
+    private boolean flashing;
+    @Getter
+    @Setter
+    private long flashPeriod;
+
+    /**
+     * Default constructor, flashing = false, flashPeriod = 1s
+     */
+    protected FlashingButton() {
+        this.lastSwitch = System.currentTimeMillis();
+        this.flash = false;
+        this.flashing = false;
+        this.flashPeriod = 1000L;
+    }
+
+    /**
+     * Sets this button to flashing, and the default flash period in seconds
+     * @param period length of time between flashes in seconds
+     */
+    protected FlashingButton(double period) {
+        this.lastSwitch = System.currentTimeMillis();
+        this.flash = false;
+        this.flashing = true;
+        this.flashPeriod = (long) (period * 1000L);
+    }
+
+    public void handleFlash() {
+        if (flashing) {
+            if (UtilTime.elapsed(lastSwitch, this.getFlashPeriod())) {
+                this.flash = !this.flash;
+                log.info(String.valueOf(flash));
+                this.lastSwitch = System.currentTimeMillis();
+                this.notifyWindows();
+            }
+        }
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
@@ -2,13 +2,11 @@ package me.mykindos.betterpvp.core.menu.button;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import me.mykindos.betterpvp.core.inventory.gui.Gui;
 import me.mykindos.betterpvp.core.inventory.item.impl.controlitem.ControlItem;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 
-@Slf4j
 @BPvPListener
 public abstract class FlashingButton<G extends Gui> extends ControlItem<G> {
     private long lastSwitch;
@@ -46,7 +44,6 @@ public abstract class FlashingButton<G extends Gui> extends ControlItem<G> {
         if (flashing) {
             if (UtilTime.elapsed(lastSwitch, this.getFlashPeriod())) {
                 this.flash = !this.flash;
-                log.info(String.valueOf(flash));
                 this.lastSwitch = System.currentTimeMillis();
                 this.notifyWindows();
             }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/FlashingButton.java
@@ -6,7 +6,6 @@ import me.mykindos.betterpvp.core.inventory.gui.Gui;
 import me.mykindos.betterpvp.core.inventory.item.impl.controlitem.ControlItem;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
-
 @BPvPListener
 public abstract class FlashingButton<G extends Gui> extends ControlItem<G> {
     private long lastSwitch;

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
@@ -12,8 +12,10 @@ import me.mykindos.betterpvp.core.inventory.item.Item;
 import me.mykindos.betterpvp.core.inventory.window.AbstractSingleWindow;
 import me.mykindos.betterpvp.core.inventory.window.Window;
 import me.mykindos.betterpvp.core.inventory.window.WindowManager;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.menu.CooldownButton;
+import me.mykindos.betterpvp.core.menu.button.FlashingButton;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -90,6 +92,21 @@ public class MenuListener implements Listener {
         }
 
         gui.setFrozen(false);
+    }
+
+    @UpdateEvent()
+    public void doFlashing() {
+        WindowManager.getInstance().getWindows().forEach(window -> {
+            if (window instanceof AbstractSingleWindow abstractSingleWindow) {
+                for (SlotElement slotElement : abstractSingleWindow.getGui().getSlotElements()) {
+                    if (slotElement instanceof SlotElement.ItemSlotElement itemSlotElement) {
+                        if (itemSlotElement.getItem() instanceof FlashingButton<?> flashingButton) {
+                           flashingButton.handleFlash();
+                        }
+                    }
+                }
+            }
+        });
     }
 
     private boolean isValid(InventoryClickEvent event) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilItem.java
@@ -180,12 +180,9 @@ public class UtilItem {
      * Add the 'enchanted' glowing effect to any ItemStack
      *
      * @param meta Item to update
-     * @return Returns an ItemStack that is now glowing
      */
-    @SuppressWarnings("deprecation")
     public static void addGlow(ItemMeta meta) {
-        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        meta.addEnchant(Enchantment.LUCK_OF_THE_SEA, 1, true);
+        meta.setEnchantmentGlintOverride(true);
     }
 
     /**


### PR DESCRIPTION
Add Flashing Button, which has elements for a button to change its go at a specified time. Extends Control Item.

Create a promptable build menu, that will flash on items that the user is intended to click on, until they successfully navigate to and create the build supplied to the menu. This will be used in the tutorial to teach player how to make a build.

Fixes #951
Fixes #952

- [x] Implement Separate Command for testing
- [x] Update names of isFlashing items to indicate why they are flashing
- [x] Sync Flashing Buttons with same period

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
