### PR TITLE
Fix Crafters being unable to craft working soups.

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/MushroomStew.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/MushroomStew.java
@@ -8,7 +8,7 @@ import me.mykindos.betterpvp.core.combat.weapon.types.CooldownWeapon;
 import me.mykindos.betterpvp.core.combat.weapon.types.InteractWeapon;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
-import me.mykindos.betterpvp.core.framework.CoreNamespaceKeys;
+import me.mykindos.betterpvp.core.items.BPvPItem;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilInventory;
@@ -19,14 +19,9 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.PrepareItemCraftEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +41,12 @@ public class MushroomStew extends Weapon implements InteractWeapon, CooldownWeap
         this.effectManager = effectManager;
     }
 
+    public void loadWeapon(BPvPItem item) {
+        super.loadWeapon(item);
+        item.createShapelessRecipe(1, "_custom", CraftingBookCategory.MISC,
+                Material.BROWN_MUSHROOM, Material.RED_MUSHROOM, Material.BOWL);
+    }
+
     @Override
     public void activate(Player player) {
         effectManager.addEffect(player, EffectTypes.REGENERATION, level, (long) (duration * 1000));
@@ -61,23 +62,6 @@ public class MushroomStew extends Weapon implements InteractWeapon, CooldownWeap
         List<Component> lore = new ArrayList<>();
         lore.add(UtilMessage.deserialize("<gray>Grants <white>Regeneration %s</white> for <yellow>%.1f seconds</yellow>", UtilFormat.getRomanNumeral(level), duration));
         return lore;
-    }
-
-    @EventHandler (priority = EventPriority.HIGHEST)
-    public void onCraftStew(PrepareItemCraftEvent event) {
-        if (!enabled) {
-            return;
-        }
-        Recipe recipe = event.getRecipe();
-        if(recipe == null) return;
-
-        if(recipe.getResult().getType() == Material.MUSHROOM_STEW) {
-
-            ItemStack item = getItemStack();
-            item.editMeta(meta -> meta.getPersistentDataContainer().set(CoreNamespaceKeys.CUSTOM_ITEM_KEY, PersistentDataType.STRING, getIdentifier()));
-            event.getInventory().setResult(item);
-
-        }
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/items/BPvPItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/items/BPvPItem.java
@@ -244,6 +244,13 @@ public class BPvPItem implements IBPvPItem {
         return shapelessRecipe;
     }
 
+    /**
+     * Creates a shapeless recipe with getShapelessRecipe, then sets it.
+     * @param count number of items this recipe creates
+     * @param key_suffix the suffix for this recipe key "key + key_suffix"
+     * @param category the cateogry this item is
+     * @param ingredients ingredients that make this item
+     */
     public void createShapelessRecipe(int count, String key_suffix, CraftingBookCategory category, Material... ingredients) {
         ShapelessRecipe recipe = getShapelessRecipe(count, key_suffix, ingredients);
 

--- a/core/src/main/resources/configs/config.yml
+++ b/core/src/main/resources/configs/config.yml
@@ -342,6 +342,7 @@ recipe:
     netherite_hoe: false
     glass_bottle: false
     shulker_box: false
+    mushroom_stew: false
     # Clans
     tnt: false
     dispenser: false


### PR DESCRIPTION
Fix soup crafting being done incorrectly, by overriding crafting event. Now creates a custom recipe.
Fixes #1499

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
