### PR TITLE
Fix Enchanted Lumberfall items not stacking with other items

### DIFF
--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/EnchantedLumberfall.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/EnchantedLumberfall.java
@@ -139,7 +139,9 @@ public class EnchantedLumberfall extends WoodcuttingProgressionSkill implements 
             if (shouldDoubleDrops) count *= 2;
 
             ItemStack itemStack = new ItemStack(lootType.getMaterial(), count);
-            itemStack.editMeta(meta -> meta.setCustomModelData(lootType.getCustomModelData()));
+            if (lootType.getCustomModelData() != 0) {
+                itemStack.editMeta(meta -> meta.setCustomModelData(lootType.getCustomModelData()));
+            }
             ItemStack finalItemStack = itemHandler.updateNames(itemStack);
             UtilItem.insert(player, finalItemStack);
 


### PR DESCRIPTION
Don't assign items with custommodeldata 0 a custom model data in Enchanted Lumberfall

Fixes #1419

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
