### PR TITLE
Fix dying resetting protection timer

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/protection/ClansProtectionListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/protection/ClansProtectionListener.java
@@ -99,15 +99,16 @@ public class ClansProtectionListener implements Listener {
     @UpdateEvent(delay = 240 * 1000L)
     public void protectionReminder() {
         clientManager.getOnline().forEach(client -> {
-            Gamer gamer = client.getGamer();
-            Player player = gamer.getPlayer();
+            final Gamer gamer = client.getGamer();
+            final Player player = gamer.getPlayer();
 
             if (effectManager.hasEffect(player, EffectTypes.PROTECTION)) {
                 assert player != null;
                 Clan clan = clanManger.getClanByLocation(player.getLocation()).orElse(null);
-                long remainingProtection = client.getGamer().getLongProperty(GamerProperty.REMAINING_PVP_PROTECTION);
+                long remainingProtection = gamer.getLongProperty(GamerProperty.REMAINING_PVP_PROTECTION);
                 if (clan == null || !clan.isSafe()) {
                     remainingProtection = remainingProtection - (System.currentTimeMillis() - gamer.getLastSafe());
+                    gamer.updateRemainingProtection();
                 }
 
                 if (remainingProtection > 0) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/listeners/GamerProtectionListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/listeners/GamerProtectionListener.java
@@ -5,21 +5,26 @@ import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.client.events.ClientJoinEvent;
 import me.mykindos.betterpvp.core.client.events.ClientQuitEvent;
 import me.mykindos.betterpvp.core.client.gamer.properties.GamerProperty;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 
 @Singleton
 @BPvPListener
 public class GamerProtectionListener implements Listener {
 
     private final EffectManager effectManager;
+    private final ClientManager clientManager;
+
 
     @Inject
-    public GamerProtectionListener(EffectManager effectManager) {
+    public GamerProtectionListener(EffectManager effectManager, ClientManager clientManager) {
         this.effectManager = effectManager;
+        this.clientManager = clientManager;
     }
 
     @EventHandler
@@ -29,6 +34,11 @@ public class GamerProtectionListener implements Listener {
             effectManager.addEffect(event.getPlayer(), EffectTypes.PROTECTION, remainingProtection);
         }
         event.getClient().getGamer().setLastSafeNow();
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        clientManager.search().online(event.getPlayer()).getGamer().updateRemainingProtection();
     }
 
     @EventHandler


### PR DESCRIPTION
Happens because you respawn in a safezone, which on leaving sets the last safe time, then updates your timer. Timer is updated on entering a territory, but no event is fired when you spawn in a safe area.

Fixes #1401

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
