### PR TITLE
Fix Fire Damage Source Attribution causing incorrect kilers

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
@@ -17,6 +17,7 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -155,7 +156,7 @@ public class NapalmArrow extends PrepareArrowSkill implements ThrowableListener,
 
         if (thrower instanceof Player damager) {
             int level = getLevel(damager);
-            hit.setFireTicks((int) (getBurnDuration(level) * 20));
+            UtilEntity.setFire(hit, damager, (long) getBurnDuration(level) * 1000L);
 
             CustomDamageEvent cde = new CustomDamageEvent(hit, damager, null, EntityDamageEvent.DamageCause.CUSTOM, getDamage(level), false, "Napalm");
             cde.setDamageDelay(damageDelay);

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/data/FireData.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/data/FireData.java
@@ -1,0 +1,17 @@
+package me.mykindos.betterpvp.core.combat.data;
+
+import lombok.Data;
+import org.bukkit.entity.LivingEntity;
+
+@Data
+public class FireData {
+    private final LivingEntity damager;
+    private final long start;
+    private final long duration;
+
+    public FireData(LivingEntity damager, long duration) {
+        this.damager = damager;
+        this.start = System.currentTimeMillis();
+        this.duration = duration;
+    }
+}


### PR DESCRIPTION
Fix issues with fire damage attribution causing players to not get kill credit when they should have. Prevent "random" players getting the kill instead

Fixes #1169 
Fixes #1170

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
