### PR TITLE
Fix armor swap message and functionality

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -240,20 +240,9 @@ public class RoleListener implements Listener {
         Gamer gamer = clientManager.search().online(player).getGamer();
 
         if (UtilItem.isArmour(mainhand.getType())) {
-            ItemStack currentArmor = null;
-            Material type = mainhand.getType();
+            Material armorType = player.getInventory().getItem(mainhand.getType().getEquipmentSlot()).getType();
 
-            if (type.name().endsWith("_HELMET")) {
-                currentArmor = player.getInventory().getHelmet();
-            } else if (type.name().endsWith("_CHESTPLATE")) {
-                currentArmor = player.getInventory().getChestplate();
-            } else if (type.name().endsWith("_LEGGINGS")) {
-                currentArmor = player.getInventory().getLeggings();
-            } else if (type.name().endsWith("_BOOTS")) {
-                currentArmor = player.getInventory().getBoots();
-            }
-
-            if (currentArmor != null && currentArmor.getType() != Material.AIR && gamer.isInCombat()) {
+            if (armorType != Material.AIR && gamer.isInCombat()) {
                 UtilMessage.message(player, "Class", "You cannot hotswap armor while in combat.");
                 event.setUseItemInHand(Event.Result.DENY);
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -231,7 +231,6 @@ public class RoleListener implements Listener {
         });
     }
 
-
     @EventHandler
     public void onArmourChange(PlayerInteractEvent event) {
         if (event.getHand() == EquipmentSlot.OFF_HAND || !event.getAction().isRightClick()) return;
@@ -241,31 +240,24 @@ public class RoleListener implements Listener {
         Gamer gamer = clientManager.search().online(player).getGamer();
 
         if (UtilItem.isArmour(mainhand.getType())) {
-            ItemStack currentArmor = getCurrentHeldArmor(mainhand, player);
+            ItemStack currentArmor = null;
+            Material type = mainhand.getType();
+
+            if (type.name().endsWith("_HELMET")) {
+                currentArmor = player.getInventory().getHelmet();
+            } else if (type.name().endsWith("_CHESTPLATE")) {
+                currentArmor = player.getInventory().getChestplate();
+            } else if (type.name().endsWith("_LEGGINGS")) {
+                currentArmor = player.getInventory().getLeggings();
+            } else if (type.name().endsWith("_BOOTS")) {
+                currentArmor = player.getInventory().getBoots();
+            }
 
             if (currentArmor != null && currentArmor.getType() != Material.AIR && gamer.isInCombat()) {
                 UtilMessage.message(player, "Class", "You cannot hotswap armor while in combat.");
                 event.setUseItemInHand(Event.Result.DENY);
             }
         }
-    }
-
-    @Nullable
-    private static ItemStack getCurrentHeldArmor(ItemStack mainhand, Player player) {
-        ItemStack currentArmor = null;
-        Material type = mainhand.getType();
-
-        if (type.name().endsWith("_HELMET")) {
-            currentArmor = player.getInventory().getHelmet();
-        } else if (type.name().endsWith("_CHESTPLATE")) {
-            currentArmor = player.getInventory().getChestplate();
-        } else if (type.name().endsWith("_LEGGINGS")) {
-            currentArmor = player.getInventory().getLeggings();
-        } else if (type.name().endsWith("_BOOTS")) {
-            currentArmor = player.getInventory().getBoots();
-        }
-
-        return currentArmor;
     }
 
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -41,6 +41,7 @@ import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -235,14 +236,38 @@ public class RoleListener implements Listener {
     public void onArmourChange(PlayerInteractEvent event) {
         if (event.getHand() == EquipmentSlot.OFF_HAND || !event.getAction().isRightClick()) return;
 
-        ItemStack mainhand = event.getPlayer().getInventory().getItemInMainHand();
         Player player = event.getPlayer();
+        ItemStack mainhand = player.getInventory().getItemInMainHand();
         Gamer gamer = clientManager.search().online(player).getGamer();
-        if (UtilItem.isArmour(mainhand.getType()) && gamer.isInCombat()) {
-            UtilMessage.message(player, "Class", "You cannot remove your class while in combat.");
-            event.setUseItemInHand(Event.Result.DENY);
+
+        if (UtilItem.isArmour(mainhand.getType())) {
+            ItemStack currentArmor = getCurrentHeldArmor(mainhand, player);
+
+            if (currentArmor != null && currentArmor.getType() != Material.AIR && gamer.isInCombat()) {
+                UtilMessage.message(player, "Class", "You cannot hotswap armor while in combat.");
+                event.setUseItemInHand(Event.Result.DENY);
+            }
         }
     }
+
+    @Nullable
+    private static ItemStack getCurrentHeldArmor(ItemStack mainhand, Player player) {
+        ItemStack currentArmor = null;
+        Material type = mainhand.getType();
+
+        if (type.name().endsWith("_HELMET")) {
+            currentArmor = player.getInventory().getHelmet();
+        } else if (type.name().endsWith("_CHESTPLATE")) {
+            currentArmor = player.getInventory().getChestplate();
+        } else if (type.name().endsWith("_LEGGINGS")) {
+            currentArmor = player.getInventory().getLeggings();
+        } else if (type.name().endsWith("_BOOTS")) {
+            currentArmor = player.getInventory().getBoots();
+        }
+
+        return currentArmor;
+    }
+
 }
 
 


### PR DESCRIPTION
## Describe your changes
- Fixed incorrect chat message when trying to equip armor from the hotbar while in combat
- Loosened the restrictions so that you can still right click armor from the hotbar while you have no armor equiped, but cannot while having armor equipped in that same type of armor slot. 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
