### PR TITLE
Drastic fix to prevent passing the border

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
@@ -56,6 +56,14 @@ public class UtilLocation {
             final Vector increment = direction.clone().multiply(0.2 * i);
             final Location newLocation = entity.getLocation().add(increment);
 
+            if (!worldBorder.isInside(newLocation)) {
+                // prevent teleport at all
+                if (then != null) {
+                    then.accept(Boolean.FALSE);
+                }
+                return;
+            }
+
             // Get the bounding box of the entity as if they were standing on the new location
             BoundingBox relativeBoundingBox = UtilLocation.copyAABBToLocation(entity.getBoundingBox(), newLocation);
 
@@ -97,10 +105,6 @@ public class UtilLocation {
 
             if (!entity.hasLineOfSight(newTeleportLocation) || !entity.hasLineOfSight(headBlock)) {
                 break; // Stop raying if we don't have line of sight
-            }
-
-            if (!worldBorder.isInside(newTeleportLocation)) {
-                break; // Stop raying if this would hit the world border
             }
 
             teleportLocation = newTeleportLocation;


### PR DESCRIPTION
stop teleport if it would hit the border

Completely cancel the teleport if it would hit the border. This allows the vanilla behavior when encountering the border to always work, and should always prevent players from getting past the border. Will stop the skill, but not use the skill. This only happens if it would hit the border (standing at the border and using a skill not directed at the border will still work).

Fixes #795
Fixes #1011 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
