### PR TITLE
#1149 - Fix moving item from main hand causing errors

### DIFF
--- a/shops/src/main/java/me/mykindos/betterpvp/shops/auctionhouse/menu/buttons/CreateListingButton.java
+++ b/shops/src/main/java/me/mykindos/betterpvp/shops/auctionhouse/menu/buttons/CreateListingButton.java
@@ -38,8 +38,8 @@ public class CreateListingButton extends ControlItem<AuctionHouseMenu> {
 
     @Override
     public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
-        ItemStack itemInMainHand = player.getInventory().getItemInMainHand();
-        if(itemInMainHand.getType().isAir()) {
+        ItemStack itemInMainHand = player.getInventory().getItemInMainHand().clone();
+        if (itemInMainHand.getType().isAir()) {
             UtilMessage.simpleMessage(player, "Auction House", "You must be holding an item to create a listing.");
             return;
         }


### PR DESCRIPTION
Clone the item in main hand, to avoid errors when that item is moved while you are making an auction.

Fix #1149

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
