### PR TITLE
Pestilence rework & some fixes

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/PestilenceProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/PestilenceProjectile.java
@@ -1,0 +1,135 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.mage.data;
+
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+import me.mykindos.betterpvp.core.utilities.model.RayProjectile;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class PestilenceProjectile extends RayProjectile {
+
+    private final Set<LivingEntity> hitEntities = new HashSet<>();
+    private final EffectManager effectManager;
+    private final double radius;
+    private final double poisonDuration;
+    private final int poisonLevel;
+    private long lastTargetTime;
+
+    public PestilenceProjectile(@Nullable Player caster, double hitboxSize, double size, Location location, long aliveTime, EffectManager effectManager, double radius, double poisonDuration, int poisonLevel) {
+        super(caster, hitboxSize, size, location, aliveTime);
+        this.lastTargetTime = getCreationTime();
+        this.effectManager = effectManager;
+        this.radius = radius;
+        this.poisonDuration = poisonDuration;
+        this.poisonLevel = poisonLevel;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return UtilTime.elapsed(lastTargetTime, aliveTime);
+    }
+
+    @Override
+    protected void onTick() {
+        // Play travel particles
+        final Collection<Player> receivers = location.getNearbyPlayers(60);
+        for (Location point : interpolateLine()) {
+            // Play travel particles
+            Particle.DUST.builder()
+                    .location(point)
+                    .count(1)
+                    .extra(0.5)
+                    .offset(0.1, 0.1, 0.1)
+                    .data(new Particle.DustOptions(Color.fromRGB(0, (int) (Math.random() * 100 + 155), 0), (float) this.size))
+                    .receivers(receivers)
+                    .spawn();
+        }
+
+        new SoundEffect(Sound.ENTITY_ARMADILLO_BRUSH, 0f, 1f).play(location);
+    }
+
+    @Override
+    protected boolean canCollideWith(Entity entity) {
+        return super.canCollideWith(entity) && !hitEntities.contains(entity);
+    }
+
+    @Override
+    protected void onImpact(Location location, RayTraceResult result) {
+        // we hit a block as per #onCollide
+        Particle.ITEM_SLIME.builder()
+                .location(location)
+                .count(50)
+                .offset(0.5, 0.5, 0.5)
+                .extra(0.5)
+                .receivers(location.getNearbyPlayers(60))
+                .spawn();
+        new SoundEffect(Sound.BLOCK_GRASS_PLACE, 0.5f, 1f).play(location);
+        new SoundEffect(Sound.BLOCK_GRASS_PLACE, 1.5f, 1f).play(location);
+    }
+
+    @Override
+    protected CollisionResult onCollide(RayTraceResult result) {
+        final Entity hitEntity = result.getHitEntity();
+        if (hitEntity == null) {
+            this.markForRemoval = true; // we hit a block
+            return CollisionResult.IMPACT;
+        }
+
+        // Apply poison
+        LivingEntity livingEntity = (LivingEntity) hitEntity;
+        hitEntities.add(livingEntity);
+        new SoundEffect(Sound.ENTITY_SILVERFISH_DEATH, 1f, 0.5f).play(livingEntity.getLocation());
+        new SoundEffect(Sound.ENTITY_SILVERFISH_DEATH, 1f, 0.5f).play(location);
+        this.effectManager.addEffect(livingEntity,
+                caster,
+                EffectTypes.POISON,
+                "Pestilence",
+                poisonLevel,
+                (long) (poisonDuration * 1000));
+
+        // Redirect if possible, otherwise, remove
+        final List<LivingEntity> nearby = UtilEntity.getNearbyEnemies(caster, location, radius);
+        final Optional<LivingEntity> closest = nearby.stream()
+                .filter(entity -> !hitEntities.contains(entity))
+                .filter(entity -> !entity.equals(caster))
+                .min(Comparator.comparingDouble(entity -> entity.getLocation().distanceSquared(location)));
+
+        Particle.TRIAL_OMEN.builder()
+                .location(livingEntity.getLocation().add(0, livingEntity.getHeight() / 2, 0))
+                .count(10)
+                .offset(0.5, 0.5, 0.5)
+                .extra(0.5)
+                .receivers(location.getNearbyPlayers(60))
+                .spawn();
+
+        if (closest.isPresent()) {
+            final LivingEntity target = closest.get();
+            final Location targetLoc = target.getLocation().add(0, target.getHeight() / 2, 0);
+            final Vector direction = targetLoc.toVector().subtract(location.toVector());
+            redirect(direction); // this normalizes it, don't do it twice for performance
+            lastTargetTime = System.currentTimeMillis();
+        } else {
+            this.markForRemoval = true;
+        }
+
+        return CollisionResult.CONTINUE; // Continue so it doesn't stop the ray
+    }
+}

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -528,12 +528,18 @@ skills:
     pestilence:
       enabled: true
       maxlevel: 3
