### PR TITLE
Change how fissure works with non-air blocks

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -174,7 +174,9 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
         Block targetBlock = fissureBlock.getBlock();
         if (UtilBlock.airFoliage(targetBlock)) {
             Material materialToSet = fissureBlock.getMaterialToSet();
-            blockHandler.addRestoreBlock(targetBlock, materialToSet, (long) (fissureExpireDuration * 1000));
+            if (!materialToSet.isAir()) {
+                blockHandler.addRestoreBlock(targetBlock, materialToSet, (long) (fissureExpireDuration * 1000));
+            }
             targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, materialToSet);
 
             Location startLocation = fissureCast.getFissurePath().getStartLocation();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
@@ -62,12 +62,15 @@ public class FissurePath {
             }
 
 
-            for(int i = 0; i < scale; i++) {
+            for (int i = 0; i < scale; i++) {
                 Block targetBlock = location.clone().add(0, 1 + i, 0).getBlock();
                 Material targetMaterial = Material.STONE;
                 Block belowBlock = location.clone().subtract(0, (scale - 1) - i, 0).getBlock();
                 if(!cast.getFissure().isForbiddenBlockType(belowBlock)) {
                     targetMaterial = belowBlock.getType();
+                }
+                if (!targetBlock.getType().isAir()) {
+                    targetMaterial = Material.AIR;
                 }
 
                 FissureBlock fissureBlock = new FissureBlock(player, targetBlock, targetMaterial);


### PR DESCRIPTION
Change fissure to not replace non-solid blocks, due to how 2 tall blocks and lilypads are handled potentially incorrectly.

Fixes #1234

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
