### PR TITLE
Brute small changes

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -113,7 +113,6 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
 
     @Override
     public double getCooldown(int level) {
-
         return cooldown - ((level - 1) * cooldownDecreasePerLevel);
     }
 
@@ -135,7 +134,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
 
             final Optional<LivingEntity> hit = UtilEntity.interpolateCollision(midpoint,
                             midpoint.clone().add(player.getVelocity().normalize().multiply(0.5)),
-                            (float) 0.6,
+                            (float) 0.9,
                             ent -> UtilEntity.IS_ENEMY.test(player, ent))
                     .map(RayTraceResult::getHitEntity).map(LivingEntity.class::cast);
 
@@ -155,6 +154,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
 
     public void doTakedown(Player player, LivingEntity target) {
         int level = getLevel(player);
+        player.setVelocity(new Vector(0, 0, 0));
 
         UtilMessage.simpleMessage(player, getClassType().getName(), "You hit <alt>" + target.getName() + "</alt> with <alt>" + getName() + " " + level);
         UtilDamage.doCustomDamage(new CustomDamageEvent(target, player, null, DamageCause.CUSTOM, getDamage(level), false, "Takedown"));
@@ -183,7 +183,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     @Override
     public void activate(Player player, int leel) {
         Vector vec = player.getLocation().getDirection();
-        VelocityData velocityData = new VelocityData(vec, velocityStrength, false, 0.0D, 0.4D, 0.6D, false);
+        VelocityData velocityData = new VelocityData(vec, velocityStrength, false, 0.0D, 0.3D, 0.5D, false);
         UtilVelocity.velocity(player, null, velocityData, VelocityType.CUSTOM);
         taskScheduler.addTask(new BPVPTask(player.getUniqueId(), uuid -> !UtilBlock.isGrounded(uuid), uuid -> {
             Player target = Bukkit.getPlayer(uuid);
@@ -205,8 +205,8 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     public void loadSkillConfig() {
         damage = getConfig("damage", 5.0, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
-        baseDuration = getConfig("baseDuration", 1.0, Double.class);
-        durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 1.0, Double.class);
+        baseDuration = getConfig("baseDuration", 2.0, Double.class);
+        durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 0.5, Double.class);
         slownessStrength = getConfig("slownessStrength", 4, Integer.class);
         recoilDamage = getConfig("recoilDamage", 1.5, Double.class);
         recoilDamageIncreasePerLevel = getConfig("recoilDamageIncreasePerLevel", 0.5, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
@@ -192,10 +192,10 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
     @Override
     public void loadSkillConfig() {
         damageRadius = getConfig("damageRadius", 3.0, Double.class);
-        vulnerabilityRadius = getConfig("vulnerabilityRadius", 2.0, Double.class);
+        vulnerabilityRadius = getConfig("vulnerabilityRadius", 1.5, Double.class);
         baseDuration = getConfig("baseDuration", 3.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 1.0, Double.class);
-        vulnerabilityStrength = getConfig("vulnerabilityStrength", 3, Integer.class);
+        vulnerabilityStrength = getConfig("vulnerabilityStrength", 2, Integer.class);
         tickDelay = getConfig("tickDelay", 12, Integer.class);
         damage = getConfig("damage", 5.0, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
@@ -196,7 +196,7 @@ public class Stampede extends Skill implements PassiveSkill, MovementSkill, Dama
 
     @Override
     public void loadSkillConfig() {
-        durationPerStack = getConfig("durationPerStack", 6.0, Double.class);
+        durationPerStack = getConfig("durationPerStack", 5.0, Double.class);
         durationPerStackDecreasePerLevel = getConfig("durationPerStackDecreasePerLevel", 1.0, Double.class);
         damage = getConfig("damage", 0.5, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 0.5, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BlockToss.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BlockToss.java
@@ -184,14 +184,14 @@ public class BlockToss extends ChannelSkill implements Listener, InteractSkill, 
         baseCharge = getConfig("baseCharge", 55.0, Double.class);
         chargeIncreasePerLevel = getConfig("chargeIncreasePerLevel", 15.0, Double.class);
         baseDamage = getConfig("baseDamage", 4.0, Double.class);
-        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 2.0, Double.class);
-        baseRadius = getConfig("baseRadius", 4.0, Double.class);
-        radiusIncreasePerLevel = getConfig("radiusIncreasePerLevel", 0.5, Double.class);
-        baseSpeed = getConfig("baseSpeed", 1.4, Double.class);
-        speedIncreasePerLevel = getConfig("speedIncreasePerLevel", 0.1, Double.class);
-        size = getConfig("size", 0.6, Double.class);
-        sizePerLevel = getConfig("sizePerLevel", 0.2, Double.class);
-        hitBoxSize = getConfig("hitBoxSize", 1.0, Double.class);
+        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
+        baseRadius = getConfig("baseRadius", 2.0, Double.class);
+        radiusIncreasePerLevel = getConfig("radiusIncreasePerLevel", 0.0, Double.class);
+        baseSpeed = getConfig("baseSpeed", 2.0, Double.class);
+        speedIncreasePerLevel = getConfig("speedIncreasePerLevel", 0.0, Double.class);
+        size = getConfig("size", 0.3, Double.class);
+        sizePerLevel = getConfig("sizePerLevel", 0.0, Double.class);
+        hitBoxSize = getConfig("hitBoxSize", 0.5, Double.class);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -56,6 +56,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
 
     private double damage;
     private double damageIncreasePerLevel;
+    private double slowDuration;
 
     @Inject
     public FleshHook(Champions champions, ChampionsManager championsManager) {
@@ -73,8 +74,9 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
                 "Hold right click with a Sword to channel",
                 "",
                 "Charge a hook that latches onto",
-                "enemies pulling them towards you" ,
-                "and dealing " + getValueString(this::getDamage, level) + " damage.",
+                "enemies and pulls them towards you,",
+                "dealing " + getValueString(this::getDamage, level) + " damage",
+                "and <effect>Slowing</effect> them for " + getValueString(this::getSlowDuration, level) + " second",
                 "",
                 "Cooldown: " + getValueString(this::getCooldown, level),
         };
@@ -108,6 +110,9 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
     public double getCooldown(int level) {
         return (cooldown - (cooldownDecreasePerLevel * (level - 1)));
     }
+
+    public double getSlowDuration(int level) {
+        returns slowDuration;
 
     @Override
     public Action[] getActions() {
@@ -234,6 +239,8 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
         final double damage = getDamage(level) * hookData.getData().getCharge();
         CustomDamageEvent ev = new CustomDamageEvent(hit, player, null, EntityDamageEvent.DamageCause.CUSTOM, damage, false, getName());
         UtilDamage.doCustomDamage(ev);
+        championsManager.getEffects().addEffect(player, EffectTypes.SLOWNESS, 1, getSlowDuration(level));
+
 
         // Cues
         UtilMessage.simpleMessage(hit, getClassType().getName(), "<alt2>" + player.getName() + "</alt2> pulled you with <alt>" + getName() + " " + level + "</alt>.");
@@ -249,6 +256,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
     public void loadSkillConfig() {
         damage = getConfig("damage", 5.0, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
+        slowDuration = = getConfig("slowDuration", 1.0, Double.class);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -112,7 +112,8 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
     }
 
     public double getSlowDuration(int level) {
-        returns slowDuration;
+        return slowDuration;
+    }
 
     @Override
     public Action[] getActions() {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -13,6 +13,7 @@ import me.mykindos.betterpvp.champions.champions.skills.types.CooldownSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.CrowdControlSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.DamageSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.combat.events.VelocityType;
@@ -240,7 +241,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
         final double damage = getDamage(level) * hookData.getData().getCharge();
         CustomDamageEvent ev = new CustomDamageEvent(hit, player, null, EntityDamageEvent.DamageCause.CUSTOM, damage, false, getName());
         UtilDamage.doCustomDamage(ev);
-        championsManager.getEffects().addEffect(player, EffectTypes.SLOWNESS, 1, getSlowDuration(level));
+        championsManager.getEffects().addEffect(player, EffectTypes.SLOWNESS, 1, (long)(getSlowDuration(level) * 1000L));
 
 
         // Cues

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -256,7 +256,7 @@ public class FleshHook extends ChannelSkill implements InteractSkill, CooldownSk
     public void loadSkillConfig() {
         damage = getConfig("damage", 5.0, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
-        slowDuration = = getConfig("slowDuration", 1.0, Double.class);
+        slowDuration = getConfig("slowDuration", 1.0, Double.class);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
@@ -152,8 +152,8 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
     @Override
     public void loadSkillConfig(){
         baseDistance = getConfig("baseDistance", 4.0, Double.class);
-        distanceIncreasePerLevel = getConfig("distanceIncreasePerLevel", 1.0, Double.class);
-        baseDamage = getConfig("damage", 3.0, Double.class);
-        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 1.0, Double.class);
+        distanceIncreasePerLevel = getConfig("distanceIncreasePerLevel", 0.5, Double.class);
+        baseDamage = getConfig("baseDamage", 3.0, Double.class);
+        damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 0.5, Double.class);
     }
 }

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -613,8 +613,8 @@ skills:
       cooldown: 25.0
       damage: 5.0
       cooldownDecreasePerLevel: 2.0
-      baseDuration: 1.0
-      durationIncreasePerLevel: 1.0
+      baseDuration: 2.0
+      durationIncreasePerLevel: 0.5
       slownessStrength: 4
       recoilDamage: 1.5
       recoilDamageIncreasePerLevel: 0.5

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -634,7 +634,7 @@ skills:
     stampede:
       enabled: true
       maxlevel: 3
-      durationPerStack: 6.0
+      durationPerStack: 5.0
       damage: 0.5
       damageIncreasePerLevel: 0.5
       durationPerStackDecreasePerLevel: 1.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -570,10 +570,10 @@ skills:
       maxlevel: 5
       cooldown: 20.0
       cooldownDecreasePerLevel: 1.0
-      baseDistance: 7.0
-      distanceIncreasePerLevel: 0.0
+      baseDistance: 4.0
+      distanceIncreasePerLevel: 0.5
       baseDamage: 3.0
-      damageIncreasePerLevel: 1.0
+      damageIncreasePerLevel: 0.5
       damage: 3.0
     cripplingblow:
       enabled: true

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -574,7 +574,6 @@ skills:
       distanceIncreasePerLevel: 0.5
       baseDamage: 3.0
       damageIncreasePerLevel: 0.5
-      damage: 3.0
     cripplingblow:
       enabled: true
       maxlevel: 3

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -584,8 +584,8 @@ skills:
     fleshhook:
       enabled: true
       maxlevel: 5
-      cooldown: 18.0
-      cooldownDecreasePerLevel: 2.0
+      cooldown: 13.0
+      cooldownDecreasePerLevel: 1.0
       damage: 5.0
       damageIncreasePerLevel: 1.0
     blocktoss:

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -644,13 +644,13 @@ skills:
     threateningshout:
       enabled: true
       maxlevel: 5
-      cooldown: 12.0
+      cooldown: 18.0
       damageRadius: 3.0
-      vulnerabilityRadius: 2.0
+      vulnerabilityRadius: 1.5
       cooldownDecreasePerLevel: 1.0
       baseDuration: 3.0
       durationIncreasePerLevel: 0.5
-      vulnerabilityStrength: 3
+      vulnerabilityStrength: 2
       tickDelay: 12
       damage: 5.0
       damageIncreasePerLevel: 1.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -590,19 +590,19 @@ skills:
     blocktoss:
       enabled: true
       maxlevel: 5
-      cooldown: 10.0
-      cooldownDecreasePerLevel: 1.0
+      cooldown: 4.0
+      cooldownDecreasePerLevel: 0.5
       baseCharge: 55.0
       chargeIncreasePerLevel: 15.0
       baseDamage: 4.0
       damageIncreasePerLevel: 1.0
-      baseRadius: 4.0
-      radiusIncreasePerLevel: 0.5
-      baseSpeed: 1.4
-      speedIncreasePerLevel: 0.1
-      hitBoxSize: 1.0
-      size: 0.6
-      sizePerLevel: 0.2
+      baseRadius: 2.0
+      radiusIncreasePerLevel: 0.0
+      baseSpeed: 2.0
+      speedIncreasePerLevel: 0.0
+      hitBoxSize: 0.5
+      size: 0.3
+      sizePerLevel: 0.0
     colossus:
       enabled: true
       maxlevel: 3


### PR DESCRIPTION
Whirlwind Sword:
- Decreased scaling of radius and damage to 0.5 per level down from 1.0 per level

Whirlwind Sword was outperforming every other brute ability because it required very little user decision making for a lot of value. Tuning down the numbers should keep it as a consistent option while allowing more freedom to use other more interactive sword abilities.

Flesh Hook:
- Decreased cooldown from 18 to 13 seconds, but also decreased the cooldown decrease per level from 2 to 1.
- Hit flesh hooks also apply slowness for 1 second

These changes should help flesh hook be viable at lower levels and also reward hitting it a bit more. Flesh hook was pretty useless against assassins since they could flash away as soon as they were hit. The one second of slowness should help prevent assassins from escaping while not giving the brute any additional advantage once the enemy has been pulled to them.

Block Toss:
- Increased velocity, lowered size, lowered damage, lowered cooldown

Block toss was very easy to hit but had such a long cooldown that it was only ever used once per fight. By decreasing the cooldown, increasing the velocity, and lowering the size. It means that block toss will be more of a skill shot that has less impact but also happens more often, making the skill more viable overall. 

Takedown:
- Increased size of hit detection hitbox
- Lowered vertical height
- Stopped users velocity when they hit a target
- Lowered slowness duration scaling

This will make takedown easier to hit, but slightly less rewarding when you do at higher levels. The problem with takedown is that often you would fly over people, or when you hit them you would fly past them. These changes should help mitigate it while making the skill less oppressive at high levels and more potent at lower levels. (With the no jump change, 5 seconds of no jump slowness is much more oppressive than it used to be)

Threatening Shout:
- Increased cooldown
- Lowered strength of vulnerability
- lowered vulnerability hitbox slightly.

Threatening shout had too quick of a cooldown for how strong it was, its aoe effects were also too forgiving to warrant level 3 vulnerability. These changes should help put it in line with the power levels of the other axe abilities.

Stampede: 
- Reduced duration per stack from 6 to 5

Stampede was too fast during the alpha, but the nerf it received was quite heavy and a bit too much. This duration is a middle ground between the two extremes and should hopefully make the skill more balanced on both sides.