### PR TITLE
Refactored Arrow Trail logic

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -406,12 +406,6 @@ public abstract class Skill implements IChampionsSkill {
         return hasSkill(player) && SkillWeapons.isHolding(player, getType());
     }
 
-
-    public static <T extends Projectile> void updateParticleForArrowTrail(Particle particle, Iterator<T> it,
-                                                                          int receiversRadius, boolean checkIfInBlock) {
-        updateParticleForArrowTrail(particle, it, receiversRadius, checkIfInBlock, new Vector(0, 0, 0));
-    }
-
     public static <T extends Projectile> void updateParticleForArrowTrail(Particle particle, Iterator<T> it,
                                                                            int receiversRadius, boolean checkIfInBlock,
                                                                            Vector vector) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.OptionalDouble;
+import java.util.function.Function;
 import java.util.function.IntToDoubleFunction;
 
 @Singleton
@@ -406,9 +407,14 @@ public abstract class Skill implements IChampionsSkill {
         return hasSkill(player) && SkillWeapons.isHolding(player, getType());
     }
 
-    public static <T extends Projectile> void updateParticleForArrowTrail(Particle particle, Iterator<T> it,
-                                                                           int receiversRadius, boolean checkIfInBlock,
-                                                                           Vector vector) {
+    public static <T extends Projectile> void updateParticleForArrowTrail(Function<Location, ParticleBuilder> builderFunction,
+                                                                          Iterator<T> it, boolean checkIfInBlock) {
+        updateParticleForArrowTrail(builderFunction, it, checkIfInBlock, new Vector(0, 0, 0));
+    }
+
+    public static <T extends Projectile> void updateParticleForArrowTrail(Function<Location, ParticleBuilder> builderFunction,
+                                                                          Iterator<T> it, boolean checkIfInBlock,
+                                                                          Vector vector) {
         while (it.hasNext()) {
             T arrowOrProjectile = it.next();
             if (arrowOrProjectile == null || arrowOrProjectile.isDead()) {
@@ -417,12 +423,8 @@ public abstract class Skill implements IChampionsSkill {
                 it.remove();
             } else {
                 Location location = arrowOrProjectile.getLocation().add(vector);
-                particle.builder()
-                        .count(1)
-                        .location(location)
-                        .receivers(receiversRadius)
-                        .extra(0)
-                        .spawn();
+                ParticleBuilder particleBuilder = builderFunction.apply(location);
+                particleBuilder.spawn();
             }
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.CustomLog;
@@ -34,14 +35,26 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.components.champions.IChampionsSkill;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.effects.Effect;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilLocation;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.util.Vector;
 
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.function.IntToDoubleFunction;
 
 @Singleton
@@ -391,5 +404,32 @@ public abstract class Skill implements IChampionsSkill {
     @Override
     public boolean isHolding(Player player) {
         return hasSkill(player) && SkillWeapons.isHolding(player, getType());
+    }
+
+
+    public static <T extends Projectile> void updateParticleForArrowTrail(Particle particle, Iterator<T> it,
+                                                                          int receiversRadius, boolean checkIfInBlock) {
+        updateParticleForArrowTrail(particle, it, receiversRadius, checkIfInBlock, new Vector(0, 0, 0));
+    }
+
+    public static <T extends Projectile> void updateParticleForArrowTrail(Particle particle, Iterator<T> it,
+                                                                           int receiversRadius, boolean checkIfInBlock,
+                                                                           Vector vector) {
+        while (it.hasNext()) {
+            T arrowOrProjectile = it.next();
+            if (arrowOrProjectile == null || arrowOrProjectile.isDead()) {
+                it.remove();
+            } else if (checkIfInBlock && arrowOrProjectile instanceof Arrow && ((Arrow) arrowOrProjectile).isInBlock()) {
+                it.remove();
+            } else {
+                Location location = arrowOrProjectile.getLocation().add(vector);
+                particle.builder()
+                        .count(1)
+                        .location(location)
+                        .receivers(receiversRadius)
+                        .extra(0)
+                        .spawn();
+            }
+        }
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -83,15 +83,14 @@ public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.ENTITY_EFFECT)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.ENTITY_EFFECT)
                 .location(location)
                 .data(Color.BLACK)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -87,14 +87,13 @@ public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.EFFECT)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.EFFECT)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
@@ -11,6 +11,7 @@ import me.mykindos.betterpvp.champions.champions.skills.types.PrepareArrowSkill;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
@@ -21,13 +22,14 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 
 import java.util.Random;
 
 @Singleton
 @BPvPListener
-public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
+public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill, Listener {
 
     private double baseDuration;
 
@@ -112,7 +114,7 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public void displayTrail(Location location) {
+    public ParticleBuilder getArrowTrail(Location location) {
         Random random = UtilMath.RANDOM;
         double spread = 0.1;
         double dx = (random.nextDouble() - 0.5) * spread;
@@ -125,7 +127,7 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
         double green = 0.2;
         double blue = 0.2;
 
-        new ParticleBuilder(Particle.ENTITY_EFFECT)
+        return new ParticleBuilder(Particle.ENTITY_EFFECT)
                 .location(particleLocation)
                 .count(0)
                 .offset(red, green, blue)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -104,7 +104,7 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public void displayTrail(Location location) {
+    public ParticleBuilder getArrowTrail(Location location) {
         Random random = UtilMath.RANDOM;
         double spread = 0.1;
         double dx = (random.nextDouble() - 0.5) * spread;
@@ -117,14 +117,13 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
         double green = 1.0;
         double blue = 0.4;
 
-        new ParticleBuilder(Particle.ENTITY_EFFECT)
+        return new ParticleBuilder(Particle.ENTITY_EFFECT)
                 .location(particleLocation)
                 .count(0)
                 .data(Color.GREEN)
                 .offset(red, green, blue)
                 .extra(1.0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/BioticShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/BioticShot.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.bow;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
@@ -201,8 +202,12 @@ public class BioticShot extends PrepareArrowSkill implements HealthSkill, TeamSk
     }
 
     @Override
-    public void displayTrail(Location location) {
-        Particle.GLOW.builder().location(location).count(3).extra(0).receivers(60, true).spawn();
+    public ParticleBuilder getArrowTrail(Location location) {
+        return Particle.GLOW.builder()
+                .location(location)
+                .count(3)
+                .extra(0)
+                .receivers(60, true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/ExplosiveArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/ExplosiveArrow.java
@@ -38,7 +38,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.util.Vector;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -165,28 +164,29 @@ public class ExplosiveArrow extends PrepareArrowSkill implements DamageSkill, Of
         explosiveArrows.remove(playerId);
     }
 
+    @Override
+    public boolean shouldUpdateParticleTrail() {
+        return false;
+    }
+
+    /**
+     * This method's purpose is to update the arrow trail with the custom particle.
+     * Although PreparedArrowSkill.java already provides an UpdateEvent for this, it is not applicable.
+     * This is because this skill does not use the arrows List inherited from PreparedArrowSkill.java
+     */
     @UpdateEvent
     public void updateArrowTrail() {
-        Iterator<Arrow> iterator = explosiveArrows.values().iterator();
-        while (iterator.hasNext()) {
-            Arrow arrow = iterator.next();
-            if (arrow.isDead() || !arrow.isValid()) {
-                iterator.remove();
-            } else {
-                displayTrail(arrow.getLocation());
-            }
-        }
+        updateParticleForArrowTrail(this::getArrowTrail, explosiveArrows.values().iterator(), false);
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.POOF)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.POOF)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -90,14 +90,13 @@ public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill,
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.ENCHANT)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.ENCHANT)
                 .location(location)
                 .count(3)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
@@ -283,14 +283,13 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.RAID_OMEN)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.RAID_OMEN)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
@@ -39,9 +39,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.WeakHashMap;
@@ -212,29 +210,24 @@ public class NapalmArrow extends PrepareArrowSkill implements ThrowableListener,
         arrow.setFireTicks(200);
     }
 
+    @Override
+    public boolean shouldUpdateParticleTrail() {
+        return false;
+    }
+
     @UpdateEvent
     public void updateArrowTrail() {
-        Iterator<Map.Entry<UUID, Arrow>> iterator = napalmArrows.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<UUID, Arrow> entry = iterator.next();
-            Arrow arrow = entry.getValue();
-            if (arrow.isDead() || !arrow.isValid()) {
-                iterator.remove();
-            } else {
-                displayTrail(arrow.getLocation());
-            }
-        }
+        updateParticleForArrowTrail(this::getArrowTrail, napalmArrows.values().iterator(), true);
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.FLAME)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.FLAME)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
@@ -110,16 +110,15 @@ public class RopedArrow extends PrepareArrowSkill implements MovementSkill {
     }
 
     @Override
-    public void displayTrail(Location location) {
+    public ParticleBuilder getArrowTrail(Location location) {
         Particle.DustOptions dustOptions = new Particle.DustOptions(Color.fromRGB(255, 255, 255), 1);
-        new ParticleBuilder(Particle.DUST)
+        return new ParticleBuilder(Particle.DUST)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
                 .receivers(60)
-                .data(dustOptions)
-                .spawn();
+                .data(dustOptions);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StormSphere.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StormSphere.java
@@ -216,14 +216,13 @@ public class StormSphere extends PrepareArrowSkill implements AreaOfEffectSkill,
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.DRIPPING_WATER)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.DRIPPING_WATER)
                 .location(location)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
@@ -427,23 +427,29 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
         }
     }
 
