### PR TITLE
Add Weakness Effect + Intimidation Rework

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Intimidation.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Intimidation.java
@@ -14,11 +14,14 @@ import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
-import me.mykindos.betterpvp.core.utilities.UtilLocation;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilSound;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,10 +34,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 @BPvPListener
 public class Intimidation extends Skill implements PassiveSkill, DebuffSkill {
 
-    private int radius;
+    private double radius;
     private int slownessStrength;
-
-
+    private int weaknessStrength;
+    private double radiusIncreasePerLevel;
+    private double hitboxSize;
 
     private final AtomicInteger soundTicks = new AtomicInteger(0);
     private final WeakHashMap<Player, Set<Player>> trackedEnemies = new WeakHashMap<>();
@@ -52,8 +56,7 @@ public class Intimidation extends Skill implements PassiveSkill, DebuffSkill {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "Every enemy facing towards you within " + getValueString(this::getRadius, level),
-                "blocks will get <effect>Slowness " + UtilFormat.getRomanNumeral(slownessStrength)
+                "Enemies you are looking at within " + getValueString(this::getRadius, level) + " blocks receive <effect>Slowness " + UtilFormat.getRomanNumeral(slownessStrength) + "</effect> and <effect>Weakness " + UtilFormat.getRomanNumeral(weaknessStrength) + "</effect>."
         };
     }
 
