### PR TITLE
Improve Skill Feedback For Specific Skills

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -16,14 +16,11 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
-import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilLocation;
-import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -38,6 +35,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -217,16 +215,15 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
         //move along the vector in the opposite direction of facing
         vector.multiply(0.75);
 
-        List<Player> viewers = new java.util.ArrayList<>(UtilPlayer.getNearbyPlayers(player, 16).stream()
-                .map(KeyValue::getKey).toList());
+        List<Player> viewers = new ArrayList<>(player.getWorld().getNearbyPlayers(player.getLocation(), 16));
         viewers.remove(player);
 
         final Location particleLocation = location.add(vector).add(0, -0.3, 0);
         Particle.DUST.builder()
                 .location(particleLocation)
                 .offset(0, 0, 0)
-                .color(Color.BLACK, 0.5f)
                 .receivers(viewers)
+                .color(Color.BLACK, 0.5f)
                 .spawn();
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -16,14 +16,18 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilLocation;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
@@ -36,6 +40,7 @@ import org.bukkit.util.Vector;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
 
 @Singleton
@@ -193,12 +198,36 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
                         player.getWorld().playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 2.0f, 1.0f);
                         it.remove();
                     }
+                    spawnParticles(player);
                 }
 
             } else {
                 it.remove();
             }
         }
