### PR TITLE
Fix evade duration truncating

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -187,7 +187,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
                         it.remove();
                     } else if (championsManager.getEffects().hasEffect(player, EffectTypes.STUN)) {
                         it.remove();
-                    } else if (UtilTime.elapsed(handRaisedTime.get(player.getUniqueId()), (long) duration * 1000)) {
+                    } else if (UtilTime.elapsed(handRaisedTime.get(player.getUniqueId()), (long) (duration * 1000))) {
                         handRaisedTime.remove(player.getUniqueId());
                         UtilMessage.simpleMessage(player, getClassType().getName(),"You failed <green>%s %d</green>", getName(), getLevel(player));
                         player.getWorld().playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 2.0f, 1.0f);


### PR DESCRIPTION
## Describe your changes
Evade duration would be floored when casting to long before multiplication. Fixed by doing multiplication before casting.
## Link to issue (if applicable)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X ] I have tested my changes.