+    @Override
+    public boolean shouldUpdateParticleTrail() {
+        return false;
+    }
+
     @UpdateEvent
     public void updateArrowTrail() {
+
+        // Not sure if this can be repalced with other method in Skill.java
         for (Arrow arrow : tetherArrows.values()) {
             if (arrow == null) continue;
-            displayTrail(arrow.getLocation());
+
+            getArrowTrail(arrow.getLocation()).spawn();
         }
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.INFESTED)
-                .location(location)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.INFESTED)
                 .count(1)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TriShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TriShot.java
@@ -41,7 +41,6 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
@@ -214,32 +213,25 @@ public class TriShot extends PrepareArrowSkill implements OffensiveSkill {
         // Do nothing
     }
 
+    @Override
+    public boolean shouldUpdateParticleTrail() {
+        return false;
+    }
+
     @UpdateEvent
     public void updateTridentTrail() {
         if (tridents.isEmpty()) return;
-
-        Iterator<Map.Entry<Trident, Player>> iterator = tridents.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Trident, Player> entry = iterator.next();
-            Trident trident = entry.getKey();
-
-            if (trident.isDead()) {
-                iterator.remove();
-            } else if (!trident.isInBlock()) {
-                displayTrail(trident.getLocation());
-            }
-        }
+        updateParticleForArrowTrail(this::getArrowTrail, tridents.keySet().iterator(), true);
     }
 
     @Override
