### PR TITLE
Fix woodcutting durability handling, add profession experience admin commands

### DIFF
--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/commands/FishingExperienceCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/commands/FishingExperienceCommand.java
@@ -1,0 +1,106 @@
+package me.mykindos.betterpvp.progression.profession.fishing.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.progression.profession.fishing.FishingHandler;
+import me.mykindos.betterpvp.progression.profile.ProfessionData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class FishingExperienceCommand extends Command implements IConsoleCommand {
+
+    public FishingExperienceCommand() {
+    }
+
+    @Override
+    public String getName() {
+        return "fishingexp";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Base fishing experience command";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        execute(player, args);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+
+    }
+
+    @Singleton
+    @SubCommand(FishingExperienceCommand.class)
+    private static class SetFishingExperienceCommand extends Command implements IConsoleCommand {
+        private final ClientManager clientManager;
+        private final FishingHandler fishingHandler;
+
+        @Inject
+        private SetFishingExperienceCommand(ClientManager clientManager, FishingHandler fishingHandler) {
+            this.clientManager = clientManager;
+            this.fishingHandler = fishingHandler;
+        }
+
+        @Override
+        public String getName() {
+            return "set";
+        }
+
+        @Override
+        public String getDescription() {
+            return "set a players woodcutting experience";
+        }
+
+        @Override
+        public void execute(Player player, Client client, String... args) {
+            execute(player, args);
+        }
+
+        @Override
+        public void execute(CommandSender sender, String[] args) {
+            if (args.length < 2) {
+                UtilMessage.message(sender, "Fishing", "Usage: /fishingexp set <player> <experience>");
+                return;
+            }
+
+            clientManager.search().offline(args[0], targetOptional -> {
+                if (targetOptional.isEmpty()) {
+                    UtilMessage.message(sender, "Fishing", "Cannot find a player with the name <yellow>%s</yellow>", args[0]);
+                    return;
+                }
+                Client target = targetOptional.get();
+
+                double newExperience;
+                try {
+                    newExperience = Double.parseDouble(args[1]);
+                    if (newExperience < 0) {
+                        throw new NumberFormatException();
+                    }
+                } catch (NumberFormatException ignored) {
+                    UtilMessage.message(sender, "Fishing", "<green>%s</green> is an invalid amount of experience", args[1]);
+                    return;
+                }
+                ProfessionData professionData = fishingHandler.getProfessionData(target.getUniqueId());
+                double oldExperience = professionData.getExperience();
+                professionData.setExperience(newExperience);
+                UtilMessage.message(sender, "Fishing", "Set <yellow>%s</yellow>'s fishing experience to <green>%s</green> (was <white>%s</white>)",
+                        target.getName(), newExperience, oldExperience);
+            });
+        }
+
+        @Override
+        public String getArgumentType(int argCount) {
+            return argCount == 1 ? ArgumentType.PLAYER.name() : ArgumentType.NONE.name();
+        }
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/MiningExperienceCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/commands/MiningExperienceCommand.java
@@ -1,0 +1,106 @@
+package me.mykindos.betterpvp.progression.profession.mining.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.progression.profession.mining.MiningHandler;
+import me.mykindos.betterpvp.progression.profile.ProfessionData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class MiningExperienceCommand extends Command implements IConsoleCommand {
+
+    public MiningExperienceCommand() {
+    }
+
+    @Override
+    public String getName() {
+        return "miningexp";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Base mining experience command";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        execute(player, args);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+
+    }
+
+    @Singleton
+    @SubCommand(MiningExperienceCommand.class)
+    private static class SetMiningExperienceCommand extends Command implements IConsoleCommand {
+        private final ClientManager clientManager;
+        private final MiningHandler miningHandler;
+
+        @Inject
+        private SetMiningExperienceCommand(ClientManager clientManager, MiningHandler miningHandler) {
+            this.clientManager = clientManager;
+            this.miningHandler = miningHandler;
+        }
+
+        @Override
+        public String getName() {
+            return "set";
+        }
+
+        @Override
+        public String getDescription() {
+            return "set a players woodcutting experience";
+        }
+
+        @Override
+        public void execute(Player player, Client client, String... args) {
+            execute(player, args);
+        }
+
+        @Override
+        public void execute(CommandSender sender, String[] args) {
+            if (args.length < 2) {
+                UtilMessage.message(sender, "Mining", "Usage: /miningexp set <player> <experience>");
+                return;
+            }
+
+            clientManager.search().offline(args[0], targetOptional -> {
+                if (targetOptional.isEmpty()) {
+                    UtilMessage.message(sender, "Mining", "Cannot find a player with the name <yellow>%s</yellow>", args[0]);
+                    return;
+                }
+                Client target = targetOptional.get();
+
+                double newExperience;
+                try {
+                    newExperience = Double.parseDouble(args[1]);
+                    if (newExperience < 0) {
+                        throw new NumberFormatException();
+                    }
+                } catch (NumberFormatException ignored) {
+                    UtilMessage.message(sender, "Mining", "<green>%s</green> is an invalid amount of experience", args[1]);
+                    return;
+                }
+                ProfessionData professionData = miningHandler.getProfessionData(target.getUniqueId());
+                double oldExperience = professionData.getExperience();
+                professionData.setExperience(newExperience);
+                UtilMessage.message(sender, "Mining", "Set <yellow>%s</yellow>'s mining experience to <green>%s</green> (was <white>%s</white>)",
+                        target.getName(), newExperience, oldExperience);
+            });
+        }
+
+        @Override
+        public String getArgumentType(int argCount) {
+            return argCount == 1 ? ArgumentType.PLAYER.name() : ArgumentType.NONE.name();
+        }
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.model.WeighedList;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.ProfessionHandler;
@@ -21,10 +21,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -122,21 +119,9 @@ public class WoodcuttingHandler extends ProfessionHandler {
         professionData.getProperties().put("TOTAL_LOGS_CHOPPED", logsChopped + ((long) amountChopped));
 
         ItemStack toolUsed = chopLogEvent.getToolUsed();
-        ItemMeta toolUsedMeta = toolUsed.getItemMeta();
 
-        if (amountChopped > 1 && (toolUsedMeta instanceof Damageable metaAsDamageable)) {
-            // Tree Feller is supposed to work only w/ axes so no need to check
-
-            // the way unbreaking rune works is by cancelling the whole event, not
-            // just reduction so that's why originalDamage will always equal damage
-            PlayerItemDamageEvent playerItemDamageEvent = UtilServer.callEvent(
-                    new PlayerItemDamageEvent(player, toolUsed, amountChopped, amountChopped)
-            );
-
-            if (!playerItemDamageEvent.isCancelled()) {
-                metaAsDamageable.setDamage(amountChopped);
-                toolUsed.setItemMeta(toolUsedMeta);
-            }
+        if (amountChopped > 1) {
+            UtilItem.damageItem(player, toolUsed, amountChopped);
         }
 
         // Checking if >0 is probably not necessary, but it's here for clarity

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/commands/WoodcuttingExperienceCommand.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/commands/WoodcuttingExperienceCommand.java
@@ -1,0 +1,106 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.commands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.IConsoleCommand;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.progression.profession.woodcutting.WoodcuttingHandler;
+import me.mykindos.betterpvp.progression.profile.ProfessionData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@Singleton
+public class WoodcuttingExperienceCommand extends Command implements IConsoleCommand {
+
+    public WoodcuttingExperienceCommand() {
+    }
+
+    @Override
+    public String getName() {
+        return "woodcuttingexp";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Base woodcutting experience command";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        execute(player, args);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+
+    }
+
+    @Singleton
+    @SubCommand(WoodcuttingExperienceCommand.class)
+    private static class SetWoodcuttingExperienceCommand extends Command implements IConsoleCommand {
+        private final ClientManager clientManager;
+        private final WoodcuttingHandler woodcuttingHandler;
+
+        @Inject
+        private SetWoodcuttingExperienceCommand(ClientManager clientManager, WoodcuttingHandler woodcuttingHandler) {
+            this.clientManager = clientManager;
+            this.woodcuttingHandler = woodcuttingHandler;
+        }
+
+        @Override
+        public String getName() {
+            return "set";
+        }
+
+        @Override
+        public String getDescription() {
+            return "set a players woodcutting experience";
+        }
+
+        @Override
+        public void execute(Player player, Client client, String... args) {
+            execute(player, args);
+        }
+
+        @Override
+        public void execute(CommandSender sender, String[] args) {
+            if (args.length < 2) {
+                UtilMessage.message(sender, "Woodcutting", "Usage: /woodcuttingexp set <player> <experience>");
+                return;
+            }
+
+            clientManager.search().offline(args[0], targetOptional -> {
+                if (targetOptional.isEmpty()) {
+                    UtilMessage.message(sender, "Woodcutting", "Cannot find a player with the name <yellow>%s</yellow>", args[0]);
+                    return;
+                }
+                Client target = targetOptional.get();
+
+                double newExperience;
+                try {
+                    newExperience = Double.parseDouble(args[1]);
+                    if (newExperience < 0) {
+                        throw new NumberFormatException();
+                    }
+                } catch (NumberFormatException ignored) {
+                    UtilMessage.message(sender, "Woodcutting", "<green>%s</green> is an invalid amount of experience", args[1]);
+                    return;
+                }
+                ProfessionData professionData = woodcuttingHandler.getProfessionData(target.getUniqueId());
+                double oldExperience = professionData.getExperience();
+                professionData.setExperience(newExperience);
+                UtilMessage.message(sender, "Woodcutting", "Set <yellow>%s</yellow>'s woodcutting experience to <green>%s</green> (was <white>%s</white>)",
+                        target.getName(), newExperience, oldExperience);
+            });
+        }
+
+        @Override
+        public String getArgumentType(int argCount) {
+            return argCount == 1 ? ArgumentType.PLAYER.name() : ArgumentType.NONE.name();
+        }
+    }
+}


### PR DESCRIPTION
Fix how durability was being handled in treefeller.
Add commands to each profession for admins to use to set experience, for testing

Fixes #1124
Fixes #1203

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
