### PR TITLE
No speed and no smokebomb on flag pickup

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/roleeffects/AssassinListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/roleeffects/AssassinListener.java
@@ -2,9 +2,10 @@ package me.mykindos.betterpvp.champions.champions.roles.listeners.roleeffects;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
 import me.mykindos.betterpvp.champions.Champions;
-import me.mykindos.betterpvp.champions.champions.roles.RoleManager;
 import me.mykindos.betterpvp.champions.champions.roles.RoleEffect;
+import me.mykindos.betterpvp.champions.champions.roles.RoleManager;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.config.ExtendedYamlConfiguration;
@@ -21,11 +22,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
 
 @BPvPListener
 @Singleton
@@ -111,7 +108,7 @@ public class AssassinListener implements Listener, ConfigAccessor {
         for (Player player : Bukkit.getOnlinePlayers()) {
             roleManager.getObject(player.getUniqueId()).ifPresent(role -> {
                 if (role == Role.ASSASSIN) {
-                    player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, -1, 1));
+                    effectManager.addEffect(player, null, EffectTypes.SPEED, "Assassin", 2, -1, false, true);
                 }
             });
         }

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/listener/FlagHolderListener.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/listener/FlagHolderListener.java
@@ -1,9 +1,12 @@
 package me.mykindos.betterpvp.game.impl.ctf.listener;
 
 import com.google.inject.Inject;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.champions.champions.npc.KitSelectorUseEvent;
 import me.mykindos.betterpvp.core.combat.death.events.CustomDeathEvent;
 import me.mykindos.betterpvp.core.components.champions.events.PlayerUseSkillEvent;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
 import me.mykindos.betterpvp.game.framework.module.powerup.ParticipantPowerupEvent;
 import me.mykindos.betterpvp.game.guice.GameScoped;
 import me.mykindos.betterpvp.game.impl.ctf.controller.GameController;
@@ -16,6 +19,7 @@ import org.bukkit.event.Listener;
  * Event listener for flag holders
  */
 @GameScoped
+@CustomLog
 public class FlagHolderListener implements Listener {
 
     private final GameController gameController;
@@ -61,6 +65,16 @@ public class FlagHolderListener implements Listener {
                 flag.setReturnCountdown(flag.getReturnCountdown() - 1);
                 break;
             }
+        }
+    }
+
+    @EventHandler
+    public void onGainEffect(EffectReceiveEvent event) {
+        if (!(event.getEffect().getEffectType() == EffectTypes.SPEED)) return;
+        if (!(event.getTarget() instanceof Player player)) return;
+
+        if (isHoldingFlag(player)) {
+            event.cancel("Holding Flag");
         }
     }
     

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/Flag.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/Flag.java
@@ -80,6 +80,7 @@ public class Flag implements Lifecycled {
             }
         } else if (state == State.PICKED_UP) {
             currentLocation = holder.getLocation();
+            inventoryHandler.tick(holder);
         }
 
         // Effects

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.game.impl.ctf.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.framework.hat.HatProvider;
@@ -13,9 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class FlagPlayerHandler implements HatProvider, ItemProvider, Lifecycled {
     private final Flag flag;
@@ -43,7 +42,15 @@ public class FlagPlayerHandler implements HatProvider, ItemProvider, Lifecycled 
         hatController.broadcast(holder, true);
 
         // Effect
-        effectManager.addEffect(holder, EffectTypes.SLOWNESS, "Flag", 1, Long.MAX_VALUE);
+        effectManager.removeEffect(holder, EffectTypes.SPEED);
+        effectManager.removeEffect(holder, EffectTypes.VANISH, "Smoke Bomb");
+
+    }
+
+    public void tick(Player holder) {
+        if (!effectManager.hasEffect(holder, EffectTypes.SLOWNESS, "Flag")) {
+            effectManager.addEffect(holder, EffectTypes.SLOWNESS, "Flag", 1, Long.MAX_VALUE);
+        }
     }
     
     public void drop(Player holder) {


### PR DESCRIPTION
Prevent flag holders from gaining the speed effect, prevent flag holders from losing the speed effect (cleanse etc.).
Picking up the flag will remove smoke bomb's vanish

Fixes #1541
Fixes #1542

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
