### PR TITLE
Cavecaller Mining Perk

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/perks/CaveCaller.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/perks/CaveCaller.java
@@ -1,0 +1,65 @@
+package me.mykindos.betterpvp.clans.progression.perks;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.core.framework.adapter.PluginAdapter;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.profession.mining.MiningHandler;
+import me.mykindos.betterpvp.progression.profession.skill.ProgressionSkillManager;
+import me.mykindos.betterpvp.progression.profession.skill.mining.CaveCallerSkill;
+import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.Objects;
+
+@Singleton
+@BPvPListener
+@PluginAdapter("Progression")
+public class CaveCaller implements Listener {
+    private final ClanManager clanManager;
+    private final ProfessionProfileManager professionProfileManager;
+    private final ProgressionSkillManager progressionSkillManager;
+    private final MiningHandler miningHandler;
+    private final CaveCallerSkill caveCallerSkill;
+
+    @Inject
+    public CaveCaller(ClanManager clanManager) {
+        this.clanManager = clanManager;
+        final Progression progression = Objects.requireNonNull((Progression) Bukkit.getPluginManager().getPlugin("Progression"));
+        this.professionProfileManager = progression.getInjector().getInstance(ProfessionProfileManager.class);
+        this.progressionSkillManager = progression.getInjector().getInstance(ProgressionSkillManager.class);
+        this.miningHandler = progression.getInjector().getInstance(MiningHandler.class);
+        this.caveCallerSkill = progression.getInjector().getInstance(CaveCallerSkill.class);
+    }
+
+    @EventHandler
+    public void onBreakStoneBlock(BlockBreakEvent event) {
+        if (event.isCancelled()) return;
+
+        // Return if invalid block
+        long experience = miningHandler.getExperienceFor(event.getBlock().getType());
+        if (experience <= 0) return;
+
+        Player player = event.getPlayer();
+        Location locationWhereBlockWasMined = event.getBlock().getLocation();
+
+        Clan playerClan = clanManager.getClanByPlayer(player).orElse(null);
+        Clan clanWhereBlockWasMined = clanManager.getClanByLocation(locationWhereBlockWasMined).orElse(null);
+
+        // Only works inside your own territory
+        if (playerClan == null) return;
+        if (!playerClan.equals(clanWhereBlockWasMined)) return;
+
+        // Move this to clans b/c u need to check if block is in your territory
+        caveCallerSkill.whenPlayerMinesBlockInTerritory(player, locationWhereBlockWasMined);
+    }
+
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
@@ -1,0 +1,28 @@
+package me.mykindos.betterpvp.progression.profession.mining.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+@CustomLog
+@Singleton
+public class CaveCallerCommand extends Command {
+    @Override
+    public @NotNull String getName() {
+        return "cavecaller";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "Toggle Cave Caller on/off";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        player.sendMessage("Cave caller on");
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
@@ -5,12 +5,31 @@ import com.google.inject.Singleton;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.progression.profession.skill.ProgressionSkillManager;
+import me.mykindos.betterpvp.progression.profession.skill.mining.CaveCallerSkill;
+import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
 
 @CustomLog
 @Singleton
 public class CaveCallerCommand extends Command {
+    private final ProfessionProfileManager profileManager;
+    private final ProgressionSkillManager progressionSkillManager;
+    private final CaveCallerSkill caveCallerSkill;
+
+    @Inject
+    public CaveCallerCommand(ProfessionProfileManager profileManager, ProgressionSkillManager progressionSkillManager,
+                             CaveCallerSkill caveCallerSkill) {
+
+        this.profileManager = profileManager;
+        this.progressionSkillManager = progressionSkillManager;
+        this.caveCallerSkill = caveCallerSkill;
+    }
+
     @Override
     public @NotNull String getName() {
         return "cavecaller";
@@ -23,6 +42,15 @@ public class CaveCallerCommand extends Command {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        player.sendMessage("Cave caller on");
+        if (!caveCallerSkill.doesPlayerHaveSkill(player)) return;
+
+        UUID playerUUID = player.getUniqueId();
+        if (caveCallerSkill.playersWithPerkActivated.contains(playerUUID)) {
+            caveCallerSkill.playersWithPerkActivated.remove(playerUUID);
+            UtilMessage.simpleMessage(player, "Mining", "Cave Caller: off");
+        } else {
+            caveCallerSkill.playersWithPerkActivated.add(playerUUID);
+            UtilMessage.simpleMessage(player, "Mining", "Cave Caller: on");
+        }
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/CaveCallerCommand.java
@@ -9,6 +9,8 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.progression.profession.skill.ProgressionSkillManager;
 import me.mykindos.betterpvp.progression.profession.skill.mining.CaveCallerSkill;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,12 +47,16 @@ public class CaveCallerCommand extends Command {
         if (!caveCallerSkill.doesPlayerHaveSkill(player)) return;
 
         UUID playerUUID = player.getUniqueId();
+        Component result;
+
         if (caveCallerSkill.playersWithPerkActivated.contains(playerUUID)) {
             caveCallerSkill.playersWithPerkActivated.remove(playerUUID);
-            UtilMessage.simpleMessage(player, "Mining", "Cave Caller: off");
+            result = Component.text("disabled", NamedTextColor.RED);
         } else {
             caveCallerSkill.playersWithPerkActivated.add(playerUUID);
-            UtilMessage.simpleMessage(player, "Mining", "Cave Caller: on");
+            result = Component.text("enabled", NamedTextColor.GREEN);
         }
+
+        UtilMessage.simpleMessage(player, "Command", Component.text("Cave Caller: ").append(result));
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/builds/menu/MiningProfessionMenu.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/builds/menu/MiningProfessionMenu.java
@@ -12,6 +12,10 @@ public class MiningProfessionMenu extends ProfessionMenu {
         progressionSkillManager.getSkill("Smelter").ifPresent(skill -> {
             setItem(13, new ProgressionSkillButton(skill, professionData, progressionSkillManager));
         });
+
+        progressionSkillManager.getSkill("Cave Caller").ifPresent(skill -> {
+            setItem(15, new ProgressionSkillButton(skill, professionData, progressionSkillManager));
+        });
     }
 
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCaller.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCaller.java
@@ -1,24 +1,92 @@
 package me.mykindos.betterpvp.progression.profession.skill.mining;
 
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.profession.mining.MiningHandler;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
+import me.mykindos.betterpvp.progression.utility.ProgressionNamespacedKeys;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Husk;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 
 @Singleton
 @BPvPListener
 public class CaveCaller extends MiningProgressionSkill implements Listener {
     ProfessionProfileManager professionProfileManager;
+    MiningHandler miningHandler;
+
+    private double caveMonsterHealth;
+    private double caveMonsterLifespanInSeconds;
+    private HashMap<UUID, ArrayList<CaveMonsterData>> playerToAliveCaveMonsters = new HashMap<>();
+
+    private final Role[] championsRoles = {
+            Role.WARLOCK, Role.MAGE,
+            Role.ASSASSIN, Role.RANGER,
+            Role.KNIGHT, Role.BRUTE
+    };
+    private enum EquipmentPiece { HELMET, CHESTPLATE, LEGGINGS, BOOTS }
+
+    @Getter
+    static class CaveMonsterData {
+        private final Husk monsterEntity;
+
+        @Setter
+        private double remainingLifespanInSeconds;
+
+        @Setter
+        private ItemStack armamentToDropOnDeath;
+
+        public CaveMonsterData(Husk monsterEntity, double startingLifespanInSeconds) {
+            this.monsterEntity = monsterEntity;
+            this.remainingLifespanInSeconds = startingLifespanInSeconds;
+            this.armamentToDropOnDeath = new ItemStack(Material.AIR);
+        }
+    }
 
     @Inject
-    public CaveCaller(Progression progression, ProfessionProfileManager professionProfileManager) {
+    public CaveCaller(Progression progression, ProfessionProfileManager professionProfileManager, MiningHandler miningHandler) {
         super(progression);
         this.professionProfileManager = professionProfileManager;
+        this.miningHandler = miningHandler;
     }
 
     @Override
@@ -29,7 +97,7 @@ public class CaveCaller extends MiningProgressionSkill implements Listener {
     @Override
     public String[] getDescription(int level) {
         return new String[]{
-                "Mine any stone block in your territory for a <green>20%</green> chance",
+                "Mine any block in your territory for a <green>20%</green> chance",
                 "to summon a cave monster. These monsters drop",
                 "various armaments.",
                 "",
@@ -45,12 +113,221 @@ public class CaveCaller extends MiningProgressionSkill implements Listener {
     @Override
     public void loadConfig() {
         super.loadConfig();
+
+        caveMonsterHealth = getConfig("caveMonsterHealth", 20.0, Double.class);
+        caveMonsterLifespanInSeconds = getConfig("caveMonsterLifespanInSeconds", 15.0, Double.class);
     }
 
     @EventHandler
     public void onBreakStoneBlock(BlockBreakEvent event) {
+        // 1.5 seconds until they're spawned
+        long DELAY_UNTIL_MONSTER_SPAWNED = 30L;
+
         if (event.isCancelled()) return;
 
-        event.getPlayer().sendMessage("Broken block " + event.getBlock().getType());
+        // Return if invalid block
+        long experience = miningHandler.getExperienceFor(event.getBlock().getType());
+        if (experience <= 0) return;
+
+        // Move this to clans b/c u need to check if block is in your territory
+
+        Player player = event.getPlayer();
+
+        professionProfileManager.getObject(player.getUniqueId().toString()).ifPresent(profile -> {
+
+            // Return if the player doesn't have the perk
+            int skillLevel = getPlayerSkillLevel(profile);
+            if (skillLevel <= 0) return;
+
+            Location locationToSpawn = event.getBlock().getLocation();
+
+            Particle.OMINOUS_SPAWNING.builder()
+                    .location(locationToSpawn)
+                    .count(25)
+                    .offset(0, 1, 0)
+                    .receivers(player)
+                    .spawn();
+
+            player.getWorld().playSound(locationToSpawn, Sound.ENTITY_HUSK_CONVERTED_TO_ZOMBIE, 2.0F, 1.0F);
+
+            UtilServer.runTaskLater(getProgression(), () -> {
+
+                Husk caveMonster = (Husk) player.getWorld().spawnEntity(locationToSpawn, EntityType.HUSK);
+                caveMonster.setAI(true);
+                caveMonster.setHealth(caveMonsterHealth);
+                caveMonster.customName(this.getSecondsAsComponent(caveMonsterLifespanInSeconds));
+                caveMonster.setCustomNameVisible(true);
+
+                // (this) Should fix bug where entities persist have restart
+                caveMonster.setPersistent(false);
+
+                PersistentDataContainer pdc = caveMonster.getPersistentDataContainer();
+                pdc.set(ProgressionNamespacedKeys.CAVE_CALLER_MONSTER, PersistentDataType.BOOLEAN, true);
+
+                CaveMonsterData caveMonsterData = new CaveMonsterData(caveMonster, caveMonsterLifespanInSeconds);
+
+                UUID playerUUID = player.getUniqueId();
+
+                if (!playerToAliveCaveMonsters.containsKey(playerUUID)) {
+                    ArrayList<CaveMonsterData> newCaveMonsterDataList = new ArrayList<>(List.of(caveMonsterData));
+                    playerToAliveCaveMonsters.put(playerUUID, newCaveMonsterDataList);
+                } else {
+                    // I believe `add` should mutate the List, so you won't have to call `put` on the `HashMap`
+                    playerToAliveCaveMonsters.get(playerUUID).add(caveMonsterData);
+                }
+
+                EntityEquipment caveMonsterEquipment = caveMonster.getEquipment();
+                caveMonsterEquipment.clear();
+
+                final Random RANDOM = new Random();
+
+                int randomRoleIndex = RANDOM.nextInt(championsRoles.length);
+                Role randomRole = championsRoles[randomRoleIndex];
+
+                caveMonsterEquipment.setHelmet(new ItemStack(randomRole.getHelmet()));
+                caveMonsterEquipment.setChestplate(new ItemStack(randomRole.getChestplate()));
+                caveMonsterEquipment.setLeggings(new ItemStack(randomRole.getLeggings()));
+                caveMonsterEquipment.setBoots(new ItemStack(randomRole.getBoots()));
+                caveMonsterEquipment.setItemInMainHand(new ItemStack(Material.IRON_SWORD));
+
+                if (randomRole.equals(Role.ASSASSIN)) {
+                    caveMonster.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, -1, 1));
+                }
+
+                // Only 4 equipment pieces + the item in main hand
+                int randomIndexForMaterialToDrop = RANDOM.nextInt(5);
+
+                Material materialToDrop = switch (randomIndexForMaterialToDrop) {
+                    case 0 -> randomRole.getBoots();
+                    case 1 -> randomRole.getLeggings();
+                    case 2 -> randomRole.getChestplate();
+                    case 3 -> randomRole.getHelmet();
+                    case 4 -> Material.IRON_SWORD;
+                    default -> Material.AIR;  // unreachable
+                };
+
+                ItemStack equipmentAsItemStack = new ItemStack(materialToDrop);
+                caveMonsterData.setArmamentToDropOnDeath(equipmentAsItemStack);
+
+                CaveMonsterPathfinder caveMonsterPathfinder = new CaveMonsterPathfinder(getProgression(), caveMonster, player);
+                Bukkit.getMobGoals().addGoal(caveMonster, 0, caveMonsterPathfinder);
+
+            }, DELAY_UNTIL_MONSTER_SPAWNED);
+        });
+    }
+
+    /**
+     * Every second, update the cave monster's timer above their head.
+     * If the cave monster time is up, then kill them
+     */
+    @UpdateEvent(delay=1000)
+    public void updateCaveMonsterState() {
+        for (UUID playerUUID : playerToAliveCaveMonsters.keySet()) {
+            List<CaveMonsterData> caveMonstersForPlayer = playerToAliveCaveMonsters.get(playerUUID);
+
+            ArrayList<CaveMonsterData> currentlyAliveCaveMonsters = new ArrayList<>(caveMonstersForPlayer);
+
+            for (CaveMonsterData caveMonsterData : caveMonstersForPlayer) {
+
+                // If the monster's lifespan is up, kill em'
+                if (caveMonsterData.getRemainingLifespanInSeconds() <= 0) {
+
+                    // It's important that the pdc is altered BEFORE you kill the monster
+                    PersistentDataContainer pdc = caveMonsterData.getMonsterEntity().getPersistentDataContainer();
+                    pdc.set(ProgressionNamespacedKeys.CAVE_CALLER_DEATH_BY_LIFESPAN, PersistentDataType.BOOLEAN, true);
+                    caveMonsterData.getMonsterEntity().setHealth(0);
+                }
+
+                if (caveMonsterData.monsterEntity.isDead()) {
+                    currentlyAliveCaveMonsters.remove(caveMonsterData);
+                    continue;
+                }
+
+                // Decrement the current lifespan
+                caveMonsterData.setRemainingLifespanInSeconds(caveMonsterData.getRemainingLifespanInSeconds() - 1);
+
+                Component secondsAsComponent = getSecondsAsComponent(caveMonsterData.getRemainingLifespanInSeconds());
+                caveMonsterData.monsterEntity.customName(secondsAsComponent);
+            }
+
+            playerToAliveCaveMonsters.put(playerUUID, currentlyAliveCaveMonsters);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerKillCaveMonster(EntityDeathEvent event) {
+        if (event.isCancelled()) return;
+
+        // If it's not a cave caller monster, then ignore
+        if (!event.getEntity().getPersistentDataContainer().has(ProgressionNamespacedKeys.CAVE_CALLER_MONSTER)) return;
+
+        // If it died of natural causes, then ignore
+        if (event.getEntity().getPersistentDataContainer().has(ProgressionNamespacedKeys.CAVE_CALLER_DEATH_BY_LIFESPAN)) return;
+
+        for (UUID playerUUID : playerToAliveCaveMonsters.keySet()) {
+            List<CaveMonsterData> caveMonstersForPlayer = playerToAliveCaveMonsters.get(playerUUID);
+
+            // Go through every monster the player has
+            for (CaveMonsterData caveMonsterData : caveMonstersForPlayer) {
+
+                // Once you find the one that the player killed, drop its armament
+                if (caveMonsterData.monsterEntity.equals(event.getEntity())) {
+                    event.getEntity().getWorld().dropItemNaturally(event.getEntity().getLocation(),
+                            caveMonsterData.armamentToDropOnDeath);
+                }
+            }
+        }
+
+    }
+
+    private Component getSecondsAsComponent(double remainingTime) {
+        TextColor color = (remainingTime > 5) ?
+                TextColor.color(0, 200, 255) :
+                TextColor.color(200, 70,  0);
+
+        return Component.text(remainingTime).color(color)
+                .append(Component.text("s").color(color));
+    }
+
+    static class CaveMonsterPathfinder implements Goal<Mob> {
+        protected final Progression progression;
+        private final GoalKey<Mob> key = GoalKey.of(Mob.class, new NamespacedKey("progression", "cave_monster"));
+        private final Mob mob;
+
+        @Setter
+        @Getter
+        private LivingEntity target;
+
+        public CaveMonsterPathfinder(Progression progression, Mob mob, LivingEntity target) {
+            this.progression = progression;
+            this.mob = mob;
+            this.target = target;
+        }
+
+        @Override
+        public boolean shouldActivate() {
+            return true;
+        }
+
+        @Override
+        public void tick() {
+            if (target == null) return;
+            mob.setTarget(target);
+
+            if (mob.getLocation().distanceSquared(target.getLocation()) < 3) return;
+
+            mob.getPathfinder().moveTo(target);
+        }
+
+        @Override
+        public @NotNull GoalKey<Mob> getKey() {
+            return key;
+        }
+
+        @Override
+        public @NotNull EnumSet<GoalType> getTypes() {
+            return EnumSet.of(GoalType.TARGET);
+        }
+
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCaller.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCaller.java
@@ -1,0 +1,56 @@
+package me.mykindos.betterpvp.progression.profession.skill.mining;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+@Singleton
+@BPvPListener
+public class CaveCaller extends MiningProgressionSkill implements Listener {
+    ProfessionProfileManager professionProfileManager;
+
+    @Inject
+    public CaveCaller(Progression progression, ProfessionProfileManager professionProfileManager) {
+        super(progression);
+        this.professionProfileManager = professionProfileManager;
+    }
+
+    @Override
+    public String getName() {
+        return "Cave Caller";
+    }
+
+    @Override
+    public String[] getDescription(int level) {
+        return new String[]{
+                "Mine any stone block in your territory for a <green>20%</green> chance",
+                "to summon a cave monster. These monsters drop",
+                "various armaments.",
+                "",
+                "Toggle this perk on/off with <green>/cavecaller</green>"
+        };
+    }
+
+    @Override
+    public Material getIcon() {
+        return Material.IRON_HELMET;
+    }
+
+    @Override
+    public void loadConfig() {
+        super.loadConfig();
+    }
+
+    @EventHandler
+    public void onBreakStoneBlock(BlockBreakEvent event) {
+        if (event.isCancelled()) return;
+
+        event.getPlayer().sendMessage("Broken block " + event.getBlock().getType());
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCallerSkill.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/CaveCallerSkill.java
@@ -41,7 +41,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -50,7 +49,7 @@ import java.util.UUID;
 
 @Singleton
 @BPvPListener
-public class CaveCaller extends MiningProgressionSkill implements Listener {
+public class CaveCallerSkill extends MiningProgressionSkill implements Listener {
     ProfessionProfileManager professionProfileManager;
     MiningHandler miningHandler;
 
@@ -83,7 +82,7 @@ public class CaveCaller extends MiningProgressionSkill implements Listener {
     }
 
     @Inject
-    public CaveCaller(Progression progression, ProfessionProfileManager professionProfileManager, MiningHandler miningHandler) {
+    public CaveCallerSkill(Progression progression, ProfessionProfileManager professionProfileManager, MiningHandler miningHandler) {
         super(progression);
         this.professionProfileManager = professionProfileManager;
         this.miningHandler = miningHandler;
@@ -118,28 +117,16 @@ public class CaveCaller extends MiningProgressionSkill implements Listener {
         caveMonsterLifespanInSeconds = getConfig("caveMonsterLifespanInSeconds", 15.0, Double.class);
     }
 
-    @EventHandler
-    public void onBreakStoneBlock(BlockBreakEvent event) {
+
+    public void whenPlayerMinesBlockInTerritory(Player player, Location locationToSpawn) {
         // 1.5 seconds until they're spawned
         long DELAY_UNTIL_MONSTER_SPAWNED = 30L;
-
-        if (event.isCancelled()) return;
-
-        // Return if invalid block
-        long experience = miningHandler.getExperienceFor(event.getBlock().getType());
-        if (experience <= 0) return;
-
-        // Move this to clans b/c u need to check if block is in your territory
-
-        Player player = event.getPlayer();
 
         professionProfileManager.getObject(player.getUniqueId().toString()).ifPresent(profile -> {
 
             // Return if the player doesn't have the perk
             int skillLevel = getPlayerSkillLevel(profile);
             if (skillLevel <= 0) return;
-
-            Location locationToSpawn = event.getBlock().getLocation();
 
             Particle.OMINOUS_SPAWNING.builder()
                     .location(locationToSpawn)

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/utility/ProgressionNamespacedKeys.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/utility/ProgressionNamespacedKeys.java
@@ -9,5 +9,6 @@ public class ProgressionNamespacedKeys {
     public static final NamespacedKey FISHING_FISH_TYPE = new NamespacedKey("progression", "fish-type");
     public static final NamespacedKey FISHING_SWIMMER = new NamespacedKey("progression", "swimmer");
     public static final NamespacedKey FISHING_BAIT_TYPE = new NamespacedKey("progression", "bait-type");
-
+    public static final NamespacedKey CAVE_CALLER_MONSTER = new NamespacedKey("progression", "cave-caller-monster");
+    public static final NamespacedKey CAVE_CALLER_DEATH_BY_LIFESPAN = new NamespacedKey("progression", "cave-caller-death-by-lifespan");
 }

--- a/progression/src/main/resources/configs/config.yml
+++ b/progression/src/main/resources/configs/config.yml
@@ -452,6 +452,9 @@ command:
   mining:
     enabled: true
     requiredRank: PLAYER
+    cavecaller:
+      enabled: true
+      requiredRank: PLAYER
   woodcutting:
     enabled: true
     requiredRank: PLAYER

--- a/progression/src/main/resources/configs/professions/mining.yml
+++ b/progression/src/main/resources/configs/professions/mining.yml
@@ -6,5 +6,5 @@ skills:
   cave_caller:
     enabled: true
     maxlevel: 250
-    caveMonsterHealth: 5.0
+    caveMonsterHealth: 20.0
     caveMonsterLifespanInSeconds: 15.0

--- a/progression/src/main/resources/configs/professions/mining.yml
+++ b/progression/src/main/resources/configs/professions/mining.yml
@@ -6,3 +6,5 @@ skills:
   cave_caller:
     enabled: true
     maxlevel: 250
+    caveMonsterHealth: 5.0
+    caveMonsterLifespanInSeconds: 15.0

--- a/progression/src/main/resources/configs/professions/mining.yml
+++ b/progression/src/main/resources/configs/professions/mining.yml
@@ -6,5 +6,5 @@ skills:
   cave_caller:
     enabled: true
     maxlevel: 250
-    caveMonsterHealth: 20.0
     caveMonsterLifespanInSeconds: 15.0
+    caveMonsterSpawnChancePerLvl: 0.0004

--- a/progression/src/main/resources/configs/professions/mining.yml
+++ b/progression/src/main/resources/configs/professions/mining.yml
@@ -3,3 +3,6 @@ skills:
     enabled: true
     maxlevel: 100
     smeltChanceIncreasePerLvl: 0.01
+  cave_caller:
+    enabled: true
+    maxlevel: 250


### PR DESCRIPTION
## Describe your changes
During the beta, I've noticed that Mining gets quite stale after you max out `Smelter` as there's nothing to work towards after it; yet, Mining is often the profession that players interact with the most on a day to day basis.

Additionally, I've also noticed that obtaining certain sets such as Warlock and Ranger (and Assassin to an extent) are *exceedingly* difficult as the ores to craft these sets do not spawn in the Wilderness (or are just very hard to find).

Besides those two issues, this perk also solves a third problem: Mining inside your claim is __boring__.

`Cave Caller` is a 250 level Mining perk that only works __inside__ of one's own territory (please ignore the inflated percentage in the screenshot)
![2024-11-07_23 46 49](https://github.com/user-attachments/assets/3235954a-3077-4757-a9a5-7864cf6aa680)

Whenever a player mines a block, a *Cave Monster* will be spawned which dies of natural causes after 15 seconds.
![2024-11-07_23 49 13](https://github.com/user-attachments/assets/1a3df110-1285-4725-828b-787b5f65ec9e)

If the player kills a *Cave Monster*, they will get either a piece of its armor or its weapon (a `Standard Sword`). If the player fails to kill the *Cave Monster* in time, then nothing will be dropped (aside from some `Rotten Flesh`).

Finally, this perk can be toggled on/off with `/cavecaller` (similar to how one toggles *Clan Chat* with `/cc`)
![2024-11-07_23 53 56](https://github.com/user-attachments/assets/854c9717-4a7a-4e18-b49f-4ed1d7802f64)


## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
