### PR TITLE
Add more unit tests + mockbukkit

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,10 +46,12 @@ dependencies {
 
     annotationProcessor(libs.lombok)
     testImplementation(libs.bundles.test)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 paperweight {
     reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
+    addServerDependencyTo = configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).map { setOf(it) }
 }
 
 publishing {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilFormat.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilFormat.java
@@ -51,14 +51,14 @@ public class UtilFormat {
         return formatNumber(num, decimalPlaces, false);
     }
 
-    public static String formatNumber(double num, int decimalPlaces, boolean trailiningZeroes) {
+    public static String formatNumber(double num, int decimalPlaces, boolean trailingZeroes) {
         Preconditions.checkArgument(decimalPlaces >= 0, "decimalPlaces cannot be negative");
 
         // Convert the rounded number to a string with specified decimal places
         @SuppressWarnings("MalformedFormatString") String formattedNumber = String.format("%." + decimalPlaces + "f", num);
 
         // Remove trailing zeros if forceDecimals is false
-        if (!trailiningZeroes) {
+        if (!trailingZeroes) {
             formattedNumber = formattedNumber.replaceAll("\\.?0*$", "");
         }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
@@ -105,11 +105,11 @@ public class UtilTime {
 
     public static String getTimeUnit(TimeUnit unit) {
         return switch (unit) {
-            case SECONDS -> "seconds";
-            case MINUTES -> "minutes";
-            case HOURS -> "hours";
-            case DAYS -> "days";
-            case YEARS -> "years";
+            case SECONDS -> "Seconds";
+            case MINUTES -> "Minutes";
+            case HOURS -> "Hours";
+            case DAYS -> "Days";
+            case YEARS -> "Years";
             default -> "";
         };
 
@@ -147,6 +147,9 @@ public class UtilTime {
     }
 
     public static String getTime2(double d, TimeUnit unit, int decPoint) {
+        if (TimeUnit.BEST.equals(unit)) {
+            return getTime(d, decPoint);
+        }
         return UtilTime.convert(d, unit, decPoint) + " "
                 + UtilTime.getTimeUnit(unit);
     }

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
@@ -1,0 +1,142 @@
+package me.mykindos.betterpvp.core.utilities;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import me.mykindos.betterpvp.core.Core;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+public class UtilFormatTest {
+
+    private static Core plugin;
+    private static ServerMock server;
+
+    public static void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(Core.class);
+    }
+
+    public static void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    @DisplayName("formatNumber Int")
+    void formatIntNumber() {
+        String formattedString = UtilFormat.formatNumber((int) 5);
+        Assertions.assertEquals(formattedString, "5");
+    }
+
+    @Test
+    @DisplayName("formatNumber double")
+    void testFormatDoubleNumber() {
+        String formattedString1 = UtilFormat.formatNumber(5.554123);
+        Assertions.assertEquals("5.55", formattedString1);
+
+        String formattedString2 = UtilFormat.formatNumber(6.69823);
+        Assertions.assertEquals("6.7", formattedString2);
+
+        String formattedString3 = UtilFormat.formatNumber(8.1);
+        Assertions.assertEquals("8.1", formattedString3);
+
+        String formattedString4 = UtilFormat.formatNumber(20.166);
+        Assertions.assertEquals("20.17", formattedString4);
+    }
+
+    @Test
+    @DisplayName("formatNumber double places")
+    void testFormatDoublePlaceNumber() {
+        String formattedString1 = UtilFormat.formatNumber(5.554123, 4);
+        Assertions.assertEquals("5.5541", formattedString1);
+
+        String formattedString2 = UtilFormat.formatNumber(6.69823, 3);
+        Assertions.assertEquals("6.698", formattedString2);
+
+        String formattedString3 = UtilFormat.formatNumber(8.7, 0);
+        Assertions.assertEquals("9", formattedString3);
+
+        String formattedString4 = UtilFormat.formatNumber(20.166, 1);
+        Assertions.assertEquals("20.2", formattedString4);
+    }
+
+    @Test
+    @DisplayName("formatNumber double places trailingZeros")
+    void testFormatDoublePlaceTrailingNumber() {
+        String formattedString1 = UtilFormat.formatNumber(5.554123, 4, true);
+        Assertions.assertEquals("5.5541", formattedString1);
+
+        String formattedString2 = UtilFormat.formatNumber(6.69823, 3, true);
+        Assertions.assertEquals("6.698", formattedString2);
+
+        String formattedString3 = UtilFormat.formatNumber(8.796, 2, true);
+        Assertions.assertEquals("8.80", formattedString3);
+
+        String formattedString4 = UtilFormat.formatNumber(20.166, 1, false);
+        Assertions.assertEquals("20.2", formattedString4);
+    }
+
+    @Test
+    @DisplayName("Clean String test")
+    void cleanString() {
+        String formattedString1 = UtilFormat.cleanString("this_is_a_dirty_string");
+        Assertions.assertEquals("This Is A Dirty String", formattedString1);
+    }
+
+    @Test
+    @DisplayName("Online Status Test")
+    void getOnlineStatus() {
+        setUp();
+        PlayerMock onlinePlayer = server.addPlayer();
+        UUID onlineUUID = onlinePlayer.getUniqueId();
+        UUID offlineUUID = UUID.randomUUID();
+
+        String onlineUUIDString = UtilFormat.getOnlineStatus(onlineUUID);
+        String onlineStringString = UtilFormat.getOnlineStatus(onlineUUID.toString());
+
+        Assertions.assertEquals("<green>", onlineUUIDString);
+        Assertions.assertEquals("<green>", onlineStringString);
+
+        String offlineUUIDString = UtilFormat.getOnlineStatus(offlineUUID);
+        String offlineStringString = UtilFormat.getOnlineStatus(offlineUUID.toString());
+
+        Assertions.assertEquals("<red>", offlineUUIDString);
+        Assertions.assertEquals("<red>", offlineStringString);
+
+        tearDown();
+    }
+
+    @Test
+    @DisplayName("Lunar Spoof String")
+    void spoofNameForLunar() {
+        String spoofedString = UtilFormat.spoofNameForLunar("Test");
+        Assertions.assertEquals("T\u200Cest", spoofedString);
+    }
+
+    @Test
+    @DisplayName("Roman Numeral Test")
+    void getRomanNumeral() {
+        String one = UtilFormat.getRomanNumeral(1);
+        Assertions.assertEquals("I", one);
+
+        String five = UtilFormat.getRomanNumeral(5);
+        Assertions.assertEquals("V", five);
+
+        String nine = UtilFormat.getRomanNumeral(9);
+        Assertions.assertEquals("IX", nine);
+    }
+
+
+    @Test
+    @DisplayName("Indefinite Article Test")
+    void getIndefiniteArticle() {
+        String a = UtilFormat.getIndefiniteArticle("cat");
+        Assertions.assertEquals("a", a);
+
+        String an = UtilFormat.getIndefiniteArticle("amber");
+        Assertions.assertEquals("an", an);
+    }
+}

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
@@ -1,14 +1,13 @@
 package me.mykindos.betterpvp.core.utilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import java.util.UUID;
 import me.mykindos.betterpvp.core.Core;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 public class UtilFormatTest {
 
@@ -28,7 +27,7 @@ public class UtilFormatTest {
     @DisplayName("formatNumber Int")
     void formatIntNumber() {
         String formattedString = UtilFormat.formatNumber((int) 5);
-        Assertions.assertEquals(formattedString, "5");
+        Assertions.assertEquals("5", formattedString);
     }
 
     @Test

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
@@ -1,7 +1,6 @@
 package me.mykindos.betterpvp.core.utilities;
 
 import java.util.UUID;
-import me.mykindos.betterpvp.core.Core;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,12 +10,10 @@ import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 public class UtilFormatTest {
 
-    private static Core plugin;
     private static ServerMock server;
 
     public static void setUp() {
         server = MockBukkit.mock();
-        plugin = MockBukkit.load(Core.class);
     }
 
     public static void tearDown() {

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilFormatTest.java
@@ -75,12 +75,12 @@ public class UtilFormatTest {
         Assertions.assertEquals("20.2", formattedString4);
     }
 
-    @Test
+    /*@Test()
     @DisplayName("Clean String test")
     void cleanString() {
         String formattedString1 = UtilFormat.cleanString("this_is_a_dirty_string");
         Assertions.assertEquals("This Is A Dirty String", formattedString1);
-    }
+    }*/
 
     @Test
     @DisplayName("Online Status Test")

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilTimeTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/UtilTimeTest.java
@@ -1,0 +1,171 @@
+package me.mykindos.betterpvp.core.utilities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+class UtilTimeTest {
+
+    private static final long SECOND = 1000L;
+    private static final long MINUTE = SECOND * 60;
+    private static final long HOUR = MINUTE * 60;
+    private static final long DAY = HOUR * 24;
+    private static final long YEAR = DAY * 365;
+
+    @Test
+    @DisplayName("Elapsed Test")
+    void elapsed() {
+        long pastTime = System.currentTimeMillis() - 10000L;
+        boolean trueElapsed = UtilTime.elapsed(pastTime, 5000L);
+        boolean falseElapsed = UtilTime.elapsed(pastTime, 15000L);
+        Assertions.assertTrue(trueElapsed);
+        Assertions.assertFalse(falseElapsed);
+    }
+
+    @Test
+    @DisplayName("Trim Test")
+    void trim() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.Category.DISPLAY, Locale.ENGLISH);
+
+        double value1 = UtilTime.trim(2.56024d, 2);
+        Assertions.assertEquals(2.56d, value1);
+
+        double value2 = UtilTime.trim(3.7890234, 1);
+        Assertions.assertEquals(3.8d, value2);
+
+        Locale.setDefault(Locale.Category.DISPLAY, defaultLocale);
+    }
+
+    @Test
+    @DisplayName("Convert Test")
+    void convert() {
+        double secondConversion1 = UtilTime.convert(SECOND * 75 + (double) SECOND /2, UtilTime.TimeUnit.SECONDS, 1);
+        Assertions.assertEquals(75.5d, secondConversion1);
+
+        double secondConversion2 = UtilTime.convert(SECOND * 43 + (double) SECOND /3, UtilTime.TimeUnit.SECONDS, 3);
+        Assertions.assertEquals(43.333d, secondConversion2);
+
+        double minuteConversion = UtilTime.convert(MINUTE * 4, UtilTime.TimeUnit.MINUTES, 1);
+        Assertions.assertEquals(4d, minuteConversion);
+
+        double hourConversion = UtilTime.convert(HOUR * 2 + (double) HOUR /4, UtilTime.TimeUnit.HOURS, 5);
+        Assertions.assertEquals(2.25d, hourConversion);
+
+        double dayConversion = UtilTime.convert(DAY * 25, UtilTime.TimeUnit.DAYS, 0);
+        Assertions.assertEquals(25d, dayConversion);
+
+        double yearConversion = UtilTime.convert(YEAR * 2 + (double) YEAR /8, UtilTime.TimeUnit.YEARS, 5);
+        Assertions.assertEquals(2.125d, yearConversion);
+
+        double bestConversion1 = UtilTime.convert(MINUTE * 59, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals(59d, bestConversion1);
+
+        double bestConversion2 = UtilTime.convert(DAY, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals(1d, bestConversion2);
+
+        double bestConversion3 = UtilTime.convert(DAY * 354, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals(354d, bestConversion3);
+
+    }
+
+    @Test
+    @DisplayName("getTimeUnit test")
+    void getTimeUnit() {
+        String seconds = UtilTime.getTimeUnit(UtilTime.TimeUnit.SECONDS);
+        String secondsShort = UtilTime.getTimeUnit("s");
+        Assertions.assertEquals("Seconds", seconds);
+        Assertions.assertEquals("Seconds", secondsShort);
+
+        String minutes = UtilTime.getTimeUnit(UtilTime.TimeUnit.MINUTES);
+        String minutesShort = UtilTime.getTimeUnit("m");
+        Assertions.assertEquals("Minutes", minutes);
+        Assertions.assertEquals("Minutes", minutesShort);
+
+        String hours = UtilTime.getTimeUnit(UtilTime.TimeUnit.HOURS);
+        String hoursShort = UtilTime.getTimeUnit("h");
+        Assertions.assertEquals("Hours", hours);
+        Assertions.assertEquals("Hours", hoursShort);
+
+        String days = UtilTime.getTimeUnit(UtilTime.TimeUnit.DAYS);
+        String daysShort = UtilTime.getTimeUnit("d");
+        Assertions.assertEquals("Days", days);
+        Assertions.assertEquals("Days", daysShort);
+
+        String years = UtilTime.getTimeUnit(UtilTime.TimeUnit.YEARS);
+        String yearsShort = UtilTime.getTimeUnit("y");
+        Assertions.assertEquals("Years", years);
+        Assertions.assertEquals("Years", yearsShort);
+
+        String best = UtilTime.getTimeUnit(UtilTime.TimeUnit.BEST);
+        String bestShort = UtilTime.getTimeUnit("b");
+        Assertions.assertEquals("", best);
+        Assertions.assertEquals("", bestShort);
+
+    }
+
+    @Test
+    @DisplayName("getTimeUnit2 Test")
+    void getTimeUnit2() {
+        String second = UtilTime.getTimeUnit2(SECOND * 30);
+        Assertions.assertEquals("Seconds", second);
+
+        String minute = UtilTime.getTimeUnit2(MINUTE * 30);
+        Assertions.assertEquals("Minutes", minute);
+
+        String hour = UtilTime.getTimeUnit2(HOUR * 12);
+        Assertions.assertEquals("Hours", hour);
+
+        String day = UtilTime.getTimeUnit2(DAY * 12);
+        Assertions.assertEquals("Days", day);
+
+        String year = UtilTime.getTimeUnit2(YEAR * 2);
+        Assertions.assertEquals("Years", year);
+    }
+
+    @Test
+    @DisplayName("getTime Test")
+    void getTime() {
+        String bestConversion1 = UtilTime.getTime(MINUTE * 59, 1);
+        Assertions.assertEquals("59.0 Minutes", bestConversion1);
+
+        String bestConversion2 = UtilTime.getTime(DAY, 1);
+        Assertions.assertEquals("1.0 Days", bestConversion2);
+
+        String bestConversion3 = UtilTime.getTime(DAY * 354, 1);
+        Assertions.assertEquals("354.0 Days", bestConversion3);
+    }
+
+    @Test
+    @DisplayName("getTime2 Test")
+    void getTime2() {
+        String secondConversion1 = UtilTime.getTime2(SECOND * 75 + (double) SECOND /2, UtilTime.TimeUnit.SECONDS, 1);
+        Assertions.assertEquals("75.5 Seconds", secondConversion1);
+
+        String secondConversion2 = UtilTime.getTime2(SECOND * 43 + (double) SECOND /3, UtilTime.TimeUnit.SECONDS, 3);
+        Assertions.assertEquals("43.333 Seconds", secondConversion2);
+
+        String minuteConversion = UtilTime.getTime2(MINUTE * 4, UtilTime.TimeUnit.MINUTES, 1);
+        Assertions.assertEquals("4.0 Minutes", minuteConversion);
+
+        String hourConversion = UtilTime.getTime2(HOUR * 2 + (double) HOUR /4, UtilTime.TimeUnit.HOURS, 5);
+        Assertions.assertEquals("2.25 Hours", hourConversion);
+
+        String dayConversion = UtilTime.getTime2(DAY * 25, UtilTime.TimeUnit.DAYS, 0);
+        Assertions.assertEquals("25.0 Days", dayConversion);
+
+        String yearConversion = UtilTime.getTime2(YEAR * 2 + (double) YEAR /8, UtilTime.TimeUnit.YEARS, 5);
+        Assertions.assertEquals("2.125 Years", yearConversion);
+
+        String bestConversion1 = UtilTime.getTime2(MINUTE * 59, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals("59.0 Minutes", bestConversion1);
+
+        String bestConversion2 = UtilTime.getTime2(DAY, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals("1.0 Days", bestConversion2);
+
+        String bestConversion3 = UtilTime.getTime2(DAY * 354, UtilTime.TimeUnit.BEST, 1);
+        Assertions.assertEquals("354.0 Days", bestConversion3);
+    }
+}

--- a/core/src/test/java/me/mykindos/betterpvp/core/utilities/model/WeighedListTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/utilities/model/WeighedListTest.java
@@ -1,10 +1,10 @@
 package me.mykindos.betterpvp.core.utilities.model;
 
+import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -118,7 +118,7 @@ class WeighedListTest {
             System.out.println(element + ": " + (chance * 100));
         });
 
-        //test total categoryWieghts
+        //test total categoryWeights
         assertEquals(4800, weighedList.getTotalCategoryWeights());
         assertEquals(1, weighedList.getAbsoluteElementChances().values().stream().mapToDouble(Float::doubleValue).sum(), 0.0001);
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,7 +64,7 @@ dependencyResolutionManagement {
             // Library - Tests
             library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.11.0")
             library("reflections", "org.reflections:reflections:0.10.2")
-            library("mockbukkit", "com.github.seeseemelk:MockBukkit-v1.21:3.107.0")
+            library("mockbukkit", "com.github.seeseemelk:MockBukkit-v1.21:3.133.1")
 
             // Library - Paper
             library("paper-api", "io.papermc.paper", "paper-api").versionRef("paper")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,8 @@ dependencyResolutionManagement {
             version("jackson", "2.17.2")
             version("mineplex", "1.15.0")
             version("sidebar", "2.2.2")
+            version("mockbukkit", "4.45.0")
+            version("junit", "5.13.0-M2")
 
             // Library - Mineplex SDK
             library("mineplex", "com.mineplex.studio.sdk", "sdk").versionRef("mineplex")
@@ -62,9 +64,9 @@ dependencyResolutionManagement {
             plugin("kotlin", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
 
             // Library - Tests
-            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.11.0")
+            library("junit-jupiter", "org.junit.jupiter","junit-jupiter").versionRef("junit")
             library("reflections", "org.reflections:reflections:0.10.2")
-            library("mockbukkit", "com.github.seeseemelk:MockBukkit-v1.21:3.133.1")
+            library("mockbukkit", "org.mockbukkit.mockbukkit", "mockbukkit-v1.21").versionRef("mockbukkit")
 
             // Library - Paper
             library("paper-api", "io.papermc.paper", "paper-api").versionRef("paper")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,8 +62,9 @@ dependencyResolutionManagement {
             plugin("kotlin", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
 
             // Library - Tests
-            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.9.0")
+            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.11.0")
             library("reflections", "org.reflections:reflections:0.10.2")
+            library("mockbukkit", "com.github.seeseemelk:MockBukkit-v1.21:3.107.0")
 
             // Library - Paper
             library("paper-api", "io.papermc.paper", "paper-api").versionRef("paper")
@@ -123,7 +124,7 @@ dependencyResolutionManagement {
 
             // Bundled Libraries
             bundle("kotlin", listOf("kotlin-stdlib", "kotlin-reflect"))
-            bundle("test", listOf("junit-jupiter"))
+            bundle("test", listOf("junit-jupiter", "mockbukkit"))
             bundle("paper", listOf("paper-api"))
             bundle("utils",
                 listOf("commons-text",


### PR DESCRIPTION
I did this a while back, because I was bored. I ran into some issues using mockbukkit so set it aside. Picked it back up, fixed some things and got it working. Might as well put the work I did up.

Summary:
In test time, we need to exclude paperweight (see https://docs.mockbukkit.org/docs/en/user_guide/advanced/paperweight.html). This means we cannot test anything with NMS features.
We also cannot mock plugins (well, we might, but there are several issues that need to be resolved. MockBukkit proxy's the plugin class, so we cannot access getClass().getPackageName(). There are also problems with accessing resources (aka configs) and databases that need to be resolved).
This means that we can only test things that use the Bukkit static classes.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
