### PR TITLE
Add Component Wrapping

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/builds/menus/buttons/EditBuildButton.java
@@ -11,10 +11,12 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.inventory.item.ItemProvider;
 import me.mykindos.betterpvp.core.menu.Windowed;
 import me.mykindos.betterpvp.core.menu.button.FlashingButton;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -23,6 +25,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 
 public class EditBuildButton extends FlashingButton<BuildMenu> {
@@ -84,6 +87,7 @@ public class EditBuildButton extends FlashingButton<BuildMenu> {
     public ItemProvider getItemProvider(BuildMenu gui) {
         final Component standardComponent = Component.text("Edit Build " + build, NamedTextColor.GRAY);
         final Component flashComponent = Component.empty().append(Component.text("Click Me!", NamedTextColor.GREEN)).appendSpace().append(standardComponent);
+
         return ItemView.builder().material(Material.ANVIL)
                 .displayName(this.isFlashing() ? flashComponent : standardComponent)
                 .glow(this.isFlash())

--- a/core/src/main/java/me/mykindos/betterpvp/core/tips/TipListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/tips/TipListener.java
@@ -79,9 +79,12 @@ public class TipListener implements Listener {
         if (tipList.size() > 0) {
             Tip tip = tipList.random();
             UtilMessage.message(player, "Tips", tip.getComponent());
+
+            Bukkit.broadcastMessage(UtilMessage.infoAboutComponent(tip.getComponent()));
+            log.info(UtilMessage.infoAboutComponent(tip.getComponent()));
             event.getGamer().setLastTipNow();
         } else {
-            log.error("No valid tips for " + player.getName()).submit();
+            log.warn("No valid tips for " + player.getName()).submit();
         }
 
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
@@ -1,23 +1,34 @@
 package me.mykindos.betterpvp.core.utilities;
 
 import lombok.AccessLevel;
+import lombok.CustomLog;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 import me.mykindos.betterpvp.core.client.Rank;
+import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.examination.Examinable;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.checkerframework.checker.units.qual.min;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@CustomLog
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UtilMessage {
 
@@ -267,6 +278,140 @@ public class UtilMessage {
         return deserialize(String.format(message, args));
     }
 
+    public static String infoAboutComponent(Component component) {
+        String information = component.examinableName();
+        if (component instanceof TextComponent textComponent) {
+            information += "\nText Component";
+            information += "\nContent: " + textComponent.content();
+        }
+        if (component.hasStyling()) {
+            information += "\nStyle: " + component.style().toString();
+        }
+        information += "\nChildren (" + component.children().size() + ")";
+        for (Component child : component.children()) {
+            information += "\n" + infoAboutComponent(child);
+        }
+        return information;
+    }
+
+    /**
+     * Turns a text component into a list of TextComponents, each 1 character long, with the same style
+     * @param component the text component to flatten
+     * @return A list of TextComponents 1 character long
+     */
+    public static List<TextComponent> flattenComponent(TextComponent component) {
+        List<TextComponent> components = new ArrayList<>();
+        Style style = component.style();
+        for (char c : component.content().toCharArray()) {
+            components.add(Component.text()
+                    .content(String.valueOf(c))
+                    .style(style)
+                    .build());
+        }
+        for (Component child : component.children()) {
+            components.addAll(flattenComponent((TextComponent) child));
+        }
+
+        return components;
+    }
+
+    //TODO ignore whitespace if new line starts with it
+    //TODO handle remainder (what happens if we end and last break isn't i?)
+    public static List<TextComponent> split(TextComponent message, int min, int max) {
+        //Bukkit.broadcastMessage("New split, min: " + min + " max: " + max);
+        //Bukkit.broadcast(message);
+
+        List<TextComponent> newLines = new ArrayList<>();
+        List<TextComponent> elements = flattenComponent(message);
+
+        int currentLineLength = 0;
+        int lastSpace = 0;
+        int lastBreak = 0;
+
+        for (int i = 0; i < elements.size(); i++) {
+            TextComponent component = elements.get(i);
+            String content = component.content();
+
+            //Bukkit.broadcast(component);
+            //Bukkit.broadcastMessage("i: " + i + " line length: " + currentLineLength + " last space: " + lastSpace + " last break: " + lastBreak);
+            int length = content.length();
+            if (content.equals("\n")) {
+                //Bukkit.broadcastMessage("newline, breaking");
+                //this is a line break, so add this to our new component list
+                int n = i + 1;
+                newLines.add(getComponentFromList(elements, lastBreak, n));
+                currentLineLength = 0;
+                lastSpace = n;
+                lastBreak = n;
+                continue;
+            }
+            if (content.isBlank()) {
+                if (currentLineLength == 0) {
+                    //ignore whitespace if it is at the beginning of a line
+                    //Bukkit.broadcastMessage("space at beginning, ignoring");
+                    lastBreak = i + 1;
+                    continue;
+                }
+                //this is a space, set the last space to here
+                //Bukkit.broadcastMessage("space");
+                lastSpace = i;
+            }
+            if (currentLineLength + length <= min && currentLineLength + length < max) {
+                    //still must be less than max
+                    currentLineLength += length;
+                    //Bukkit.broadcastMessage("new length is less than equal to min, is now: " + currentLineLength);
+                    continue;
+                }
+
+            //Bukkit.broadcastMessage("line is greater than min or is greater than max");
+            //now greater than the min alloted.
+            if (lastSpace == i) {
+                //we have hit a space, add a new component and then continue
+                //Bukkit.broadcastMessage("found a space, returning");
+                int n = i + 1;
+                newLines.add(getComponentFromList(elements, lastBreak, n));
+                currentLineLength = 0;
+                lastSpace = n;
+                lastBreak = n;
+                continue;
+            }
+            if (currentLineLength + length >= max) {
+                //Bukkit.broadcastMessage("line is at max");
+                //we have hit the maximum length of a line
+                if (lastSpace <= lastBreak) {
+                    //there is no spaces in this line, just cut it off here
+                    //Bukkit.broadcastMessage("solid chunk");
+                    int n = i + 1;
+                    newLines.add(getComponentFromList(elements, lastBreak, n));
+                    currentLineLength = 0;
+                    lastBreak = n;
+                    continue;
+                }
+                //we split at the most recent space
+                //Bukkit.broadcastMessage("Going from last space");
+                newLines.add(getComponentFromList(elements, lastBreak, lastSpace));
+                currentLineLength = i - (lastSpace);
+                lastBreak = lastSpace + 1;
+                continue;
+            }
+            //we have not hit a space or the max, continue incrementing
+            //Bukkit.broadcastMessage("incrementing above min");
+            currentLineLength += length;
+            continue;
+        }
+        //handle remainder
+        newLines.add(getComponentFromList(elements, lastBreak, elements.size()));
+        return newLines;
+    }
+
+    private static TextComponent getComponentFromList(List<TextComponent> elements, int start, int end) {
+        Component component = Component.empty();
+        for (int i = start; i < end; i++) {
+            component = component.append(elements.get(i));
+        }
+        return (TextComponent) component.compact();
+    }
+
     public static Component normalize(Component component) {
         return component.applyFallbackStyle(NamedTextColor.GRAY);
     }
@@ -315,6 +460,19 @@ public class UtilMessage {
      */
     public static void broadcast(Component message) {
         Bukkit.getServer().broadcast(message);
+    }
+
+    @Data
+    public static class ComponentSplit {
+        @Nullable Component current;
+        @Nullable Component remainder;
+        int usedLength;
+
+        public ComponentSplit(@Nullable Component current, Component remainder, int usedLength) {
+            this.current = current;
+            this.remainder = remainder;
+            this.usedLength = usedLength;
+        }
     }
 
 }


### PR DESCRIPTION
Add a UtilMessage function that performs wrapping on the provided function
Wraps based on min/max characters. (will enter new line first space after min, or after last space if at max)
Works by flattening the component into a list of components, each 1 char long, with the proper styling. Then does wrap logic, compacts the returned list of components.

TODO:
- [ ] Have a function that returns a single component with newlines
- [ ] Implement this with descriptions

## Link to issue (if applicable)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [x] I have tested my changes.
