### PR TITLE
Fix Fissure breaking lily pads and pitcher plants

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -3,7 +3,6 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.mage.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import lombok.CustomLog;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -48,7 +47,6 @@ import java.util.List;
 
 @Singleton
 @BPvPListener
-@CustomLog
 public class Fissure extends Skill implements InteractSkill, CooldownSkill, Listener, DamageSkill, DebuffSkill, OffensiveSkill, WorldSkill {
 
     private final WorldBlockHandler blockHandler;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.mage.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -47,6 +48,7 @@ import java.util.List;
 
 @Singleton
 @BPvPListener
+@CustomLog
 public class Fissure extends Skill implements InteractSkill, CooldownSkill, Listener, DamageSkill, DebuffSkill, OffensiveSkill, WorldSkill {
 
     private final WorldBlockHandler blockHandler;
@@ -174,7 +176,8 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
         Block targetBlock = fissureBlock.getBlock();
         if (UtilBlock.airFoliage(targetBlock)) {
             Material materialToSet = fissureBlock.getMaterialToSet();
-            blockHandler.addRestoreBlock(targetBlock, materialToSet, (long) (fissureExpireDuration * 1000));
+
+            blockHandler.addRestoreBlock(fissureCast.getPlayer(), targetBlock, fissureBlock.getBlockData(), materialToSet, (long) (fissureExpireDuration * 1000), true, "Fissure");
             targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, materialToSet);
 
             Location startLocation = fissureCast.getFissurePath().getStartLocation();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissureBlock.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissureBlock.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
@@ -14,6 +15,7 @@ public class FissureBlock {
 
     private final Player player;
     private final Block block;
+    private final BlockData blockData;
     private final Material materialToSet;
 
     public List<LivingEntity> getNearbyEntities() {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.mage.data;
 
+import lombok.CustomLog;
 import lombok.Data;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@CustomLog
 public class FissurePath {
 
     private Location startLocation;
@@ -62,7 +64,7 @@ public class FissurePath {
             }
 
 
-            for(int i = 0; i < scale; i++) {
+            for (int i = 0; i < scale; i++) {
                 Block targetBlock = location.clone().add(0, 1 + i, 0).getBlock();
                 Material targetMaterial = Material.STONE;
                 Block belowBlock = location.clone().subtract(0, (scale - 1) - i, 0).getBlock();
@@ -70,7 +72,7 @@ public class FissurePath {
                     targetMaterial = belowBlock.getType();
                 }
 
-                FissureBlock fissureBlock = new FissureBlock(player, targetBlock, targetMaterial);
+                FissureBlock fissureBlock = new FissureBlock(player, targetBlock, targetBlock.getBlockData().clone(), targetMaterial);
 
                 if (block.equals(startLocation.getBlock())) continue;
                 if (fissureBlocks.contains(fissureBlock)) continue;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/FissurePath.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.champions.champions.skills.skills.mage.data;
 
-import lombok.CustomLog;
 import lombok.Data;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
@@ -15,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@CustomLog
 public class FissurePath {
 
     private Location startLocation;

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/RestoreBlock.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/RestoreBlock.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.world.blocks;
 
+import lombok.CustomLog;
 import lombok.Data;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
@@ -12,10 +13,11 @@ import org.jetbrains.annotations.Nullable;
 
 
 @Data
+@CustomLog
 public class RestoreBlock {
 
     private final Block block;
-    private final Material newMaterial;
+    private Material newMaterial;
     private long expire;
 
     private BlockData blockData;
@@ -28,15 +30,19 @@ public class RestoreBlock {
 
     private boolean restored;
 
-    public RestoreBlock(Block block, Material newMaterial, long expire, @Nullable LivingEntity summoner, @Nullable String label) {
+    public RestoreBlock(Block block, BlockData blockData, Material newMaterial, long expire, @Nullable LivingEntity summoner, @Nullable String label) {
         this.block = block;
         this.newMaterial = newMaterial;
         this.expire = System.currentTimeMillis() + expire;
-        this.blockData = block.getBlockData().clone();
+        this.blockData = blockData;
         this.summoner = summoner;
         this.label = label;
 
         block.setType(newMaterial);
+    }
+
+    public RestoreBlock(Block block, Material newMaterial, long expire, @Nullable LivingEntity summoner, @Nullable String label) {
+        this(block, block.getBlockData().clone(), newMaterial, expire, summoner, label);
     }
 
     public RestoreBlock(Block block, Material newMaterial, long expire, @Nullable LivingEntity summoner) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/RestoreBlock.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/RestoreBlock.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.core.world.blocks;
 
-import lombok.CustomLog;
 import lombok.Data;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
@@ -13,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 
 
 @Data
-@CustomLog
 public class RestoreBlock {
 
     private final Block block;

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
@@ -70,7 +70,7 @@ public class WorldBlockHandler {
         } else {
             if (block.getType().equals(Material.WATER) && !newMaterial.equals(Material.WATER)) {
                 Block aboveBlock = block.getLocation().clone().add(0, 1, 0).getBlock();
-                if (aboveBlock.getType().equals(Material.LILY_PAD)) {
+                if (!aboveBlock.getType().isSolid()) {
                     addRestoreBlock(entity, aboveBlock, Material.AIR, expiry, force, label);
                 }
             }

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/blocks/WorldBlockHandler.java
@@ -47,6 +47,14 @@ public class WorldBlockHandler {
      * @param force       Whether to override an existing restore block's expiry or choose the higher value
      */
     public void addRestoreBlock(@Nullable LivingEntity entity, Block block, Material newMaterial, long expiry, boolean force, @Nullable String label) {
+        addRestoreBlock(entity, block, block.getBlockData().clone(), newMaterial, expiry, force, label);
+    }
+
+    public void addRestoreBlock(@Nullable LivingEntity entity, Block block, Material newMaterial, long expiry, boolean force) {
+        addRestoreBlock(entity, block, newMaterial, expiry, force, null);
+    }
+
+    public void addRestoreBlock(@Nullable LivingEntity entity, Block block, BlockData blockData, Material newMaterial, long expiry, boolean force, @Nullable String label) {
         Optional<RestoreBlock> restoreBlockOptional = getRestoreBlock(block);
         if (restoreBlockOptional.isPresent()) {
             final long newExpiry = System.currentTimeMillis() + expiry;
@@ -55,14 +63,20 @@ public class WorldBlockHandler {
                 restoreBlock.setSummoner(entity);
             }
             restoreBlock.setExpire(force ? newExpiry : Math.max(restoreBlock.getExpire(), newExpiry));
+            if (restoreBlock.getNewMaterial() == Material.AIR) {
+                restoreBlock.setNewMaterial(newMaterial);
+                block.setType(newMaterial);
+            }
         } else {
-            RestoreBlock newRestoreBlock = new RestoreBlock(block, newMaterial, expiry, entity, label);
+            if (block.getType().equals(Material.WATER) && !newMaterial.equals(Material.WATER)) {
+                Block aboveBlock = block.getLocation().clone().add(0, 1, 0).getBlock();
+                if (aboveBlock.getType().equals(Material.LILY_PAD)) {
+                    addRestoreBlock(entity, aboveBlock, Material.AIR, expiry, force, label);
+                }
+            }
+            RestoreBlock newRestoreBlock = new RestoreBlock(block, blockData, newMaterial, expiry, entity, label);
             restoreBlocks.put(block, newRestoreBlock);
         }
-    }
-
-    public void addRestoreBlock(@Nullable LivingEntity entity, Block block, Material newMaterial, long expiry, boolean force) {
-        addRestoreBlock(entity, block, newMaterial, expiry, force, null);
     }
 
     public void scheduleRestoreBlock(Block block, Material newMaterial, long delay, long expiry) {


### PR DESCRIPTION
Change how fissure stores blockdata (now correctly stores blockdata)

Change RestoreBlock to handle this functionality
Make RestoreBlock handle lily pads much better

Fixes #1234

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