+    }
+
+    public void spawnParticles(Player player) {
+        final Location location = player.getEyeLocation().clone();
+        //get where player is facing
+        Vector vector = location.getDirection()
+                .clone()
+                .normalize();
+
+        //move along the vector in the opposite direction of facing
+        vector.multiply(0.75);
+
+        List<Player> viewers = new java.util.ArrayList<>(UtilPlayer.getNearbyPlayers(player, 16).stream()
+                .map(KeyValue::getKey).toList());
+        viewers.remove(player);
+
+        final Location particleLocation = location.add(vector).add(0, -0.3, 0);
+        Particle.DUST.builder()
+                .location(particleLocation)
+                .offset(0, 0, 0)
+                .color(Color.BLACK, 0.5f)
+                .receivers(viewers)
+                .spawn();
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
@@ -12,6 +12,9 @@ import me.mykindos.betterpvp.core.combat.events.VelocityType;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 
@@ -57,9 +60,20 @@ public class Colossus extends Skill implements PassiveSkill, UtilitySkill {
         if(event.getVelocityType() != VelocityType.KNOCKBACK && event.getVelocityType() != VelocityType.KNOCKBACK_CUSTOM) return;
 
         int level = getLevel(player);
-        if(level > 0) {
+        if (level > 0) {
             event.setVector(event.getVector().multiply(1 - ((reductionPerLevel) * level)));
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_PLACE, 0.075f, 0.5f - (0.1f * level));
+            spawnParticles(player);
         }
+    }
+
+    private void spawnParticles(Player player) {
+        Particle.BLOCK.builder()
+                .location(player.getLocation().clone().add(0, player.getHeight()/2, 0))
+                .data(Material.STONE.createBlockData())
+                .receivers(32)
+                .count(4)
+                .spawn();
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
@@ -56,13 +56,13 @@ public class Colossus extends Skill implements PassiveSkill, UtilitySkill {
 
     @EventHandler
     public void onCustomVelocity(CustomEntityVelocityEvent event) {
-        if(!(event.getEntity() instanceof Player player)) return;
-        if(event.getVelocityType() != VelocityType.KNOCKBACK && event.getVelocityType() != VelocityType.KNOCKBACK_CUSTOM) return;
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (event.getVelocityType() != VelocityType.KNOCKBACK && event.getVelocityType() != VelocityType.KNOCKBACK_CUSTOM) return;
 
         int level = getLevel(player);
         if (level > 0) {
             event.setVector(event.getVector().multiply(1 - ((reductionPerLevel) * level)));
-            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_PLACE, 0.075f, 0.5f - (0.1f * level));
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_PLACE, 0.075f, 0.05f - (0.01f * (level - 1)));
             spawnParticles(player);
         }
     }
@@ -70,9 +70,9 @@ public class Colossus extends Skill implements PassiveSkill, UtilitySkill {
     private void spawnParticles(Player player) {
         Particle.BLOCK.builder()
                 .location(player.getLocation().clone().add(0, player.getHeight()/2, 0))
-                .data(Material.STONE.createBlockData())
+                .data(Material.CHISELED_STONE_BRICKS.createBlockData())
                 .receivers(32)
-                .count(4)
+                .count(6)
                 .spawn();
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Colossus.java
@@ -62,7 +62,7 @@ public class Colossus extends Skill implements PassiveSkill, UtilitySkill {
         int level = getLevel(player);
         if (level > 0) {
             event.setVector(event.getVector().multiply(1 - ((reductionPerLevel) * level)));
-            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_PLACE, 0.075f, 0.05f - (0.01f * (level - 1)));
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BELL_USE, 1f, 2f);
             spawnParticles(player);
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
@@ -100,7 +100,7 @@ public class Fortify extends Skill implements PassiveSkill, DefensiveSkill {
             Particle.DUST.builder()
                     .count(1)
                     .location(location.clone().add(x[i], player.getHeight()/2, z[i]))
-                    .color(Color.BLUE, 0.5f)
+                    .color(Color.fromRGB(81, 184, 172), 0.5f)
                     .receivers(16)
                     .spawn();
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
@@ -11,7 +11,8 @@ import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.utilities.UtilMath;
+import org.bukkit.Color;
+import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -24,9 +25,27 @@ public class Fortify extends Skill implements PassiveSkill, DefensiveSkill {
     public int base;
     public int increasePerLevel;
 
+    final int numParticles;
+    final double particleRadius;
+    private final double[] x;
+    private final double[] z;
+
+
     @Inject
     public Fortify(Champions champions, ChampionsManager championsManager) {
         super(champions, championsManager);
+        numParticles = 8;
+        particleRadius = 0.5;
+
+        x = new double[numParticles];
+        z = new double[numParticles];
+
+        for (int i = 0; i < this.numParticles; i++) {
+            final double angleValue = Math.toRadians(((double)i/this.numParticles) * 360);
+            this.x[i] = Math.cos(angleValue) * this.particleRadius;
+            this.z[i] = Math.sin(angleValue) * this.particleRadius;
+        }
+
     }
 
     @Override
@@ -75,18 +94,14 @@ public class Fortify extends Skill implements PassiveSkill, DefensiveSkill {
     }
 
     private void doParticles(Player player) {
-        double xLimit = 0.4;
-        double yLimit = 0.4;
-        double zLimit = 0.4;
+        final Location location = player.getLocation();
 
-        for (int i = 0; i <= 4; i++) {
-            double x = UtilMath.randDouble(-xLimit, xLimit);
-            double y = UtilMath.randDouble(-yLimit, yLimit);
-            double z = UtilMath.randDouble(-zLimit, zLimit);
-            Particle.RAID_OMEN.builder()
-                    .location(player.getLocation().add(x, 1 + y, z))
-                    .offset(0, 0, 0)
-                    .receivers(30)
+        for (int i = 0; i < this.numParticles; i++) {
+            Particle.DUST.builder()
+                    .count(1)
+                    .location(location.clone().add(x[i], player.getHeight()/2, z[i]))
+                    .color(Color.BLUE, 0.5f)
+                    .receivers(16)
                     .spawn();
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Fortify.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
-import org.bukkit.Color;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -80,14 +79,14 @@ public class Fortify extends Skill implements PassiveSkill, DefensiveSkill {
         double yLimit = 0.4;
         double zLimit = 0.4;
 
-        for (int i = 0; i <= 10; i++) {
+        for (int i = 0; i <= 4; i++) {
             double x = UtilMath.randDouble(-xLimit, xLimit);
             double y = UtilMath.randDouble(-yLimit, yLimit);
             double z = UtilMath.randDouble(-zLimit, zLimit);
-            Particle.DUST.builder()
+            Particle.RAID_OMEN.builder()
                     .location(player.getLocation().add(x, 1 + y, z))
+                    .offset(0, 0, 0)
                     .receivers(30)
-                    .data(new Particle.DustOptions(Color.BLUE, 1))
                     .spawn();
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
@@ -147,7 +147,7 @@ public class Stampede extends Skill implements PassiveSkill, MovementSkill, Dama
                 }
                 if (data.getSprintStrength() > 0) {
                     championsManager.getEffects().addEffect(player, player, EffectTypes.SPEED, getName(), data.getSprintStrength(), 2200, true);
-                    spawnParticles(player.getLocation(), (data.getSprintStrength() + 3) * 3);
+                    spawnParticles(player.getLocation(), (data.getSprintStrength() + 3) * 2);
                 }
             } else {
                 removeSpeed(player);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
@@ -20,11 +20,15 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.math.VelocityData;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -138,15 +142,29 @@ public class Stampede extends Skill implements PassiveSkill, MovementSkill, Dama
                         championsManager.getEffects().addEffect(player, player, EffectTypes.SPEED, getName(), data.getSprintStrength(), 2200, true);
                         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_AMBIENT, 2.0F, 0.2F * data.getSprintStrength() + 1.2F);
                         UtilMessage.simpleMessage(player, getClassType().getName(), "Stampede Level: <yellow>%d", data.getSprintStrength());
+                        spawnParticles(player.getLocation(), 30);
                     }
                 }
                 if (data.getSprintStrength() > 0) {
                     championsManager.getEffects().addEffect(player, player, EffectTypes.SPEED, getName(), data.getSprintStrength(), 2200, true);
+                    spawnParticles(player.getLocation(), (data.getSprintStrength() + 3) * 3);
                 }
             } else {
                 removeSpeed(player);
                 iterator.remove();
             }
+        }
+
+    }
+
+    private void spawnParticles(Location location, int count) {
+        for (int i = 0; i < count; i ++) {
+            Particle.ENTITY_EFFECT.builder()
+                    .location(location.clone()
+                            .add(UtilMath.randDouble(-0.2, 0.2), UtilMath.randDouble(0.0, 0.1), UtilMath.randDouble(-0.2, 0.2)))
+                    .receivers(60)
+                    .data(Color.WHITE)
+                    .spawn();
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Stampede.java
@@ -142,7 +142,7 @@ public class Stampede extends Skill implements PassiveSkill, MovementSkill, Dama
                         championsManager.getEffects().addEffect(player, player, EffectTypes.SPEED, getName(), data.getSprintStrength(), 2200, true);
                         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_AMBIENT, 2.0F, 0.2F * data.getSprintStrength() + 1.2F);
                         UtilMessage.simpleMessage(player, getClassType().getName(), "Stampede Level: <yellow>%d", data.getSprintStrength());
-                        spawnParticles(player.getLocation(), 30);
+                        spawnParticles(player.getLocation(), (maxSpeedStrength + 2 + 3) * 2);
                     }
                 }
                 if (data.getSprintStrength() > 0) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
@@ -15,16 +15,11 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
-import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
-import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -33,7 +28,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 import java.util.WeakHashMap;
 
@@ -165,13 +159,21 @@ public class DefensiveStance extends ChannelSkill implements CooldownSkill, Inte
             }
             else {
                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_STONE_STEP, 0.5F, 1.0F);
-                spawnParticles(player);
             }
 
         }
 
     }
 
