### PR TITLE
Fix tree feller durability

### DIFF
--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.ProfessionHandler;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
@@ -18,6 +19,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -106,8 +108,16 @@ public class WoodcuttingHandler extends ProfessionHandler {
         if (amountChopped > 1 && (toolUsedMeta instanceof Damageable metaAsDamageable)) {
             // Tree Feller is supposed to work only w/ axes so no need to check
 
-            metaAsDamageable.setDamage(amountChopped);
-            toolUsed.setItemMeta(toolUsedMeta);
+            // the way unbreaking rune works is by cancelling the whole event, not
+            // just reduction so that's why originalDamage will always equal damage
+            PlayerItemDamageEvent playerItemDamageEvent = UtilServer.callEvent(
+                    new PlayerItemDamageEvent(player, toolUsed, amountChopped, amountChopped)
+            );
+
+            if (!playerItemDamageEvent.isCancelled()) {
+                metaAsDamageable.setDamage(amountChopped);
+                toolUsed.setItemMeta(toolUsedMeta);
+            }
         }
 
         // Checking if >0 is probably not necessary, but it's here for clarity

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -9,6 +9,7 @@ import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.ProfessionHandler;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
 import me.mykindos.betterpvp.progression.profession.woodcutting.leaderboards.TotalLogsChoppedLeaderboard;
 import me.mykindos.betterpvp.progression.profession.woodcutting.repository.WoodcuttingRepository;
 import me.mykindos.betterpvp.progression.profile.ProfessionData;
@@ -18,6 +19,8 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -58,23 +61,28 @@ public class WoodcuttingHandler extends ProfessionHandler {
     /**
      * This handles all the experience gaining and logging that happens when a
      * player chops a log (`block`)
+     * @param chopLogEvent the event that was called
      * @param experienceModifier represents a higher order function that modifies
      *                           the experience gained by the player here.
      */
-    public void attemptToChopLog(Player player, Material originalBlockType, Block block, DoubleUnaryOperator experienceModifier,
-                                 int amountChopped, int additionalLogsDropped) {
+    public void attemptToChopLog(PlayerChopLogEvent chopLogEvent, DoubleUnaryOperator experienceModifier) {
+
+        Player player = chopLogEvent.getPlayer();
         ProfessionData professionData = getProfessionData(player.getUniqueId());
         if (professionData == null) {
             return;
         }
 
+        Material originalBlockType = chopLogEvent.getLogType();
         long experience = getExperienceFor(originalBlockType);
         if (experience <= 0) {
             return;
         }
 
+        int amountChopped = chopLogEvent.getAmountChopped();
         final double finalExperience = experienceModifier.applyAsDouble(experience) * amountChopped;
 
+        Block block = chopLogEvent.getChoppedLogBlock();
         if (didPlayerPlaceBlock(block)) {
             professionData.grantExperience(0, player);
             return;
@@ -90,7 +98,20 @@ public class WoodcuttingHandler extends ProfessionHandler {
         long logsChopped = (long) professionData.getProperties().getOrDefault("TOTAL_LOGS_CHOPPED", 0L);
         professionData.getProperties().put("TOTAL_LOGS_CHOPPED", logsChopped + ((long) amountChopped));
 
+
+
+        ItemStack toolUsed = chopLogEvent.getToolUsed();
+        ItemMeta toolUsedMeta = toolUsed.getItemMeta();
+
+        if (amountChopped > 1 && (toolUsedMeta instanceof Damageable metaAsDamageable)) {
+            // Tree Feller is supposed to work only w/ axes so no need to check
+
+            metaAsDamageable.setDamage(amountChopped);
+            toolUsed.setItemMeta(toolUsedMeta);
+        }
+
         // Checking if >0 is probably not necessary, but it's here for clarity
+        int additionalLogsDropped = chopLogEvent.getAdditionalLogsDropped();
         if (additionalLogsDropped > 0) {
             block.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(originalBlockType, additionalLogsDropped));
         }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerChopLogEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerChopLogEvent.java
@@ -5,11 +5,17 @@ import lombok.Setter;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 @Getter
 public class PlayerChopLogEvent extends ProgressionWoodcuttingEvent {
     private final Material logType;
     private final Block choppedLogBlock;
+
+    /**
+     * The tool that the player used to chop the log
+     */
+    private final ItemStack toolUsed;
 
     /**
      * This is the number by which the player's xp will be multiplied by.
@@ -18,15 +24,19 @@ public class PlayerChopLogEvent extends ProgressionWoodcuttingEvent {
     @Setter
     private double experienceBonusModifier = 1.0;
 
+    /**
+     * Will be more than one if Tree Feller was activated
+     */
     @Setter
     private int amountChopped = 0;
 
     @Setter
     private int additionalLogsDropped = 0;
 
-    public PlayerChopLogEvent(Player player, Material logType, Block choppedLogBlock) {
+    public PlayerChopLogEvent(Player player, Material logType, Block choppedLogBlock, ItemStack toolUsed) {
         super(player);
         this.logType = logType;
         this.choppedLogBlock = choppedLogBlock;
+        this.toolUsed = toolUsed;
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.function.DoubleUnaryOperator;
 
@@ -43,15 +44,17 @@ public class WoodcuttingListener implements Listener {
 
         if (!woodcuttingHandler.getExperiencePerWood().containsKey(blockType)) return;
 
+        ItemStack toolUsed = event.getPlayer().getInventory().getItemInMainHand();
         Block choppedLogBlock = event.getBlock();
-        PlayerChopLogEvent chopLogEvent = UtilServer.callEvent(new PlayerChopLogEvent(event.getPlayer(), blockType,
-                choppedLogBlock));
+        PlayerChopLogEvent chopLogEvent = UtilServer.callEvent(
+                new PlayerChopLogEvent(event.getPlayer(), blockType, choppedLogBlock, toolUsed));
 
         // if the player doesn't have tree feller, then add the log that was chopped manually here
-        int amountChopped = chopLogEvent.getAmountChopped() > 0 ? chopLogEvent.getAmountChopped() : 1;
+        if (chopLogEvent.getAmountChopped() <= 0) {
+            chopLogEvent.setAmountChopped(1);
+        }
 
         DoubleUnaryOperator experienceModifier = (xp) -> xp * chopLogEvent.getExperienceBonusModifier();
-        woodcuttingHandler.attemptToChopLog(event.getPlayer(), chopLogEvent.getLogType(), event.getBlock(), experienceModifier,
-                amountChopped, chopLogEvent.getAdditionalLogsDropped());
+        woodcuttingHandler.attemptToChopLog(chopLogEvent, experienceModifier);
     }
 }


### PR DESCRIPTION
## Describe your changes
- __Tree Feller__ didn't damage the tool or cause any durability so now this should fix that
- For every log felled, 1 durability is taken off
- Works with __Unbreaking Rune__

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