-    public void displayTrail(Location location) {
-        new ParticleBuilder(Particle.FALLING_WATER)
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.FALLING_WATER)
                 .location(location)
                 .count(4)
                 .offset(0.1, 0.1, 0.1)
                 .extra(0)
-                .receivers(60)
-                .spawn();
+                .receivers(60);
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -33,6 +33,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.util.Vector;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -217,24 +218,8 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
 
     @UpdateEvent
     public void updateArrowTrail() {
-        Iterator<Projectile> it = barbedProjectiles.keySet().iterator();
-        while (it.hasNext()) {
-            Projectile next = it.next();
-            if (next == null) {
-                it.remove();
-            } else if (next.isDead()) {
-                it.remove();
-            } else {
-                Location location = next.getLocation();
-                Particle.SQUID_INK.builder()
-                        .count(1)
-                        .extra(0)
-                        .offset(0.0, 0.0, 0.0)
-                        .location(location)
-                        .receivers(30)
-                        .spawn();
-            }
-        }
+        updateParticleForArrowTrail(Particle.SQUID_INK, barbedProjectiles.keySet().iterator(), 30,
+                false, new Vector(0, 0.1, 0));
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
@@ -207,6 +208,16 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 if (currentTime - barbedData.hitTime > damageResetTimeMs) {
                     UtilMessage.simpleMessage(player, getClassType().getName(), "Your <alt>%s</alt> in %s have fallen out.", getName(), target.getName());
                     targetIterator.remove();
+                } else {
+                    // charge offsets?
+                    Location particleLocation = target.getLocation();
+                    new ParticleBuilder(Particle.DUST)
+                            .location(particleLocation.add(0, 1, 0))
+                            .count(1)
+                            .offset(0.0, 0.0, 0.0)
+                            .data(new Particle.DustOptions(org.bukkit.Color.fromRGB(192, 192, 192), 2f))
+                            .receivers(player)
+                            .spawn();
                 }
             }
 
@@ -214,12 +225,6 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 playerIterator.remove();
             }
         }
