### PR TITLE
Disallow item pickups while Smoke Bomb active

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -169,7 +169,7 @@ public class SmokeBomb extends Skill implements CooldownToggleSkill, Listener, D
         if(allowPickupItems) return;
         Player player = event.getPlayer();
         if (smoked.containsKey(player.getUniqueId())) {
-            interact(player);
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
## Describe your changes
* Disabled picking up items while smoke bomb is active
* Before, picking up an item would end the vanish, but cleaning while vanished would totally not be broken or anything

## Link to issue (if applicable)
https://github.com/Mykindos/BetterPvP/issues/1098

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.