+    @Override
+    public boolean isShieldInvisible() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldShowShield(Player player) {
+        return !championsManager.getCooldowns().hasCooldown(player, getName());
+    }
 
     @Override
     public float getEnergy(int level) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
@@ -15,12 +15,16 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import org.bukkit.Bukkit;
-import org.bukkit.Effect;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -29,6 +33,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
 import java.util.WeakHashMap;
 
@@ -159,7 +164,8 @@ public class DefensiveStance extends ChannelSkill implements CooldownSkill, Inte
                 iterator.remove();
             }
             else {
-                player.getWorld().playEffect(player.getLocation(), Effect.STEP_SOUND, 20);
+                player.getWorld().playSound(player.getLocation(), Sound.BLOCK_STONE_STEP, 0.5F, 1.0F);
+                spawnParticles(player);
             }
 
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
@@ -166,6 +166,7 @@ public class DefensiveStance extends ChannelSkill implements CooldownSkill, Inte
 
     }
 
+
     @Override
     public float getEnergy(int level) {
         return (float) (energy - ((level - 1) * energyDecreasePerLevel));

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/listeners/RuneCraftingListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/runes/listeners/RuneCraftingListener.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.items.BPvPItem;
 import me.mykindos.betterpvp.core.items.ItemHandler;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -46,7 +45,7 @@ public class RuneCraftingListener implements Listener {
     }
 
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPrepareAnvil(PrepareAnvilEvent event) {
 
         var firstItem = event.getInventory().getFirstItem();
@@ -56,10 +55,10 @@ public class RuneCraftingListener implements Listener {
         if (secondItem == null) return;
 
         BPvPItem item = itemHandler.getItem(secondItem);
-        if(!(item instanceof Rune rune)) return;
+        if (!(item instanceof Rune rune)) return;
 
-        if(!rune.itemMatchesFilter(firstItem.getType())) return;
-        if(!rune.canApplyToItem(secondItem.getItemMeta(), firstItem.getItemMeta())) return;
+        if (!rune.itemMatchesFilter(firstItem.getType())) return;
+        if (!rune.canApplyToItem(secondItem.getItemMeta(), firstItem.getItemMeta())) return;
 
         ItemStack result = firstItem.clone();
         ItemMeta meta = result.getItemMeta();
@@ -69,8 +68,7 @@ public class RuneCraftingListener implements Listener {
         result.setItemMeta(meta);
 
         event.setResult(itemHandler.updateNames(result));
-        // Don't ask why, it's just required for some stupid reason
-        UtilServer.runTaskLater(champions, () -> event.getInventory().setRepairCost(0), 1);
+        event.getView().setRepairCost(0);
 
     }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansWorldListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansWorldListener.java
@@ -65,6 +65,7 @@ import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -908,6 +909,12 @@ public class ClansWorldListener extends ClanListener {
             }
 
         }
+    }
+
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onAnvilUse(PrepareAnvilEvent event) {
+        event.getView().setRepairCost(9001);
     }
 
     @EventHandler

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
@@ -195,7 +195,7 @@ public class CombatListener implements Listener {
                     return;
                 }
             }