-    }
-
-    @UpdateEvent
-    public void updateArrowTrail() {
-        updateParticleForArrowTrail(Particle.SQUID_INK, barbedProjectiles.keySet().iterator(), 30,
-                false, new Vector(0, 0.1, 0));
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -226,7 +226,7 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 it.remove();
             } else {
                 Location location = next.getLocation();
-                Particle.ENCHANTED_HIT.builder()
+                Particle.SQUID_INK.builder()
                         .count(1)
                         .extra(0)
                         .offset(0.0, 0.0, 0.0)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
@@ -66,8 +67,15 @@ public class HeavyArrows extends Skill implements PassiveSkill, EnergySkill, Mov
     @UpdateEvent
     public void update() {
         Vector vector = new Vector(0, 0.25, 0);
-        updateParticleForArrowTrail(Particle.ENCHANTED_HIT, arrows.iterator(), 60,
-                false, vector);
+        updateParticleForArrowTrail(this::getArrowTrail, arrows.iterator(), false, vector);
+    }
+
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.ENCHANTED_HIT)
+                .location(location)
+                .count(1)
+                .extra(0)
+                .receivers(60);
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/HeavyArrows.java
@@ -65,16 +65,9 @@ public class HeavyArrows extends Skill implements PassiveSkill, EnergySkill, Mov
 
     @UpdateEvent
     public void update() {
-        Iterator<Arrow> it = arrows.iterator();
-        while (it.hasNext()) {
-            Arrow arrow = it.next();
-            if (arrow == null || arrow.isDead() || !(arrow.getShooter() instanceof Player)) {
-                it.remove();
-            } else {
-                Location location = arrow.getLocation().add(new Vector(0, 0.25, 0));
-                Particle.ENCHANTED_HIT.builder().location(location).receivers(60).extra(0).spawn();
-            }
-        }
+        Vector vector = new Vector(0, 0.25, 0);
+        updateParticleForArrowTrail(Particle.ENCHANTED_HIT, arrows.iterator(), 60,
+                false, vector);
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
@@ -1,6 +1,7 @@
 
 package me.mykindos.betterpvp.champions.champions.skills.skills.ranger.passives;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.champions.Champions;
@@ -31,6 +32,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -128,12 +130,16 @@ public class Kinetics extends Skill implements PassiveSkill, MovementSkill {
     @UpdateEvent
     public void updateArrowTrail() {
         Vector vector = new Vector(0, 0.25, 0);
-        updateParticleForArrowTrail(Particle.TRIAL_SPAWNER_DETECTION_OMINOUS, arrows.iterator(), 60,
-                true, vector);
+        updateParticleForArrowTrail(this::getArrowTrail, arrows.iterator(), false, vector);
     }
 
-    // tbh only do it for kinetics
-    // dont bother with rest and leave barbed as is
+    public ParticleBuilder getArrowTrail(Location location) {
+        return new ParticleBuilder(Particle.TRIAL_SPAWNER_DETECTION_OMINOUS)
+                .location(location)
+                .count(1)
+                .extra(0)
+                .receivers(60);
+    }
 
     @EventHandler
     public void onShoot(EntityShootBowEvent event) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
@@ -129,7 +129,7 @@ public class Kinetics extends Skill implements PassiveSkill, MovementSkill {
     public void updateArrowTrail() {
         Vector vector = new Vector(0, 0.25, 0);
         updateParticleForArrowTrail(Particle.TRIAL_SPAWNER_DETECTION_OMINOUS, arrows.iterator(), 60,
-                false, vector);
+                true, vector);
     }
 
     // tbh only do it for kinetics

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
@@ -31,7 +31,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
-import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -128,20 +127,9 @@ public class Kinetics extends Skill implements PassiveSkill, MovementSkill {
 
     @UpdateEvent
     public void updateArrowTrail() {
-        Iterator<Arrow> it = arrows.iterator();
-        while (it.hasNext()) {
-            Arrow arrow = it.next();
-            if (arrow == null || arrow.isDead() || !(arrow.getShooter() instanceof Player) || arrow.isInBlock()) {
-                it.remove();
-            } else {
-                Location location = arrow.getLocation().add(new Vector(0, 0.25, 0));
-                Particle.TRIAL_SPAWNER_DETECTION_OMINOUS.builder()
-                        .location(location)
-                        .receivers(60)
-                        .extra(0)
-                        .spawn();
-            }
-        }
+        Vector vector = new Vector(0, 0.25, 0);
+        updateParticleForArrowTrail(Particle.TRIAL_SPAWNER_DETECTION_OMINOUS, arrows.iterator(), 60,
+                false, vector, false);
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Kinetics.java
@@ -129,8 +129,11 @@ public class Kinetics extends Skill implements PassiveSkill, MovementSkill {
     public void updateArrowTrail() {
         Vector vector = new Vector(0, 0.25, 0);
         updateParticleForArrowTrail(Particle.TRIAL_SPAWNER_DETECTION_OMINOUS, arrows.iterator(), 60,
-                false, vector, false);
+                false, vector);
     }
+
+    // tbh only do it for kinetics
+    // dont bother with rest and leave barbed as is
 
     @EventHandler
     public void onShoot(EntityShootBowEvent event) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
@@ -72,11 +72,6 @@ public class Precision extends Skill implements PassiveSkill, DamageSkill, Offen
         return SkillType.PASSIVE_B;
     }
 
-    @UpdateEvent
-    public void updateArrowTrail() {
-        updateParticleForArrowTrail(Particle.TOTEM_OF_UNDYING, arrows.iterator(), 60, true);
-    }
-
     @EventHandler
     public void onShoot(EntityShootBowEvent event) {
         if (!(event.getEntity() instanceof Player player)) return;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/Precision.java
@@ -74,20 +74,7 @@ public class Precision extends Skill implements PassiveSkill, DamageSkill, Offen
 
     @UpdateEvent
     public void updateArrowTrail() {
-        Iterator<Arrow> it = arrows.iterator();
-        while (it.hasNext()) {
-            Arrow arrow = it.next();
-            if (arrow == null || arrow.isDead() || !(arrow.getShooter() instanceof Player) || arrow.isInBlock()) {
-                it.remove();
-            } else {
-                Location location = arrow.getLocation().add(new Vector(0, 0.25, 0));
-                Particle.TOTEM_OF_UNDYING.builder()
-                        .location(location)
-                        .receivers(60)
-                        .extra(0)
-                        .spawn();
-            }
-        }
+        updateParticleForArrowTrail(Particle.TOTEM_OF_UNDYING, arrows.iterator(), 60, true);
     }
 
     @EventHandler
@@ -106,9 +93,9 @@ public class Precision extends Skill implements PassiveSkill, DamageSkill, Offen
         if (!(event.getDamager() instanceof Player damager)) return;
 
         int level = getLevel(damager);
-        if (level > 0) {
-            event.setDamage(event.getDamage() + getDamage(level));
-        }
+        if (level <= 0) return;
+
+        event.setDamage(event.getDamage() + getDamage(level));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/VitalitySpores.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/VitalitySpores.java
@@ -164,7 +164,7 @@ public class VitalitySpores extends Skill implements PassiveSkill, DefensiveSkil
                             .location(particleLocation)
                             .count(1)
                             .offset(0.0, 0.0, 0.0)
-                            .data(new Particle.DustOptions(org.bukkit.Color.fromRGB(0, 255, 0), 0.5f))
+                            .data(new Particle.DustOptions(org.bukkit.Color.fromRGB(0, 255, 0), 1f))
                             .receivers(charge.applier)
                             .spawn();
                     return false;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PrepareArrowSkill.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills.types;
 
+import com.destroystokyo.paper.ParticleBuilder;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
@@ -13,7 +14,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityShootBowEvent;
-import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -67,21 +67,14 @@ public abstract class PrepareArrowSkill extends PrepareSkill implements Cooldown
         arrows.add(arrow);
     }
 
+    public boolean shouldUpdateParticleTrail() {
+        return true;
+    }
+
     @UpdateEvent
     public void updateParticle() {
-        Iterator<Arrow> it = arrows.iterator();
-        while (it.hasNext()) {
-            Arrow next = it.next();
-            if (next == null || next.isOnGround()) {
-                it.remove();
-            } else if (next.isDead()) {
-                it.remove();
-            } else {
-                Location loc = next.getLocation().add(new Vector(0, 0.25, 0));
-                displayTrail(loc);
-
-            }
-        }
+        if (!shouldUpdateParticleTrail()) return;
+        updateParticleForArrowTrail(this::getArrowTrail, arrows.iterator(), true);
     }
 
     @UpdateEvent(delay = 250)
@@ -117,7 +110,7 @@ public abstract class PrepareArrowSkill extends PrepareSkill implements Cooldown
 
     public abstract void onHit(Player damager, LivingEntity target, int level);
 
-    public abstract void displayTrail(Location location);
+    public abstract ParticleBuilder getArrowTrail(Location location);
 
     public void onFire(Player shooter) {
         // Overridable - Not abstract to avoid breaking existing skills


### PR DESCRIPTION
## Describe your changes
- Greatly simplified the logic for arrow trails and made it uniform across bow skills (even special ones that don't use the `arrows` list)
- Added a cool arrow trial for Kinetics
- Made the Vitality Spores particle slightly more visible
- Added a particle to Barbed Arrows (when you hit a player) that is very similar to Vitality Spores's
- Also removed Barbed Arrows's arrow trail (as it was the same as Heavy Arrows's)

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
