### PR TITLE
Add the capability to view and modify inventories offline

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/InvSeeCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/InvSeeCommand.java
@@ -1,17 +1,28 @@
 package me.mykindos.betterpvp.core.command.commands.admin;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.menus.PlayerInventoryMenu;
+import me.mykindos.betterpvp.core.utilities.UtilInventory;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import org.bukkit.Bukkit;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.craftbukkit.inventory.CraftInventoryPlayer;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
 
 @Singleton
 public class InvSeeCommand extends Command {
 
-    public InvSeeCommand() {
+    private final ClientManager clientManager;
+
+    @Inject
+    public InvSeeCommand(ClientManager clientManager) {
+        this.clientManager = clientManager;
         aliases.add("openinv");
     }
 
@@ -32,13 +43,28 @@ public class InvSeeCommand extends Command {
             return;
         }
 
-        Player target = Bukkit.getPlayer(args[0]);
-        if (target != null) {
-            new PlayerInventoryMenu(target).show(player);
-            UtilMessage.simpleMessage(player, "You opened <yellow>" + target.getName() + "'s <gray>inventory.");
-        } else {
-            UtilMessage.simpleMessage(player, "Could not find player <yellow>" + args[0]);
-        }
+        clientManager.search().offline(args[0], clientOptional -> {
+            if (clientOptional.isEmpty()) {
+                UtilMessage.simpleMessage(player, "Could not find player <yellow>" + args[0]);
+                return;
+            }
+
+            final Client target = clientOptional.get();
+            final Gamer targetGamer = target.getGamer();
+            final Player targetPlayer = targetGamer.getPlayer();
+            if (targetPlayer != null) {
+                UtilServer.runTask(JavaPlugin.getPlugin(Core.class), () -> {
+                    new PlayerInventoryMenu(targetPlayer, targetPlayer.getName(), targetPlayer.getUniqueId(), (CraftInventoryPlayer) targetPlayer.getInventory(), false).show(player);
+                });
+                return;
+            }
+
+            CraftInventoryPlayer playerInventory = UtilInventory.getOfflineInventory(target.getName(), target.getUniqueId());
+            UtilServer.runTask(JavaPlugin.getPlugin(Core.class), () -> {
+                new PlayerInventoryMenu(null, target.getName(), target.getUniqueId(), playerInventory, true).show(player);
+            });
+
+        }, true);
 
     }
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
@@ -23,21 +23,28 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
     @Getter
     private @Nullable Player player;
     @Getter
-    private ReferencingInventory playerInventory;
+    private final ReferencingInventory playerInventory;
     private ReferencingInventory craftingInventory;
-    private String name;
-    private UUID id;
+    private final String name;
+    private final UUID id;
     private boolean offline;
-    private CraftInventoryPlayer craftInventoryPlayer;
+    private final CraftInventoryPlayer craftInventoryPlayer;
 
 
     /**
-     * TODO
-     * @param player
-     * @param name
-     * @param id
-     * @param inventoryPlayer
-     * @param offline
+     * Represents a player's inventory.
+     * Can be offline or online.
+     * An online player logging off will
+     * set this to an offline menu.
+     * An offline player logging on
+     * will close this menu.
+     * Changes in the primary inventory (armor + storage)
+     * Will be reflected in the actual player's inventory.
+     * @param player the player object, null if offline
+     * @param name the name of the player
+     * @param id the UUID of the player
+     * @param inventoryPlayer the CraftInventoryPlayer of the player
+     * @param offline whether this is an offline representation or not
      */
     public PlayerInventoryMenu(@Nullable Player player, String name, UUID id, CraftInventoryPlayer inventoryPlayer, boolean offline) {
         super(9, 6);
@@ -96,8 +103,8 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
 
     /**
      * Called at the earliest for a player login
-     * To save the inventory
-     * @param player
+     * closes this menu
+     * @param player the player
      */
     public void playerLogin(Player player) {
         if (!player.getUniqueId().equals(id)) return;
@@ -106,6 +113,11 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
         this.findAllWindows().forEach(Window::close);
     }
 
+    /**
+     * Called when a player leaves the server
+     * Sets this menu to an offline menu
+     * @param player the player
+     */
     public void onPlayerLeave(Player player) {
         if (!player.getUniqueId().equals(id)) return;
 
@@ -114,6 +126,9 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
 
     }
 
+    /**
+     * Saves this inventory to file
+     */
     private void saveOfflineInventory() {
         if (!offline) return;
         UtilInventory.saveOfflineInventory(id, craftInventoryPlayer);

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
@@ -56,11 +56,6 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
         this.playerInventory = ReferencingInventory.fromContents(inventoryPlayer);
 
         this.bake();
-
-        //playerInventory.setPostUpdateHandler((itemPostUpdateEvent -> {
-        //    if (!offline) return;
-        //    UtilInventory.saveOfflineInventory(id, inventoryPlayer);
-        //}));
     }
 
     private void bake() {

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/menus/PlayerInventoryMenu.java
@@ -7,24 +7,43 @@ import me.mykindos.betterpvp.core.inventory.inventory.ReferencingInventory;
 import me.mykindos.betterpvp.core.menu.Menu;
 import me.mykindos.betterpvp.core.menu.Windowed;
 import me.mykindos.betterpvp.core.menu.button.CursorButton;
+import me.mykindos.betterpvp.core.utilities.UtilInventory;
 import net.kyori.adventure.text.Component;
+import org.bukkit.craftbukkit.inventory.CraftInventoryPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 public class PlayerInventoryMenu extends AbstractGui implements Windowed {
     @Getter
-    private final Player player;
+    private final @Nullable Player player;
     @Getter
-    ReferencingInventory playerInventory;
-    ReferencingInventory craftingInventory;
+    private ReferencingInventory playerInventory;
+    private ReferencingInventory craftingInventory;
+    private String name;
+    private UUID id;
+    private boolean offline;
 
 
-    public PlayerInventoryMenu(Player player) {
+    /**
+     * TODO
+     * @param player
+     * @param name
+     * @param id
+     * @param inventoryPlayer
+     * @param offline
+     */
+    public PlayerInventoryMenu(@Nullable Player player, String name, UUID id, CraftInventoryPlayer inventoryPlayer, boolean offline) {
         super(9, 6);
         this.player = player;
-        this.playerInventory = ReferencingInventory.fromContents(player.getInventory());
-        if (player.getOpenInventory().getTopInventory().getType() == InventoryType.CRAFTING) {
+        this.name = name;
+        this.id = id;
+        this.offline = offline;
+        this.playerInventory = ReferencingInventory.fromContents(inventoryPlayer);
+        if (player != null && player.getOpenInventory().getTopInventory().getType() == InventoryType.CRAFTING) {
             craftingInventory = ReferencingInventory.fromContents(player.getOpenInventory().getTopInventory());
         }
         for (int i = 0; i < playerInventory.getSize(); i++) {
@@ -43,11 +62,16 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
         setItem(2, 5, Menu.BACKGROUND_GUI_ITEM);
         setItem(3, 5, Menu.BACKGROUND_GUI_ITEM);
         setItem(5, 5, Menu.BACKGROUND_GUI_ITEM);
+
+        playerInventory.setPostUpdateHandler((itemPostUpdateEvent -> {
+            if (!offline) return;
+            UtilInventory.saveOfflineInventory(id, inventoryPlayer);
+        }));
     }
 
     public void updateInventories() {
         playerInventory.notifyWindows();
-        if (player.getOpenInventory().getTopInventory().getType() == InventoryType.CRAFTING) {
+        if (player != null && player.getOpenInventory().getTopInventory().getType() == InventoryType.CRAFTING) {
             craftingInventory = ReferencingInventory.fromContents(player.getOpenInventory().getTopInventory());
             setSlotElement(8, 5, new SlotElement.InventorySlotElement(craftingInventory, 0));
             setSlotElement(6, 4, new SlotElement.InventorySlotElement(craftingInventory, 1));
@@ -56,12 +80,14 @@ public class PlayerInventoryMenu extends AbstractGui implements Windowed {
             setSlotElement(7, 5, new SlotElement.InventorySlotElement(craftingInventory, 4));
             craftingInventory.notifyWindows();
         }
-        setItem(4, 5, new CursorButton(player));
+        if (player != null) {
+            setItem(4, 5, new CursorButton(player));
+        }
     }
 
     @Override
     public @NotNull Component getTitle() {
-        return Component.text(player.getName() + "'s inventory");
+        return Component.text(name + "'s inventory");
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
@@ -24,6 +24,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
@@ -134,7 +136,30 @@ public class MenuListener implements Listener {
                 }
             }
         });
+    }
 
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        final Player player = event.getPlayer();
+        for (Window window : WindowManager.getInstance().getWindows()) {
+            if (window instanceof AbstractSingleWindow abstractSingleWindow) {
+                if (abstractSingleWindow.getGui() instanceof PlayerInventoryMenu playerInventory) {
+                    playerInventory.playerLogin(player);
+                }
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerJoin(PlayerQuitEvent event) {
+        final Player player = event.getPlayer();
+        for (Window window : WindowManager.getInstance().getWindows()) {
+            if (window instanceof AbstractSingleWindow abstractSingleWindow) {
+                if (abstractSingleWindow.getGui() instanceof PlayerInventoryMenu playerInventory) {
+                    playerInventory.onPlayerLeave(player);
+                }
+            }
+        }
     }
 
     //@UpdateEvent() Requires optimization

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilInventory.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilInventory.java
@@ -194,9 +194,10 @@ public class UtilInventory {
     }
 
     /**
-     * TODO
-     * @param id
-     * @param inventory
+     * Saves the CraftPlayerInventory as the players inventory
+     * in the playerdatafolder
+     * @param id the UUID of the player
+     * @param inventory the inventory of the player to save
      */
     public static void saveOfflineInventory(UUID id, CraftInventoryPlayer inventory) {
         //get the player's current data
@@ -208,10 +209,11 @@ public class UtilInventory {
     }
 
     /**
-     * TODO
-     * @param name
-     * @param id
-     * @return
+     * Gets the offline inventory of a player with the specified name and id
+     * from their playerdata.dat file
+     * @param name the name of the player
+     * @param id the UUID of the player
+     * @return the bukkit CraftInventoryPlayer inventory that belongs to this player
      */
     public static CraftInventoryPlayer getOfflineInventory(String name, UUID id) {
         //in order to access an offline players inventory, we need to load it

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilInventory.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilInventory.java
@@ -199,8 +199,11 @@ public class UtilInventory {
      * @param inventory
      */
     public static void saveOfflineInventory(UUID id, CraftInventoryPlayer inventory) {
+        //get the player's current data
         CompoundTag compound = UtilNBT.getPlayerData(id).orElseThrow();
+        //overwrite the Inventory data with the modified inventory
         compound.put("Inventory", inventory.getInventory().save(new ListTag()));
+        //save the players data
         UtilNBT.savePlayerData(id, compound);
     }
 
@@ -216,19 +219,28 @@ public class UtilInventory {
         //so instead we just recreate how inventories are loaded
         //by using those exact methods
 
+        //get data from the player.dat file
         CompoundTag compound = UtilNBT.getPlayerData(id).orElseThrow();
 
+        //get the inventory nbt data
         ListTag nbttaglist = compound.getList("Inventory", 10);
 
+        //in order to load the inventory, we need a ServerPlayer, server players require this
+        //data. Defaults are fine, this is only used to load the inventory
         MinecraftServer server = MinecraftServer.getServer();
         ServerLevel serverLevel = server.getLevel(Level.OVERWORLD);
         GameProfile gameProfile = new GameProfile(id, name);
         ClientInformation clientOptions= ClientInformation.createDefault();
+
         ServerPlayer serverPlayer = new ServerPlayer(server, serverLevel, gameProfile, clientOptions);
+
+        //create Minecraft Inventory
         Inventory inventory = new net.minecraft.world.entity.player.Inventory(serverPlayer);
 
+        //load that inventory from the NBT
         inventory.load(nbttaglist);
 
+        //return the BukkitPlayerInventory (same one you get from player#getInventory())
         return new CraftInventoryPlayer(inventory);
 
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
@@ -22,10 +22,8 @@ public class UtilNBT {
      */
     public static Optional<CompoundTag> getPlayerData(UUID id) {
         File currentPlayerData = new File(Bukkit.getWorldContainer(), "world/playerdata/" + id + ".dat");
-        //NbtCompound compound;
         CompoundTag compound;
         try {
-            //compound = NbtFactory.fromFile(currentPlayerData.getPath());
             compound = NbtIo.readCompressed(Path.of(currentPlayerData.getPath()), NbtAccounter.unlimitedHeap());
             log.info(currentPlayerData.getPath()).submit();
         } catch (

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
@@ -1,6 +1,8 @@
 package me.mykindos.betterpvp.core.utilities;
 
+import lombok.AccessLevel;
 import lombok.CustomLog;
+import lombok.NoArgsConstructor;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
@@ -12,6 +14,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @CustomLog
 public class UtilNBT {
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.utilities;
+
+import lombok.CustomLog;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import org.bukkit.Bukkit;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+
+@CustomLog
+public class UtilNBT {
+
+    /**
+     * TODO
+     * @param id
+     * @return
+     */
+    public static Optional<CompoundTag> getPlayerData(UUID id) {
+        File currentPlayerData = new File(Bukkit.getWorldContainer(), "world/playerdata/" + id + ".dat");
+        //NbtCompound compound;
+        CompoundTag compound;
+        try {
+            //compound = NbtFactory.fromFile(currentPlayerData.getPath());
+            compound = NbtIo.readCompressed(Path.of(currentPlayerData.getPath()), NbtAccounter.unlimitedHeap());
+            log.info(currentPlayerData.getPath()).submit();
+        } catch (
+                IOException exception) {
+            log.error("Error getting player data {}", exception).submit();
+            return Optional.empty();
+        }
+        return Optional.of(compound);
+    }
+
+    /**
+     * TODO
+     * @param id
+     * @param data
+     */
+    public static void savePlayerData(UUID id, CompoundTag data) {
+        File currentPlayerData = new File(Bukkit.getWorldContainer(), "world/playerdata/" + id + ".dat");
+        try {
+            NbtIo.writeCompressed(data, Path.of(currentPlayerData.getPath()));
+            log.info(currentPlayerData.getPath()).submit();
+        } catch (IOException exception) {
+            log.error("Error saving player data {}", exception).submit();
+        }
+    }
+
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilNBT.java
@@ -16,18 +16,16 @@ import java.util.UUID;
 public class UtilNBT {
 
     /**
-     * TODO
-     * @param id
-     * @return
+     * Gets the player data from the playerdata.dat file
+     * @param id the id of the player
+     * @return Optional of the playerdata as a CompoundTag
      */
     public static Optional<CompoundTag> getPlayerData(UUID id) {
         File currentPlayerData = new File(Bukkit.getWorldContainer(), "world/playerdata/" + id + ".dat");
         CompoundTag compound;
         try {
             compound = NbtIo.readCompressed(Path.of(currentPlayerData.getPath()), NbtAccounter.unlimitedHeap());
-            log.info(currentPlayerData.getPath()).submit();
-        } catch (
-                IOException exception) {
+        } catch (IOException exception) {
             log.error("Error getting player data {}", exception).submit();
             return Optional.empty();
         }
@@ -35,9 +33,9 @@ public class UtilNBT {
     }
 
     /**
-     * TODO
-     * @param id
-     * @param data
+     * Saves the playerdata (in the form of a CompoundTag)
+     * @param id the UUID of the player
+     * @param data the full playerdata to save
      */
     public static void savePlayerData(UUID id, CompoundTag data) {
         File currentPlayerData = new File(Bukkit.getWorldContainer(), "world/playerdata/" + id + ".dat");


### PR DESCRIPTION
Mock Minecraft inventory loading and saving of player data to access the inventory

- [x] View Offline inventories
- [x] Modify offline inventories
- [x] Handle players logging in/off while viewing inventory
- [x] Only save offline once

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [x] I have tested my changes.