@@ -66,64 +69,96 @@ public class Intimidation extends Skill implements PassiveSkill, DebuffSkill {
     public void invalidatePlayer(Player player, Gamer gamer) {
         if (!trackedEnemies.containsKey(player)) return;
         for (Player tracked : trackedEnemies.get(player)) {
-            UtilPlayer.clearWarningEffect(tracked); // Clear them if they are no longer in front
+            UtilPlayer.clearWarningEffect(tracked);
         }
         trackedEnemies.remove(player);
     }
 
-    public int getRadius(int level) {
-        return radius + (level - 1);
+    public double getRadius(int level) {
+        return radius + ((level - 1) * radiusIncreasePerLevel);
     }
 
     @UpdateEvent
     public void onUpdate() {
-        final boolean sounds = soundTicks.get() == 0;
+        final boolean playSound = soundTicks.get() == 0;
         final Iterator<Player> iterator = trackedEnemies.keySet().iterator();
         while (iterator.hasNext()) {
             final Player player = iterator.next();
             if (player == null || !player.isOnline()) {
-                iterator.remove(); // Remove if not online
+                iterator.remove();
                 continue;
             }
 
             int level = getLevel(player);
             if (level < 0) {
-                iterator.remove(); // Remove because unequipped
+                iterator.remove();
                 continue;
             }
 
-            intimidateNearby(player, level, sounds);
+            intimidateEnemies(player, level, playSound);
         }
 
         if (soundTicks.addAndGet(1) >= 20) {
-            soundTicks.set(0); // Play sound every second
+            soundTicks.set(0);
         }
     }
 
-    public void intimidateNearby(Player player, int level, boolean sounds) {
+    public void intimidateEnemies(Player player, int level, boolean playSound) {
         double radius = getRadius(level);
         List<Player> nearbyEnemies = UtilPlayer.getNearbyEnemies(player, player.getLocation(), radius);
-        trackedEnemies.get(player).removeIf(enemy -> {
-            final boolean remove = !nearbyEnemies.contains(enemy);
+
+        // Get or create the tracked enemies set for the player
+        Set<Player> tracked = trackedEnemies.computeIfAbsent(player, k -> new HashSet<>());
+
+        // Remove enemies that are no longer nearby or no longer being looked at
+        tracked.removeIf(enemy -> {
+            boolean remove = !nearbyEnemies.contains(enemy) || !enemy.isOnline() || !isLookingAt(player, enemy, radius, 0.5);
             if (remove) {
                 UtilPlayer.clearWarningEffect(enemy);
+                UtilPlayer.setGlowing(player, enemy, false);
+
             }
             return remove;
-        }); // Remove enemies that are no longer nearby
+        });
 
         for (Player enemy : nearbyEnemies) {
-            if (enemy.hasLineOfSight(player) && UtilLocation.isInFront(enemy, player.getEyeLocation())) {
-                trackedEnemies.get(player).add(enemy); // track
-                UtilPlayer.setWarningEffect(enemy, 1);
-                if (sounds) {
+            if (isLookingAt(player, enemy, radius, hitboxSize)) {
+                // Apply slowness and weakness effects
+                championsManager.getEffects().addEffect(enemy, player, EffectTypes.SLOWNESS, getName(), slownessStrength, 500, true);
+                championsManager.getEffects().addEffect(enemy, player, EffectTypes.WEAKNESS, getName(), weaknessStrength, 500, true);
+
+                // Play sound effects and manage warning effects
+                if (tracked.add(enemy)) {
+                    UtilPlayer.setWarningEffect(enemy, 1);
+                    UtilPlayer.setGlowing(player, enemy, true);
+                }
+                if (playSound) {
                     UtilSound.playSound(enemy, Sound.ENTITY_WARDEN_HEARTBEAT, 1f, 1f, true);
                 }
-
-                championsManager.getEffects().addEffect(enemy, player, EffectTypes.SLOWNESS, getName(), slownessStrength, 500, true);
-            } else if (trackedEnemies.get(player).remove(enemy)) {
-                UtilPlayer.clearWarningEffect(enemy); // Clear them if they are no longer in front
+            } else if (tracked.remove(enemy)) {
+                UtilPlayer.setGlowing(player, enemy, false);
+                UtilPlayer.clearWarningEffect(enemy);
             }
         }
+    }
+
+    // Utility method to check if a player is looking at another player using ray tracing
+    private boolean isLookingAt(Player player, Player target, double maxDistance, double hitboxSize) {
+        Location eyeLocation = player.getEyeLocation();
+        Vector direction = eyeLocation.getDirection();
+
+        // Perform ray trace
+        RayTraceResult result = player.getWorld().rayTrace(
+                eyeLocation,
+                direction,
+                maxDistance,
+                FluidCollisionMode.NEVER,
+                true,
+                hitboxSize,
+                entity -> entity.equals(target)
+        );
+
+        return result != null && result.getHitEntity() != null && result.getHitEntity().equals(target);
     }
 
     @Override
@@ -138,7 +173,10 @@ public class Intimidation extends Skill implements PassiveSkill, DebuffSkill {
 
     @Override
     public void loadSkillConfig() {
-        radius = getConfig("radius", 3, Integer.class);
+        radius = getConfig("radius", 4.0, Double.class);
         slownessStrength = getConfig("slownessStrength", 1, Integer.class);
+        weaknessStrength = getConfig("weaknessStrength", 1, Integer.class);
+        radiusIncreasePerLevel = getConfig("radiusIncreasePerLevel", 3.0, Double.class);
+        hitboxSize = getConfig("hitboxSize", 0.5, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BladeBreaker.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BladeBreaker.java
@@ -1,0 +1,211 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.ChampionsManager;
+import me.mykindos.betterpvp.champions.champions.skills.Skill;
+import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
+import me.mykindos.betterpvp.champions.champions.skills.types.DebuffSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.PassiveSkill;
+import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+@Singleton
+@BPvPListener
+public class BladeBreaker extends Skill implements PassiveSkill, DebuffSkill {
+
+    @Inject
+    private CooldownManager cooldownManager;
+    public int weaknessStrength;
+    public double weaknessDuration;
+    public double weaknessDurationIncreasePerLevel;
+    public double internalCooldown;
+    public double internalCooldownDecreasePerLevel;
+
+    private static final NamespacedKey WEAKNESS_KEY = new NamespacedKey("blade_breaker_weakness", "betterpvp");
+
+    @Inject
+    public BladeBreaker(Champions champions, ChampionsManager championsManager) {
+        super(champions, championsManager);
+    }
+
+    @Override
+    public String getName() {
+        return "Blade Breaker";
+    }
+
+    @Override
+    public String[] getDescription(int level) {
+        return new String[]{
+                "Your axe attacks break the enemy's current weapon, inflicting",
+                "<effect>Weakness " + UtilFormat.getRomanNumeral(getWeaknessStrength(level)) + "</effect> for " + getValueString(this::getDuration, level) + " seconds while they hold that item",
+                "",
+                "Internal cooldown of " + getValueString(this::getInternalCooldown, level) + " seconds"
+        };
+    }
+
+    @Override
+    public Role getClassType() {
+        return Role.RANGER;
+    }
+
+    public double getDuration(int level) {
+        return weaknessDuration + ((level - 1) * weaknessDurationIncreasePerLevel);
+    }
+
+    public double getInternalCooldown(int level) {
+        return internalCooldown - ((level - 1) * internalCooldownDecreasePerLevel);
+    }
+
+    public int getWeaknessStrength(int level) {
+        return weaknessStrength;
+    }
+
+    @EventHandler
+    public void onHit(CustomDamageEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!(event.getDamagee() instanceof Player target)) return;
+
+        ItemStack heldItem = target.getInventory().getItemInMainHand();
+        if (heldItem.getType() == Material.AIR) {
+            return;
+        }
+
+        int level = getLevel(player);
+        if (level <= 0) return;
+
+        if (!SkillWeapons.isHolding(player, SkillType.AXE)) {
+            return;
+        }
+
+        if (cooldownManager.hasCooldown(player, getName())) return;
+
+        double effectDuration = getDuration(level);
+
+        applyWeakness(target, heldItem, effectDuration);
+
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_SHIELD_BREAK, 1.0F, 1.0F);
+        UtilMessage.simpleMessage(player, getClassType().getName(), "You broke <alt2>%s</alt2> with <alt>%s %d</alt>.", event.getDamagee().getName(), getName(), level);
+        event.addReason(getName());
+
+        cooldownManager.use(player, getName(), getInternalCooldown(level), true);
+    }
+
+    @EventHandler
+    public void onItemHeldChange(PlayerItemHeldEvent event) {
+        Player player = event.getPlayer();
+        ItemStack newItem = player.getInventory().getItem(event.getNewSlot());
+
+        if (hasWeaknessPersistentData(newItem)) {
+            reapplyWeakness(player, newItem);
+        } else {
+            removeWeakness(player);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        removeWeakness(event.getPlayer());
+    }
+
+    @UpdateEvent
+    public void update() {
+        for (Player player : champions.getServer().getOnlinePlayers()) {
+            ItemStack heldItem = player.getInventory().getItemInMainHand();
+            if (hasWeaknessPersistentData(heldItem)) {
+                long expirationTime = getWeaknessExpirationTime(heldItem);
+                if (System.currentTimeMillis() > expirationTime) {
+                    removeWeaknessPersistentData(heldItem);
+                    championsManager.getEffects().removeEffect(player, EffectTypes.WEAKNESS);
+                }
+            }
+        }
+    }
+
+    private void reapplyWeakness(Player player, ItemStack item) {
+        long expirationTime = getWeaknessExpirationTime(item);
+        double remainingDuration = (expirationTime - System.currentTimeMillis()) / 1000.0;
+        championsManager.getEffects().addEffect(player, EffectTypes.WEAKNESS, getName(), weaknessStrength, (long) (remainingDuration * 1000L));
+    }
+
+    private void removeWeakness(Player player) {
+        championsManager.getEffects().removeEffect(player, EffectTypes.WEAKNESS);
+    }
+
+    private boolean hasWeaknessPersistentData(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR) return false;
+        if (!item.hasItemMeta()) return false;
+
+        PersistentDataContainer container = item.getItemMeta().getPersistentDataContainer();
+        return container.has(WEAKNESS_KEY, PersistentDataType.LONG);
+    }
+
+    private long getWeaknessExpirationTime(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR || !item.hasItemMeta()) return 0;
+
+        PersistentDataContainer container = item.getItemMeta().getPersistentDataContainer();
+        if (container.has(WEAKNESS_KEY, PersistentDataType.LONG)) {
+            return container.get(WEAKNESS_KEY, PersistentDataType.LONG);
+        }
+        return 0;
+    }
+
+    private void applyWeakness(Player player, ItemStack item, double duration) {
+        if (item == null || item.getType() == Material.AIR) return;
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        long expirationTime = System.currentTimeMillis() + (long) (duration * 1000);
+
+        container.set(WEAKNESS_KEY, PersistentDataType.LONG, expirationTime);
+        item.setItemMeta(meta);
+
+        championsManager.getEffects().addEffect(player, EffectTypes.WEAKNESS, getName(), weaknessStrength, (long) (duration * 1000L));
+    }
+
+    private void removeWeaknessPersistentData(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR || !item.hasItemMeta()) return;
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.remove(WEAKNESS_KEY);
+        item.setItemMeta(meta);
+    }
+
+    @Override
+    public SkillType getType() {
+        return SkillType.PASSIVE_B;
+    }
+
+    @Override
+    public void loadSkillConfig() {
+        weaknessDuration = getConfig("weaknessDuration", 2.0, Double.class);
+        weaknessDurationIncreasePerLevel = getConfig("weaknessDurationIncreasePerLevel", 1.0, Double.class);
+        weaknessStrength = getConfig("basePushBack", 2, Integer.class);
+        internalCooldown = getConfig("internalCooldown", 5.0, Double.class);
+        internalCooldownDecreasePerLevel = getConfig("internalCooldownDecreasePerLevel", 0.0, Double.class);
+    }
+}

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -282,6 +282,9 @@ skills:
       baseBonusDamage: 1.0
       bonusDamageIncreasePerLevel: 0.5
       minBonusDamage: 0.5
+      duration: 2.0
+      durationIncreasePerLevel: 0.5
+      weaknessLevel: 1
     deflection:
       enabled: true
       maxlevel: 3
@@ -546,10 +549,12 @@ skills:
       energyDecreasePerLevel: 1.0
     intimidation:
       enabled: true
-      maxlevel: 3
-      baseRadius: 3.0
-      radius: 3
+      maxlevel: 4.0
+      radius: 4.0
       slownessStrength: 1
+      weaknessStrength: 1
+      hitboxSize: 0.5
+      radiusIncreasePerLevel: 3.0
     seismicslam:
       enabled: true
       maxlevel: 5
@@ -748,6 +753,14 @@ skills:
       energy: 24
       basePushBack: 1.0
       energyDecreasePerLevel: 2.0
+    bladebreaker:
+      enabled: true
+      maxlevel: 3
+      weaknessDuration: 2.0
+      weaknessDurationIncreasePerLevel: 1.0
+      weaknessStrength: 2
+      internalCooldown: 5.0
+      internalCooldownDecreasePerLevel: 0.0
     overcharge:
       enabled: true
       maxlevel: 5

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectTypes.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectTypes.java
@@ -16,6 +16,7 @@ import me.mykindos.betterpvp.core.effects.types.negative.SilenceEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.SlownessEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.StunEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.VulnerabilityEffect;
+import me.mykindos.betterpvp.core.effects.types.negative.WeaknessEffect;
 import me.mykindos.betterpvp.core.effects.types.negative.WitherEffect;
 import me.mykindos.betterpvp.core.effects.types.positive.AttackSpeedEffect;
 import me.mykindos.betterpvp.core.effects.types.positive.CooldownReductionEffect;
@@ -58,6 +59,7 @@ public class EffectTypes {
     public static final EffectType WITHER = createEffectType(new WitherEffect());
     public static final EffectType DARKNESS = createEffectType(new DarknessEffect());
     public static final EffectType FROZEN = createEffectType(new FrozenEffect());
+    public static final EffectType WEAKNESS = createEffectType(new WeaknessEffect());
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Positive Effect Types">

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/WeaknessListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/WeaknessListener.java
@@ -1,0 +1,37 @@
+package me.mykindos.betterpvp.core.effects.listeners.effects;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import me.mykindos.betterpvp.core.effects.Effect;
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import java.util.Optional;
+
+@BPvPListener
+@Singleton
+public class WeaknessListener implements Listener {
+
+    private final EffectManager effectManager;
+
+    @Inject
+    public WeaknessListener(EffectManager effectManager) {
+        this.effectManager = effectManager;
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onWeaknessDamage(DamageEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK) return;
+        if (event.getDamager() instanceof Player player) {
+            Optional<Effect> effectOptional = effectManager.getEffect(player, EffectTypes.WEAKNESS);
+            effectOptional.ifPresent(effect -> event.setDamage(Math.max(event.getDamage() - (1.0 * effect.getAmplifier()), 0.1)));
+        }
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/WeaknessEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/WeaknessEffect.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.effects.types.negative;
 
 import me.mykindos.betterpvp.core.effects.VanillaEffectType;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import org.bukkit.potion.PotionEffectType;
 
 public class WeaknessEffect extends VanillaEffectType {
@@ -17,7 +18,16 @@ public class WeaknessEffect extends VanillaEffectType {
 
     @Override
     public PotionEffectType getVanillaPotionType() {
-        return PotionEffectType.WEAKNESS;
+        return PotionEffectType.OOZING;
     }
 
+    @Override
+    public String getDescription(int level) {
+        return "<white>Weakness " + UtilFormat.getRomanNumeral(level) + " <reset>decreases melee damage dealt by <stat>" + (level * 1.0) + "</stat>";
+    }
+
+    @Override
+    public String getGenericDescription() {
+        return  "<white>" + getName() + "</white> decreases melee damage by <green>1.0</green> per level";
+    }
 }


### PR DESCRIPTION
Replaces the old PR with lots of merge conflicts

- Weakness reduces melee damage by 1.0 per level
- Power chop applies weakness 1 for a few seconds
- Intimidation is now activated when the user stares at a player within a range, that player will be slowed and given weakness 1
- Passive B for the new ranger, Blade Breaker: breaks the enemy's current item, causing them to have weakness 2 while holding that item for a few seconds
