### PR TITLE
Add a log for UUIDItems being looted from dungeons/events

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/items/listener/UUIDListener.java
@@ -12,6 +12,7 @@ import me.mykindos.betterpvp.core.client.properties.ClientProperty;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.combat.events.KillContributionEvent;
 import me.mykindos.betterpvp.core.combat.stats.model.Contribution;
+import me.mykindos.betterpvp.core.framework.events.items.SpecialItemDropEvent;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.items.ItemHandler;
 import me.mykindos.betterpvp.core.items.uuiditem.UUIDItem;
@@ -156,6 +157,18 @@ public class UUIDListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
+    public void onUUIDDrop (SpecialItemDropEvent event) {
+        itemHandler.getUUIDItem(event.getItem().getItemStack()).ifPresent(uuidItem -> {
+            Location location = event.getItem().getLocation();
+            log.info("({}) was looted from {} at {}",
+                    uuidItem.getUuid(), event.getSource(), UtilWorld.locationToString(location))
+                    .setAction("ITEM_LOOT_SPAWN").addItemContext(uuidItem)
+                    .addContext(LogContext.SOURCE, event.getSource())
+                    .addLocationContext(location).submit();
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onUUIDPickup(EntityPickupItemEvent event) {
         if (event.isCancelled()) return;
         Optional<UUIDItem> uuidItemOptional = itemHandler.getUUIDItem(event.getItem().getItemStack());
@@ -164,7 +177,8 @@ public class UUIDListener implements Listener {
         }
         UUIDItem uuidItem = uuidItemOptional.get();
         Location location = event.getEntity().getLocation();
-        PendingLog pendingLog = log.info("{} picked up ({}) at ({})", event.getEntity().getName(), uuidItem.getUuid(), UtilWorld.locationToString(location))
+        PendingLog pendingLog = log.info("{} picked up ({}) at {}",
+                event.getEntity().getName(), uuidItem.getUuid(), UtilWorld.locationToString(location))
                 .setAction("ITEM_PICKUP").addLocationContext(location);
 
         if (event.getEntity() instanceof Player player) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/LogContext.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/LogContext.java
@@ -27,4 +27,7 @@ public class LogContext {
     // Items
     public static final String ITEM = "Item";
     public static final String ITEM_NAME = "ItemName";
+
+    // Dungeons
+    public static final String SOURCE = "Source";
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/LootSpawnItemLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/LootSpawnItemLogFormatter.java
@@ -1,0 +1,30 @@
+package me.mykindos.betterpvp.core.logging.formatters.items;
+
+import me.mykindos.betterpvp.core.framework.annotations.WithReflection;
+import me.mykindos.betterpvp.core.logging.LogContext;
+import me.mykindos.betterpvp.core.logging.formatters.ILogFormatter;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import java.util.HashMap;
+
+@WithReflection
+public class LootSpawnItemLogFormatter implements ILogFormatter {
+
+    @Override
+    public String getAction() {
+        return "ITEM_LOOT_SPAWN";
+    }
+
+    @Override
+    public Component formatLog(HashMap<String, String> context) {
+        return Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN)
+                .append(Component.text(" was looted from ", NamedTextColor.GRAY))
+                .append(Component.text(context.get(LogContext.SOURCE), NamedTextColor.GREEN)
+                        .hoverEvent(HoverEvent.showText(Component.text(context.get(LogContext.ITEM)))))
+                .append(Component.text(" at ", NamedTextColor.GRAY))
+                .append(Component.text(context.get(LogContext.LOCATION), NamedTextColor.YELLOW));
+
+    }
+}


### PR DESCRIPTION
Add a log that uses the SpecialSpawnItemEvent to track UUIDItems being created from dungeons/events

Fixes #737

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
