### PR TITLE
Fix some item logs, clan formatters, allow admins to view logs by clan id

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/AdminLogsSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/AdminLogsSubCommand.java
@@ -1,0 +1,82 @@
+package me.mykindos.betterpvp.clans.clans.commands.subcommands;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.commands.ClanCommand;
+import me.mykindos.betterpvp.clans.clans.commands.ClanSubCommand;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.logging.LogContext;
+import me.mykindos.betterpvp.core.logging.menu.CachedLogMenu;
+import me.mykindos.betterpvp.core.logging.repository.LogRepository;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Singleton
+@SubCommand(ClanCommand.class)
+public class AdminLogsSubCommand extends ClanSubCommand {
+
+    private final LogRepository logRepository;
+
+    @Inject
+    public AdminLogsSubCommand(ClanManager clanManager, ClientManager clientManager, LogRepository logRepository) {
+        super(clanManager, clientManager);
+        this.logRepository = logRepository;
+    }
+
+    @Override
+    public String getName() {
+        return "adminlogs";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Get logs associated with the specified clan";
+    }
+
+    @Override
+    public String getUsage() {
+        return super.getUsage() + " <clanname|clanid>";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        if (args.length < 1) {
+            UtilMessage.message(player, "Logs", getUsage());
+        }
+        Optional<Clan> clanOptional = clanManager.getClanByName(args[0]);
+
+        if (clanOptional.isPresent()) {
+            Clan clan = clanOptional.get();
+            new CachedLogMenu(clan.getName(), LogContext.CLAN, clan.getId().toString(), null, CachedLogMenu.CLANS, JavaPlugin.getPlugin(Clans.class), logRepository, null).show(player);
+            return;
+        }
+        UUID clanId;
+        try {
+             clanId = UUID.fromString(args[0]);
+        } catch (IllegalArgumentException ignored) {
+            UtilMessage.message(player, "Logs", "<yellow>%s</yellow> is not a valid ID", args[0]);
+            return;
+        }
+        new CachedLogMenu(args[0], LogContext.CLAN, clanId.toString(), null, CachedLogMenu.CLANS, JavaPlugin.getPlugin(Clans.class), logRepository, null).show(player);
+
+    }
+
+    @Override
+    public boolean canExecuteWithoutClan() {
+        return true;
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? ClanArgumentType.CLAN.name() : ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/clans/ClanInviteLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/clans/ClanInviteLogFormatter.java
@@ -42,7 +42,7 @@ public class ClanInviteLogFormatter implements ILogFormatter {
                 Component.text(context.get(LogContext.CLIENT_NAME), NamedTextColor.YELLOW),
                 Component.text("invited", NamedTextColor.GRAY),
                 Component.text(context.get(LogContext.TARGET_CLIENT_NAME), NamedTextColor.YELLOW),
-                Component.text("to").append(Component.text(context.get(LogContext.CLAN_NAME), NamedTextColor.AQUA)),
+                Component.text("to ").append(Component.text(context.get(LogContext.CLAN_NAME), NamedTextColor.AQUA)),
                 UtilMessage.DIVIDER
 
         );

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/clans/ClanPromoteMemberLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/clans/ClanPromoteMemberLogFormatter.java
@@ -41,7 +41,7 @@ public class ClanPromoteMemberLogFormatter implements ILogFormatter {
                 cachedLog.getAbsoluteTimeComponent(),
                 UtilMessage.DIVIDER,
                 Component.text(context.get(LogContext.CLIENT_NAME), NamedTextColor.YELLOW),
-                Component.text("demoted", NamedTextColor.GRAY),
+                Component.text("promoted", NamedTextColor.GRAY),
                 Component.text(context.get(LogContext.TARGET_CLIENT_NAME), NamedTextColor.YELLOW),
                 UtilMessage.deserialize("from <green>%s</green> to <green>%s</green>",
                         context.get(LogContext.CURRENT_CLAN_RANK), context.get(LogContext.NEW_CLAN_RANK)),

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemDespawnLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/ItemDespawnLogFormatter.java
@@ -7,11 +7,13 @@ import me.mykindos.betterpvp.core.logging.CachedLog;
 import me.mykindos.betterpvp.core.logging.LogContext;
 import me.mykindos.betterpvp.core.logging.formatters.ILogFormatter;
 import me.mykindos.betterpvp.core.logging.menu.LogRepositoryMenu;
+import me.mykindos.betterpvp.core.logging.menu.button.LocationButton;
 import me.mykindos.betterpvp.core.logging.menu.button.UUIDItemButton;
 import me.mykindos.betterpvp.core.logging.repository.LogRepository;
 import me.mykindos.betterpvp.core.menu.PreviousableButton;
 import me.mykindos.betterpvp.core.menu.Windowed;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilWorld;
 import me.mykindos.betterpvp.core.utilities.model.description.Description;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 import net.kyori.adventure.text.Component;
@@ -57,7 +59,8 @@ public class ItemDespawnLogFormatter implements ILogFormatter {
         );
 
         List<? extends PreviousableButton> buttons = List.of(
-                new UUIDItemButton(context.get(LogContext.ITEM_NAME), context.get(LogContext.ITEM), JavaPlugin.getPlugin(Core.class), logRepository, previous)
+                new UUIDItemButton(context.get(LogContext.ITEM_NAME), context.get(LogContext.ITEM), JavaPlugin.getPlugin(Core.class), logRepository, previous),
+                new LocationButton(UtilWorld.stringToLocation(context.get(LogContext.LOCATION)), true, previous)
         );
 
         ItemProvider itemProvider = ItemView.builder()

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/PlayerDeathItemLogFormatter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/formatters/items/PlayerDeathItemLogFormatter.java
@@ -55,7 +55,7 @@ public class PlayerDeathItemLogFormatter implements ILogFormatter {
                 cachedLog.getRelativeTimeComponent(),
                 cachedLog.getAbsoluteTimeComponent(),
                 UtilMessage.DIVIDER,
-                Component.text(context.get(LogContext.CLIENT_NAME), NamedTextColor.YELLOW)
+                Component.text(context.get("Victim"), NamedTextColor.YELLOW)
                         .append(Component.text(" was killed while holding", NamedTextColor.GRAY)),
                 Component.text(context.get(LogContext.ITEM_NAME), NamedTextColor.GREEN),
                 UtilMessage.deserialize("(<light_purple>%s</light_purple>)",


### PR DESCRIPTION
Fix an error with playerdeath item log, add location button to despawn log, fix some formatting errors in clan logs.
Add /c adminlogs <clanname|id>, allowing admins to view logs of clans they are not in, and allow them to see logs of clans by ID (i.e. a disbanded clan)

Fixes #1439
Fixes #1440
Fixes #1441

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
