### PR TITLE
Blink Rework

### DIFF
--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -107,11 +107,11 @@ skills:
       durationPerLevel: 0.5
     blink:
       enabled: true
-      cooldown: 13.0
+      cooldown: 12.0
       maxlevel: 5
-      maxTravelDistance: 9
+      maxTravelDistance: 12
       canUseWhileSlowed: false
-      cooldownDecreasePerLevel: 1.0
+      cooldownDecreasePerLevel: 0.0
       distanceIncreasePerLevel: 3
       deblinkTime: 4
       deblinkTimeIncreasePerLevel: 0


### PR DESCRIPTION
## Describe your changes
- Cooldown set to a constant 12 like mineplex
- Base distance now starts at 12 blocks like mineplex
- Distance scales by 2 instead of 3 per level
- Killing players resets blink cooldown

These changes will hopefully make blink less oppressive in terms of raw mobility but more useful for fighting and escaping, allowing it to compete with flash in combat

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