-      cooldown: 20.0
-      cooldownDecreasePerLevel: 3.0
-      enemyDamageReduction: 0.2
-      radius: 5.0
-      infectionDuration: 5.0
-      duration: 5.0
+      energy: 25
+      energyDecreasePerLevel: 2.0
+      cooldown: 16.0
+      cooldownDecreasePerLevel: 2.0
+      poisonDuration: 5.0
+      poisonDurationIncreasePerLevel: 1.0
+      poisonLevel: 2
+      radius: 8.0
+      speed: 2.0
+      radiusIncreasePerLevel: 0.0
+      hitboxSize: 0.7
+      expirySeconds: 2.0
     rootingaxe:
       enabled: true
       maxlevel: 3

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.utilities.events.FetchNearbyEntityEvent;
 import me.mykindos.betterpvp.core.utilities.events.GetEntityRelationshipEvent;
 import me.mykindos.betterpvp.core.utilities.model.EntityRemovalReason;
 import me.mykindos.betterpvp.core.utilities.model.MultiRayTraceResult;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -129,7 +128,7 @@ public class UtilEntity {
         source.getWorld().getLivingEntities().stream()
                 .filter(livingEntity -> {
                     if (livingEntity.equals(source)) return false;
-                    if (livingEntity.getLocation().distanceSquared(location) > radius) return false;
+                    if (livingEntity.getLocation().distanceSquared(location) > radius * radius) return false;
                     if(livingEntity instanceof Player player) {
                         if(player.getGameMode().isInvulnerable()) {
                             return false;

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/RayProjectile.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/RayProjectile.java
@@ -7,6 +7,8 @@ import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.math.VectorLine;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.RayTraceResult;
@@ -107,6 +109,10 @@ public abstract class RayProjectile {
         return CollisionResult.IMPACT;
     }
 
+    protected boolean canCollideWith(Entity entity) {
+        return entity != caster && entity instanceof LivingEntity && !(entity instanceof ArmorStand);
+    }
+
     private Optional<RayTraceResult> checkCollision() {
         if (isExpired()) {
             return Optional.of(new RayTraceResult(location.toVector()));
@@ -118,7 +124,7 @@ public abstract class RayProjectile {
                 FluidCollisionMode.NEVER,
                 true,
                 hitboxSize,
-                entity -> entity != caster && entity instanceof LivingEntity);
+                this::canCollideWith);
         if (rayTrace != null) {
             return Optional.of(rayTrace);
         }


### PR DESCRIPTION
## Describe your changes
- Fix https://github.com/Mykindos/BetterPvP/commit/68a6ad5b78025fd68c56b102979e1d34e19fe179 making all effective radiuses for all skills be `sqrt(radius)`
- Add a collision entity filter to `RayProjectile`
- Pestilence no longer weakens enemies
- Pestilence is now a channeled skill that fires a projectile.
     - The projectile fired redirects toward the closest enemy and poisons them.
     - Charging the skill increases the speed of the projectile (persists across target jumps)
     - There is no target limit.

This change to Pestilence aims to add some skill expression and reduce its base power. To account for the power reduction, the poison duration was increased to (5 -> 6 -> 7 seconds)  and bumped to an amplifier of 2. (Deals 3 hearts to assassin at max level, just a little higher than before)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
