### PR TITLE
Change c stuck timer to the same duration as c home

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -247,13 +247,8 @@ public class ClansMovementListener extends ClanListener {
             return;
         }
 
-        ClanRelation relation = clanManager.getRelation(clanManager.getClanByPlayer(player).orElse(null), territoryOptional.get());
+        event.setDelayInSeconds(20);
 
-        if (relation == ClanRelation.ENEMY) {
-            event.setDelayInSeconds(120);
-        } else {
-            event.setDelayInSeconds(60);
-        }
         if (event.getDelayInSeconds() > 0) {
             UtilMessage.simpleMessage(player, "Clans", "Teleporting to nearest wilderness in <green>%.1f</green> seconds, don't move!", event.getDelayInSeconds());
         }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -247,7 +247,7 @@ public class ClansMovementListener extends ClanListener {
             return;
         }
 
-        event.setDelayInSeconds(20);
+        event.setDelayInSeconds(30);
 
         if (event.getDelayInSeconds() > 0) {
             UtilMessage.simpleMessage(player, "Clans", "Teleporting to nearest wilderness in <green>%.1f</green> seconds, don't move!", event.getDelayInSeconds());


### PR DESCRIPTION
## Describe your changes
- C stuck is a much less useful command than c home, and in general forces players to stay around dangerous areas instead of teleporting to safety. There is no reason why it should be significantly longer than a home teleport.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested my changes.
