### PR TITLE
Stripped Log Experience Fix

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -310,6 +310,8 @@ public class SkillListener implements Listener {
         ItemStack mainHand = player.getInventory().getItemInMainHand();
         Block clickedBlock = event.getClickedBlock();
 
+        // TODO: add preference to make this optional:
+        // This is the code where you are unable to use a skill while trying to strip a log
         if (clickedBlock != null) {
             if (UtilItem.isAxe(mainHand) && UtilBlock.isLog(clickedBlock.getType())) {
                 return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -310,8 +310,6 @@ public class SkillListener implements Listener {
         ItemStack mainHand = player.getInventory().getItemInMainHand();
         Block clickedBlock = event.getClickedBlock();
 
-        // TODO: add preference to make this optional:
-        // This is the code where you are unable to use a skill while trying to strip a log
         if (clickedBlock != null) {
             if (UtilItem.isAxe(mainHand) && UtilBlock.isLog(clickedBlock.getType())) {
                 return;

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/blocktag/BlockTaggingListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/blocktag/BlockTaggingListener.java
@@ -44,6 +44,7 @@ import java.util.WeakHashMap;
 @BPvPListener
 @Singleton
 public class BlockTaggingListener implements Listener {
+    public static final long DELAY_FOR_PROCESS_BLOCK_TAGS = 1L;
 
     private final Core core;
 
@@ -193,7 +194,7 @@ public class BlockTaggingListener implements Listener {
             });
 
             blockTags.clear();
-        }, 1L);
+        }, DELAY_FOR_PROCESS_BLOCK_TAGS);
 
 
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
@@ -166,7 +166,8 @@ public class UtilBlock {
                 Material.BIRCH_LOG,
                 Material.DARK_OAK_LOG,
                 Material.JUNGLE_LOG,
-                Material.SPRUCE_LOG
+                Material.SPRUCE_LOG,
+                Material.CHERRY_LOG
         };
 
         return Arrays.asList(validLogTypes).contains(material);

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilBlock.java
@@ -167,7 +167,8 @@ public class UtilBlock {
                 Material.DARK_OAK_LOG,
                 Material.JUNGLE_LOG,
                 Material.SPRUCE_LOG,
-                Material.CHERRY_LOG
+                Material.CHERRY_LOG,
+                Material.MANGROVE_LOG
         };
 
         return Arrays.asList(validLogTypes).contains(material);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/BarkBounty.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/BarkBounty.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.woodcutting.WoodcuttingHandler;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerStripLogEvent;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -86,35 +87,23 @@ public class BarkBounty extends WoodcuttingProgressionSkill implements Listener 
      * Whenever a player strips a log, the logic in this method <i>should</i> be executed, and this method will
      * get a random number to see if the player should receive <b>Tree Bark</b> based on their level
      */
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void whenPlayerStripsALog(PlayerInteractEvent event) {
-        if (event.getHand() != EquipmentSlot.HAND) return;
-        if (!event.getAction().isRightClick()) return;
-        if (event.useInteractedBlock() == Event.Result.DENY
-                && event.useItemInHand() == Event.Result.DENY) {
-            //Both events are denied, this is a cancelled event
-            return;
-        }
+    @EventHandler(ignoreCancelled = true)
+    public void whenPlayerStripsALog(PlayerStripLogEvent event) {
+        event.getPlayer().sendMessage("Listened for here!!");
+        if (event.wasEventDeniedAndCancelled()) return;
 
         Player player = event.getPlayer();
+        if (player.getGameMode() == GameMode.ADVENTURE) return;
+        if (!player.getWorld().getName().equalsIgnoreCase("world")) return;
 
-        if(player.getGameMode() == GameMode.ADVENTURE) return;
-
-        if (!player.getWorld().getName().equalsIgnoreCase("world")) {
-            return;
-        }
-
-        Block block = event.getClickedBlock();
-        if (block == null) return;
-        if (!UtilBlock.isNonStrippedLog(block.getType())) return;
-
-        if (!UtilItem.isAxe(player.getInventory().getItemInMainHand())) return;
-
+        Block block = event.getStrippedLog();
         if (woodcuttingHandler.didPlayerPlaceBlock(block)) return;
 
         professionProfileManager.getObject(player.getUniqueId().toString()).ifPresent(profile -> {
             int skillLevel = getPlayerSkillLevel(profile);
             if (skillLevel <= 0) return;
+
+            event.getPlayer().sendMessage("Firing skill");
 
             if (Math.random() < getChanceForBarkToDrop(skillLevel)) {
                 ItemStack treeBark = new ItemStack(Material.GLISTERING_MELON_SLICE);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/BarkBounty.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/BarkBounty.java
@@ -89,7 +89,6 @@ public class BarkBounty extends WoodcuttingProgressionSkill implements Listener 
      */
     @EventHandler(ignoreCancelled = true)
     public void whenPlayerStripsALog(PlayerStripLogEvent event) {
-        event.getPlayer().sendMessage("Listened for here!!");
         if (event.wasEventDeniedAndCancelled()) return;
 
         Player player = event.getPlayer();
@@ -102,8 +101,6 @@ public class BarkBounty extends WoodcuttingProgressionSkill implements Listener 
         professionProfileManager.getObject(player.getUniqueId().toString()).ifPresent(profile -> {
             int skillLevel = getPlayerSkillLevel(profile);
             if (skillLevel <= 0) return;
-
-            event.getPlayer().sendMessage("Firing skill");
 
             if (Math.random() < getChanceForBarkToDrop(skillLevel)) {
                 ItemStack treeBark = new ItemStack(Material.GLISTERING_MELON_SLICE);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -104,6 +104,7 @@ public class WoodcuttingHandler extends ProfessionHandler {
 
         Block block = chopLogEvent.getChoppedLogBlock();
         if (didPlayerPlaceBlock(block)) {
+            player.sendMessage("Player placed this block " + block);
             professionData.grantExperience(0, player);
             return;
         }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerStripLogEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerStripLogEvent.java
@@ -1,0 +1,2 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.event;public class PlayerStripLogEvent {
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerStripLogEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerStripLogEvent.java
@@ -1,2 +1,26 @@
-package me.mykindos.betterpvp.progression.profession.woodcutting.event;public class PlayerStripLogEvent {
+package me.mykindos.betterpvp.progression.profession.woodcutting.event;
+
+import lombok.Getter;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+
+@Getter
+public class PlayerStripLogEvent extends ProgressionWoodcuttingEvent {
+    private final Block strippedLog;
+    private final Result blockInteraction;
+    private final Result itemInHandInteraction;
+
+
+    public PlayerStripLogEvent(Player player, Block strippedLog, Result blockInteraction,
+                               Result itemInHandInteraction) {
+        super(player);
+        this.strippedLog = strippedLog;
+        this.blockInteraction = blockInteraction;
+        this.itemInHandInteraction= itemInHandInteraction;
+    }
+
+    public boolean wasEventDeniedAndCancelled() {
+        return isCancelled() && blockInteraction == Event.Result.DENY && itemInHandInteraction == Event.Result.DENY;
+    }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
@@ -1,2 +1,49 @@
-package me.mykindos.betterpvp.progression.profession.woodcutting.listener;public class StrippedLogListener {
+package me.mykindos.betterpvp.progression.profession.woodcutting.listener;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
+import me.mykindos.betterpvp.core.framework.blocktag.BlockTaggingListener;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerStripLogEvent;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * This class's purpose is to remove the player-placed data on a log when it is stripped
+ */
+@BPvPListener
+@Singleton
+public class StrippedLogListener implements Listener {
+
+    /**
+     * This is the primary listener of the class.
+     * Its purpose is to remove the player-placed data on a block when it is stripped
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerStripsLog(PlayerStripLogEvent event) {
+        if (event.wasEventDeniedAndCancelled()) return;
+
+        // If the initial log was placed by a player, then keep the player placed key
+        Block block = event.getStrippedLog();
+        PersistentDataContainer regularLogPdc = UtilBlock.getPersistentDataContainer(block);
+        if (regularLogPdc.has(CoreNamespaceKeys.PLAYER_PLACED_KEY)) return;
+
+        UtilServer.runTaskLater(JavaPlugin.getPlugin(Progression.class), () -> {
+            PersistentDataContainer strippedLogPdc = UtilBlock.getPersistentDataContainer(block);
+            if (!strippedLogPdc.has(CoreNamespaceKeys.PLAYER_PLACED_KEY)) return;
+
+            strippedLogPdc.remove(CoreNamespaceKeys.PLAYER_PLACED_KEY);
+            UtilBlock.setPersistentDataContainer(block, strippedLogPdc);
+        }, BlockTaggingListener.DELAY_FOR_PROCESS_BLOCK_TAGS + 2L);
+        // this should fire two ticks later than block tag
+    }
+
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
@@ -1,0 +1,2 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.listener;public class StrippedLogListener {
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/StrippedLogListener.java
@@ -36,7 +36,14 @@ public class StrippedLogListener implements Listener {
         PersistentDataContainer regularLogPdc = UtilBlock.getPersistentDataContainer(block);
         if (regularLogPdc.has(CoreNamespaceKeys.PLAYER_PLACED_KEY)) return;
 
+        String expectedStrippedLog = "STRIPPED_" + block.getType().name();
+
         UtilServer.runTaskLater(JavaPlugin.getPlugin(Progression.class), () -> {
+
+            // This stops players from mining the log and putting a more profitable log there instead
+            // (like a mangrove log)
+            if (!block.getType().name().equalsIgnoreCase(expectedStrippedLog)) return;
+
             PersistentDataContainer strippedLogPdc = UtilBlock.getPersistentDataContainer(block);
             if (!strippedLogPdc.has(CoreNamespaceKeys.PLAYER_PLACED_KEY)) return;
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
@@ -4,15 +4,21 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.progression.profession.woodcutting.WoodcuttingHandler;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerStripLogEvent;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.function.DoubleUnaryOperator;
@@ -56,5 +62,24 @@ public class WoodcuttingListener implements Listener {
 
         DoubleUnaryOperator experienceModifier = (xp) -> xp * chopLogEvent.getExperienceBonusModifier();
         woodcuttingHandler.attemptToChopLog(chopLogEvent, experienceModifier);
+    }
+
+    /**
+     * Whenever a play strips a log, this event will trigger and fire the appropriate custom event
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void whenPlayerStripsALog(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (!event.getAction().isRightClick()) return;
+
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+        if (!UtilBlock.isNonStrippedLog(block.getType())) return;
+
+        Player player = event.getPlayer();
+        if (!UtilItem.isAxe(player.getInventory().getItemInMainHand())) return;
+        player.sendMessage("Monitor found it!!! firing strip log event");
+
+        UtilServer.callEvent(new PlayerStripLogEvent(player, block, event.useInteractedBlock(), event.useItemInHand()));
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingListener.java
@@ -78,7 +78,6 @@ public class WoodcuttingListener implements Listener {
 
         Player player = event.getPlayer();
         if (!UtilItem.isAxe(player.getInventory().getItemInMainHand())) return;
-        player.sendMessage("Monitor found it!!! firing strip log event");
 
         UtilServer.callEvent(new PlayerStripLogEvent(player, block, event.useInteractedBlock(), event.useItemInHand()));
     }


### PR DESCRIPTION
## Describe your changes
- More cherry logs compatibility that was needed to get added
- There's still an edge case where if the player immediately chops the log after stripping (within 3 ticks), 0.0 exp will be awarded
- This edge case is realistically, only encountered when **Hyper Axe** is used

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