-            playDamageEffect(cde);
+            playDamageEffect(cde, customDamageReductionEvent);
         }
 
         finalizeDamage(event, customDamageReductionEvent);
@@ -476,7 +476,7 @@ public class CombatListener implements Listener {
         });
     }
 
-    private void playDamageEffect(CustomDamageEvent event) {
+    private void playDamageEffect(CustomDamageEvent event, CustomDamageReductionEvent damageReductionEvent) {
         final LivingEntity damagee = event.getDamagee();
         if (event.isHurtAnimation()) {
             damagee.playHurtAnimation(270);
@@ -493,17 +493,17 @@ public class CombatListener implements Listener {
         }
 
         if (event.getDamager() instanceof Player player) {
-            player.setLevel((int) event.getDamage());
+            player.setLevel((int) damageReductionEvent.getInitialDamage());
         }
         if ((event.getDamager() instanceof Player) && event.getCause() == DamageCause.ENTITY_ATTACK) {
             Location location = damagee.getLocation().clone().add(0, damagee.getHeight()/2, 0);
-            if (event.getDamage() >= 8.0) {
+            if (damageReductionEvent.getInitialDamage() >= 8.0) {
                 Particle.ENCHANTED_HIT.builder()
                         .location(location)
                         .count(4)
                         .receivers(32)
                         .spawn();
-            } else if (event.getDamage() >= 6.0) {
+            } else if (damageReductionEvent.getInitialDamage() >= 6.0) {
                 Particle.CRIT.builder()
                         .location(location)
                         .count(4)

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
@@ -33,7 +33,9 @@ import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.math.VelocityData;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
@@ -487,6 +489,23 @@ public class CombatListener implements Listener {
                 damagee.getWorld().playSound(sound, damagee);
             } else {
                 damagee.getWorld().playSound(damagee.getLocation(), sound.name().asString(), sound.volume(), sound.pitch());
+            }
+        }
+
+        if ((event.getDamager() instanceof Player) && event.getCause() == DamageCause.ENTITY_ATTACK) {
+            Location location = damagee.getLocation().clone().add(0, damagee.getHeight()/2, 0);
+            if (event.getDamage() >= 8.0) {
+                Particle.ENCHANTED_HIT.builder()
+                        .location(location)
+                        .count(4)
+                        .receivers(32)
+                        .spawn();
+            } else if (event.getDamage() >= 6.0) {
+                Particle.CRIT.builder()
+                        .location(location)
+                        .count(4)
+                        .receivers(32)
+                        .spawn();
             }
         }
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
@@ -492,6 +492,9 @@ public class CombatListener implements Listener {
             }
         }
 
+        if (event.getDamager() instanceof Player player) {
+            player.setLevel((int) event.getDamage());
+        }
         if ((event.getDamager() instanceof Player) && event.getCause() == DamageCause.ENTITY_ATTACK) {
             Location location = damagee.getLocation().clone().add(0, damagee.getHeight()/2, 0);
             if (event.getDamage() >= 8.0) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatListener.java
@@ -33,9 +33,7 @@ import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.math.VelocityData;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
@@ -494,22 +492,6 @@ public class CombatListener implements Listener {
 
         if (event.getDamager() instanceof Player player) {
             player.setLevel((int) damageReductionEvent.getInitialDamage());
-        }
-        if ((event.getDamager() instanceof Player) && event.getCause() == DamageCause.ENTITY_ATTACK) {
-            Location location = damagee.getLocation().clone().add(0, damagee.getHeight()/2, 0);
-            if (damageReductionEvent.getInitialDamage() >= 8.0) {
-                Particle.ENCHANTED_HIT.builder()
-                        .location(location)
-                        .count(4)
-                        .receivers(32)
-                        .spawn();
-            } else if (damageReductionEvent.getInitialDamage() >= 6.0) {
-                Particle.CRIT.builder()
-                        .location(location)
-                        .count(4)
-                        .receivers(32)
-                        .spawn();
-            }
         }
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/energy/EnergyListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/energy/EnergyListener.java
@@ -30,9 +30,6 @@ public class EnergyListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onRegen(RegenerateEnergyEvent event) {
         Player player = event.getPlayer();
-        if(player.getLevel() > 0){
-            player.setLevel(0);
-        }
         energyHandler.regenerateEnergy(event.getPlayer(), event.getEnergy());
 
     }


### PR DESCRIPTION
Add small particles for when Evade is active
Change defensive stance particles to be less obtrusive
Add stampede particles
Change fortify particles to be smaller and more consistent
Add Sound and Visual feedback for Colossus

Add particles for melee hits starting at 6.0 damage (different particles at 8.0 damage)
Add damage dealt as experience level

Fix Defensive Stance Energy Usage
Change Sacrifice to not round up to next round number of damage (make it behave more accurately to description)

Fixes #1062 
Fixes #1068 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
