### PR TITLE
Achievements

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/properties/ChampionsPropertyListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/properties/ChampionsPropertyListener.java
@@ -2,14 +2,13 @@ package me.mykindos.betterpvp.champions.properties;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Optional;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.events.ClientJoinEvent;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.Optional;
 
 
 @Singleton
@@ -25,7 +24,7 @@ public class ChampionsPropertyListener implements Listener {
 
     @EventHandler
     public void onPropertyUpdated(ChampionsPropertyUpdateEvent event) {
-        clientManager.saveGamerProperty(event.getGamer(), event.getProperty(), event.getValue());
+        clientManager.saveGamerProperty(event.getContainer(), event.getProperty(), event.getValue());
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/properties/ChampionsPropertyUpdateEvent.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/properties/ChampionsPropertyUpdateEvent.java
@@ -4,14 +4,11 @@ import lombok.Getter;
 import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
 
-
+//todo remove, does not look like it is being used
 @Getter
-public class ChampionsPropertyUpdateEvent extends PropertyUpdateEvent {
+public class ChampionsPropertyUpdateEvent extends PropertyUpdateEvent<Gamer> {
 
-    private final Gamer gamer;
-
-    public ChampionsPropertyUpdateEvent(Gamer gamer, String property, Object value) {
-        super(property, value);
-        this.gamer = gamer;
+    public ChampionsPropertyUpdateEvent(Gamer container, String property, Object value) {
+        super(container, property, value);
     }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/Clan.java
@@ -1,6 +1,13 @@
 package me.mykindos.betterpvp.clans.clans;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.Data;
 import me.mykindos.betterpvp.clans.clans.chat.AllianceChatChannel;
@@ -32,14 +39,6 @@ import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 @CustomLog
 @Data
 public class Clan extends PropertyContainer implements IClan, Invitable, IMapListener {
@@ -70,11 +69,11 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
     }
 
     public long getTimeCreated() {
-        return (long) this.getProperty(ClanProperty.TIME_CREATED).orElse(0L);
+        return this.getLongProperty(ClanProperty.TIME_CREATED);
     }
 
     public long getLastLogin() {
-        return (long) this.getProperty(ClanProperty.LAST_LOGIN).orElse(0L);
+        return this.getLongProperty(ClanProperty.LAST_LOGIN);
     }
 
     public int getEnergy() {
@@ -86,7 +85,7 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
     }
 
     public int getPoints() {
-        return (int) this.getProperty(ClanProperty.POINTS).orElse(0);
+        return this.getIntProperty(ClanProperty.POINTS);
     }
 
     /**
@@ -95,7 +94,7 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
      * @return The time the cooldown expires (epoch)
      */
     public long getNoDominanceCooldown() {
-        return (long) this.getProperty(ClanProperty.NO_DOMINANCE_COOLDOWN).orElse(0L);
+        return this.getLongProperty(ClanProperty.NO_DOMINANCE_COOLDOWN);
     }
 
     public boolean isNoDominanceCooldownActive() {
@@ -103,7 +102,7 @@ public class Clan extends PropertyContainer implements IClan, Invitable, IMapLis
     }
 
     public int getBalance() {
-        return (int) this.getProperty(ClanProperty.BALANCE).orElse(0);
+        return this.getIntProperty(ClanProperty.BALANCE);
     }
 
     public void setBalance(final int balance) {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/ClanPropertyUpdateEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/events/ClanPropertyUpdateEvent.java
@@ -5,13 +5,10 @@ import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
 
 @Getter
-public class ClanPropertyUpdateEvent extends PropertyUpdateEvent {
+public class ClanPropertyUpdateEvent extends PropertyUpdateEvent<Clan> {
 
-    private final Clan clan;
-
-    public ClanPropertyUpdateEvent(Clan clan, String property, Object value) {
-        super(property, value);
-        this.clan = clan;
+    public ClanPropertyUpdateEvent(Clan container, String property, Object value) {
+        super(container, property, value);
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanPropertyListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClanPropertyListener.java
@@ -20,7 +20,7 @@ public class ClanPropertyListener extends ClanListener{
 
     @EventHandler
     public void onSettingsUpdated(ClanPropertyUpdateEvent event) {
-        clanManager.getRepository().saveProperty(event.getClan(), event.getProperty(), event.getValue());
+        clanManager.getRepository().saveProperty(event.getContainer(), event.getProperty(), event.getValue());
     }
 
     @UpdateEvent(delay = 120_000)

--- a/core/src/main/java/me/mykindos/betterpvp/core/Core.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/Core.java
@@ -3,9 +3,12 @@ package me.mykindos.betterpvp.core;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import java.lang.reflect.Field;
+import java.util.Set;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
+import me.mykindos.betterpvp.core.client.achievements.AchievementManager;
 import me.mykindos.betterpvp.core.client.punishments.rules.RuleManager;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.combat.stats.impl.GlobalCombatStatsRepository;
@@ -39,9 +42,6 @@ import net.megavex.scoreboardlibrary.api.exception.NoPacketAdapterAvailableExcep
 import net.megavex.scoreboardlibrary.api.noop.NoopScoreboardLibrary;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
-
-import java.lang.reflect.Field;
-import java.util.Set;
 
 @CustomLog
 public class Core extends BPvPPlugin {
@@ -116,6 +116,9 @@ public class Core extends BPvPPlugin {
 
         var ruleManager = injector.getInstance(RuleManager.class);
         ruleManager.load(this);
+
+        var achievementManager = injector.getInstance(AchievementManager.class);
+        achievementManager.loadAchievements();
 
         updateEventExecutor.loadPlugin(this);
         updateEventExecutor.initialize();

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/Achievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/Achievement.java
@@ -1,0 +1,60 @@
+package me.mykindos.betterpvp.core.client.achievements;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.CustomLog;
+import lombok.Getter;
+import me.mykindos.betterpvp.core.properties.PropertyContainer;
+import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * todo
+ */
+@CustomLog
+public abstract class Achievement<T extends PropertyContainer, E extends PropertyUpdateEvent<T>> implements IAchievement<T, E>, Listener {
+
+    @Getter
+    private final String name;
+    @Getter
+    private final Set<String> watchedProperties = new HashSet<>();
+
+    public Achievement(String name, String... watchedProperties) {
+        this.name = name;
+        this.watchedProperties.addAll(Arrays.stream(watchedProperties).toList());
+    }
+
+    public Achievement(String name, Enum<?>... watchedProperties) {
+        this.name = name;
+        this.watchedProperties.addAll(Arrays.stream(watchedProperties)
+                .map(Enum::name)
+                .toList()
+        );
+    }
+
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @Override
+    public void onPropertyChangeListener(E event) {
+        log.info(event.toString()).submit();
+        final String changedProperty = event.getProperty();
+        final Object value = event.getValue();
+        final T container = event.getContainer();
+        if (!watchedProperties.contains(changedProperty)) return;
+
+        Map<String, Object> otherProperties = new HashMap<>();
+        watchedProperties.stream()
+                .filter(property -> !property.equals(changedProperty))
+                .forEach(property -> {
+                    otherProperties.put(property, container.getProperty(property).orElseThrow());
+                });
+
+        onChangeValue(container, changedProperty, value, otherProperties);
+
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/AchievementManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/AchievementManager.java
@@ -1,0 +1,39 @@
+package me.mykindos.betterpvp.core.client.achievements;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.framework.manager.Manager;
+import org.reflections.Reflections;
+
+@Singleton
+@CustomLog
+public class AchievementManager extends Manager<IAchievement> {
+
+    private final Core core;
+    @Inject
+    public AchievementManager(Core core) {
+        this.core = core;
+    }
+
+    //todo refactor to a loader
+    public void loadAchievements(){
+        Reflections reflections = new Reflections(getClass().getPackageName());
+        Set<Class<? extends IAchievement>> classes = reflections.getSubTypesOf(IAchievement.class);
+        for (var clazz : classes) {
+            if(clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) continue;
+            if(clazz.isAnnotationPresent(Deprecated.class)) continue;
+            IAchievement achievement = core.getInjector().getInstance(clazz);
+            core.getInjector().injectMembers(achievement);
+
+            addObject(achievement.getName(), achievement);
+
+        }
+
+        log.error("Loaded " + objects.size() + " achievements").submit();
+        core.saveConfig();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/IAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/IAchievement.java
@@ -1,0 +1,46 @@
+package me.mykindos.betterpvp.core.client.achievements;
+
+import java.util.Map;
+import me.mykindos.betterpvp.core.properties.PropertyContainer;
+import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
+import me.mykindos.betterpvp.core.utilities.model.description.Description;
+
+public interface IAchievement<T extends PropertyContainer, E extends PropertyUpdateEvent<T>> {
+
+    /**
+     * Listens for the event to call {@link IAchievement#onChangeValue(PropertyContainer, String, Object, Map)} if valid
+     * @param event
+     */
+    void onPropertyChangeListener(E event);
+
+    /**
+     * Called when a watched property is updated
+     * @param container the {@link PropertyContainer} being updated
+     * @param property the property that has changed
+     * @param value the value that was changed
+     * @param otherProperties the other watched properties for the container, excluding the changed property
+     */
+    void onChangeValue(T container, String property, Object value, Map<String, Object> otherProperties);
+
+    /**
+     * Gets the name of this achievement
+     * @return the name
+     */
+    String getName();
+
+
+    /**
+     * Gets the description of this achievement for the specified container
+     * For use in UI's
+     * @param container the {@link PropertyContainer}
+     * @return
+     */
+    Description getDescription(T container);
+
+    /**
+     * For the given {@link PropertyContainer}, calculate how complete this achievement is
+     * @param container the {@link PropertyContainer}
+     * @return between {@code 0.0f} (no progress) and {@code 1.0f} (completed)
+     */
+    float getPercentComplete(T container);
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/SingleSimpleAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/SingleSimpleAchievement.java
@@ -1,0 +1,34 @@
+package me.mykindos.betterpvp.core.client.achievements;
+
+import me.mykindos.betterpvp.core.properties.PropertyContainer;
+import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
+
+/**
+ * Tracks a single property when it is updated, completing at the goal
+ * @param <T>
+ * @param <E>
+ * @param <C>
+ */
+public abstract class SingleSimpleAchievement <T extends PropertyContainer, E extends PropertyUpdateEvent<T>, C extends Number> extends Achievement<T, E> {
+    protected final C goal;
+
+    public SingleSimpleAchievement(String name, C goal, Enum<?> watchedProperty) {
+        super(name, watchedProperty);
+        this.goal = goal;
+    }
+
+    public SingleSimpleAchievement(String name, C goal, String watchedProperty) {
+        super(name, watchedProperty);
+        this.goal = goal;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected C getProperty(T container) {
+        return (C) container.getProperty(getWatchedProperties().stream().findAny().orElseThrow()).orElseThrow();
+    }
+
+    @Override
+    public float getPercentComplete(T container) {
+        return getProperty(container).floatValue() / goal.floatValue();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/DeathAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/DeathAchievement.java
@@ -1,0 +1,39 @@
+package me.mykindos.betterpvp.core.client.achievements.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import me.mykindos.betterpvp.core.client.achievements.SingleSimpleAchievement;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.gamer.properties.GamerProperty;
+import me.mykindos.betterpvp.core.client.gamer.properties.GamerPropertyUpdateEvent;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.description.Description;
+import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
+import org.bukkit.Material;
+
+public abstract class DeathAchievement extends SingleSimpleAchievement<Gamer, GamerPropertyUpdateEvent, Integer> {
+    public DeathAchievement(String name, int goal) {
+        super(name, goal, GamerProperty.DEATHS);
+    }
+
+    @Override
+    public void onChangeValue(Gamer container, String property, Object value, Map<String, Object> otherProperties) {
+        //todo do better
+        int current = getProperty(container);
+        UtilMessage.message(Objects.requireNonNull(container.getPlayer()), UtilMessage.deserialize("Progress: <green>%s</green>/<yellow>%s</yellow> (<green>%s</green>%%)", current, goal, getPercentComplete(container) * 100));
+    }
+
+    @Override
+    public Description getDescription(Gamer container) {
+        int current = getProperty(container);
+        ItemView itemView = ItemView.builder()
+                .material(Material.ZOMBIE_SPAWN_EGG)
+                .displayName(UtilMessage.deserialize("<light_purple>Die <yellow>%s</yellow> Times", this.goal))
+                .lore(List.of(UtilMessage.deserialize("Progress: <green>%s</green>/<yellow>%s</yellow> (<green>%s</green>%)", current, goal, getPercentComplete(container) * 100)))
+                .build();
+        return Description.builder()
+                .icon(itemView)
+                .build();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/Died10TimesAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/Died10TimesAchievement.java
@@ -1,0 +1,14 @@
+package me.mykindos.betterpvp.core.client.achievements.test;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+
+@Singleton
+@BPvPListener
+public class Died10TimesAchievement extends DeathAchievement {
+    @Inject
+    public Died10TimesAchievement() {
+        super("Die 10 Times", 10);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/Kill10MobsAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/Kill10MobsAchievement.java
@@ -1,0 +1,14 @@
+package me.mykindos.betterpvp.core.client.achievements.test;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+
+@Singleton
+@BPvPListener
+public class Kill10MobsAchievement extends MobKillsAchievement {
+    @Inject
+    public Kill10MobsAchievement() {
+        super("Kill 10 Mobs", 10);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/MobKillsAchievement.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/test/MobKillsAchievement.java
@@ -1,0 +1,41 @@
+package me.mykindos.betterpvp.core.client.achievements.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import me.mykindos.betterpvp.core.client.achievements.SingleSimpleAchievement;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.gamer.properties.GamerProperty;
+import me.mykindos.betterpvp.core.client.gamer.properties.GamerPropertyUpdateEvent;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.description.Description;
+import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
+import org.bukkit.Material;
+
+public abstract class MobKillsAchievement extends SingleSimpleAchievement<Gamer, GamerPropertyUpdateEvent, Integer> {
+    //todo abstract common things to a simple achievement
+
+    public MobKillsAchievement(String name, int goal) {
+        super(name, goal, GamerProperty.MOB_KILLS);
+    }
+
+    @Override
+    public void onChangeValue(Gamer container, String property, Object value, Map<String, Object> otherProperties) {
+        //todo do better
+        int current = getProperty(container);
+        UtilMessage.message(Objects.requireNonNull(container.getPlayer()), UtilMessage.deserialize("Progress: <green>%s</green>/<yellow>%s</yellow> (<green>%s</green>%%)", current, goal, getPercentComplete(container) * 100));
+    }
+
+    @Override
+    public Description getDescription(Gamer container) {
+        int current = getProperty(container);
+        ItemView itemView = ItemView.builder()
+                .material(Material.ZOMBIE_SPAWN_EGG)
+                .displayName(UtilMessage.deserialize("<light_purple>Kill <yellow>%s</yellow> Mobs", this.goal))
+                .lore(List.of(UtilMessage.deserialize("Progress: <green>%s</green>/<yellow>%s</yellow> (<green>%s</green>%%)", current, goal, getPercentComplete(container) * 100)))
+                .build();
+        return Description.builder()
+                .icon(itemView)
+                .build();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/Gamer.java
@@ -1,5 +1,7 @@
 package me.mykindos.betterpvp.core.client.gamer;
 
+import java.util.Objects;
+import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,9 +32,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
-import java.util.UUID;
 
 /**
  * A gamer represents a clients seasonal data.
@@ -115,15 +114,7 @@ public class Gamer extends PropertyContainer implements Invitable, Unique, IMapL
     }
 
     public int getBalance() {
-        return (int) getProperty(GamerProperty.BALANCE).orElse(0);
-    }
-
-    public int getIntProperty(Enum<?> key) {
-        return (int) getProperty(key).orElse(0);
-    }
-
-    public long getLongProperty(Enum<?> key) {
-        return (long) getProperty(key).orElse(0L);
+        return getIntProperty(GamerProperty.BALANCE);
     }
 
     public void setSidebar(@Nullable Sidebar newSidebar) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/properties/GamerProperty.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/properties/GamerProperty.java
@@ -20,7 +20,19 @@ public enum GamerProperty {
     DAMAGE_DEALT,
     DAMAGE_TAKEN,
 
+    /**
+     * Represents the amount of times a gamer has died
+     * <p>Casting class {@link Integer}</p>
+     */
+    DEATHS,
+
     TIME_PLAYED,
     REMAINING_PVP_PROTECTION,
+
+    /**
+     * Incremented whenever a non player living entity is killed by a gamer
+     * <p>Casting class {@link Integer}</p>
+     */
+    MOB_KILLS
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/properties/GamerPropertyUpdateEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/properties/GamerPropertyUpdateEvent.java
@@ -5,12 +5,9 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
 
 @Getter
-public class GamerPropertyUpdateEvent extends PropertyUpdateEvent {
+public class GamerPropertyUpdateEvent extends PropertyUpdateEvent<Gamer> {
 
-    private final Gamer gamer;
-
-    public GamerPropertyUpdateEvent(Gamer gamer, String property, Object value) {
-        super(property, value);
-        this.gamer = gamer;
+    public GamerPropertyUpdateEvent(Gamer container, String property, Object value) {
+        super(container, property, value);
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/repository/GamerStatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/repository/GamerStatListener.java
@@ -6,13 +6,16 @@ import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.client.gamer.properties.GamerProperty;
 import me.mykindos.betterpvp.core.client.gamer.properties.GamerPropertyUpdateEvent;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.combat.death.events.CustomDeathEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 @BPvPListener
@@ -27,7 +30,7 @@ public class GamerStatListener implements Listener {
 
     @EventHandler
     public void onSettingsUpdated(GamerPropertyUpdateEvent event) {
-        clientManager.saveGamerProperty(event.getGamer(), event.getProperty(), event.getValue());
+        clientManager.saveGamerProperty(event.getContainer(), event.getProperty(), event.getValue());
     }
 
     @EventHandler (priority = EventPriority.MONITOR)
@@ -50,8 +53,31 @@ public class GamerStatListener implements Listener {
         final Client client = clientManager.search().online(player);
         final Gamer gamer = client.getGamer();
 
-        int blocksBroken = (int) (gamer.getProperty(GamerProperty.BLOCKS_BROKEN).orElse(0)) + 1;
+        int blocksBroken = (gamer.getIntProperty(GamerProperty.BLOCKS_BROKEN)) + 1;
         gamer.saveProperty(GamerProperty.BLOCKS_BROKEN, blocksBroken);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDeath(CustomDeathEvent event) {
+        if (!(event.getKilled() instanceof Player player)) return;
+        final Client client = clientManager.search().online(player);
+        final Gamer gamer = client.getGamer();
+        int deaths = gamer.getIntProperty(GamerProperty.DEATHS) + 1;
+        gamer.saveProperty(GamerProperty.DEATHS, deaths);
+    }
+
+    //todo remove
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMobKill(EntityDeathEvent event) {
+        final LivingEntity killed = event.getEntity();
+        if (killed instanceof Player) return;
+        if (killed.getLastDamageCause() == null ||
+                !(killed.getLastDamageCause().getDamageSource().getCausingEntity() instanceof Player player)) return;
+
+        final Client client = clientManager.search().online(player);
+        final Gamer gamer = client.getGamer();
+        int mobsKilled = gamer.getIntProperty(GamerProperty.MOB_KILLS) + 1;
+        gamer.saveProperty(GamerProperty.MOB_KILLS, mobsKilled);
     }
 
     @EventHandler (priority = EventPriority.HIGHEST)

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/properties/ClientPropertyUpdateEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/properties/ClientPropertyUpdateEvent.java
@@ -5,12 +5,9 @@ import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
 
 @Getter
-public class ClientPropertyUpdateEvent extends PropertyUpdateEvent {
+public class ClientPropertyUpdateEvent extends PropertyUpdateEvent<Client> {
 
-    private final Client client;
-
-    public ClientPropertyUpdateEvent(Client client, String property, Object object) {
-        super(property, object);
-        this.client = client;
+    public ClientPropertyUpdateEvent(Client container, String property, Object object) {
+        super(container, property, object);
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/repository/ClientListener.java
@@ -2,6 +2,12 @@ package me.mykindos.betterpvp.core.client.repository;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.Rank;
@@ -32,13 +38,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.ServerLoadEvent;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @BPvPListener
 @CustomLog
@@ -230,7 +229,7 @@ public class ClientListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onSettingsUpdated(ClientPropertyUpdateEvent event) {
-        this.clientManager.saveProperty(event.getClient(), event.getProperty(), event.getValue());
+        this.clientManager.saveProperty(event.getContainer(), event.getProperty(), event.getValue());
     }
 
     private void checkUnsetProperties(Client client) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/sidebar/SidebarController.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/sidebar/SidebarController.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.core.framework.sidebar;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Objects;
+import java.util.function.Function;
 import lombok.CustomLog;
 import lombok.Getter;
 import me.mykindos.betterpvp.core.Core;
@@ -20,9 +22,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
-import java.util.function.Function;
 
 @BPvPListener
 @Singleton
@@ -60,7 +59,7 @@ public class SidebarController implements Listener {
             return; // Skip if not the sidebar property
         }
 
-        final Client client = event.getClient();
+        final Client client = event.getContainer();
         final Gamer gamer = client.getGamer();
         final Sidebar sidebar = gamer.getSidebar();
         if (sidebar == null || !gamer.isOnline()) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/properties/PropertyContainer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/properties/PropertyContainer.java
@@ -1,9 +1,8 @@
 package me.mykindos.betterpvp.core.properties;
 
+import java.util.Optional;
 import lombok.Getter;
 import me.mykindos.betterpvp.core.framework.customtypes.MyConcurrentHashMap;
-
-import java.util.Optional;
 
 /**
  * Simple container for properties.
@@ -80,6 +79,14 @@ public abstract class PropertyContainer {
      */
     public void saveProperty(Enum<?> key, Object object) {
         saveProperty(key.name(), object);
+    }
+
+    public int getIntProperty(Enum<?> key) {
+        return (int) getProperty(key).orElse(0);
+    }
+
+    public long getLongProperty(Enum<?> key) {
+        return (long) getProperty(key).orElse(0L);
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/properties/PropertyUpdateEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/properties/PropertyUpdateEvent.java
@@ -8,8 +8,9 @@ import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class PropertyUpdateEvent extends CustomCancellableEvent {
+public class PropertyUpdateEvent<T extends PropertyContainer> extends CustomCancellableEvent {
 
+    private final T container;
     private final String property;
     private final Object value;
 

--- a/core/src/main/resources/core-migrations/global/client/V20250501_1__Achievements.sql
+++ b/core/src/main/resources/core-migrations/global/client/V20250501_1__Achievements.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO property_map VALUES ("MOB_KILLS", "int");
+INSERT IGNORE INTO property_map VALUES ("DEATHS", "int");

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/event/ProfessionPropertyUpdateEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/event/ProfessionPropertyUpdateEvent.java
@@ -1,19 +1,21 @@
 package me.mykindos.betterpvp.progression.event;
 
-import lombok.Getter;
-import me.mykindos.betterpvp.core.properties.PropertyUpdateEvent;
-
 import java.util.UUID;
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
 
 @Getter
-public class ProfessionPropertyUpdateEvent extends PropertyUpdateEvent {
+public class ProfessionPropertyUpdateEvent extends CustomCancellableEvent {
 
     private final UUID uuid;
     private final String profession;
+    private final String property;
+    private final Object value;
 
     public ProfessionPropertyUpdateEvent(UUID uuid, String profession, String property, Object value) {
-        super(property, value);
         this.uuid = uuid;
         this.profession = profession;
+        this.property = property;
+        this.value = value;
     }
 }


### PR DESCRIPTION
WIP
Achievements:
Tied to PropertyContainers, track achievements that they make based off of stats in their container.

Basic premise is that achievements are attatched to a specific property container (i.e. Gamer). When a gamer property is updated, the achievement checks to see if that property is tracked by an achievement. If so, it sends that data, along with the non-changed data, to the achievement itself, which will handle notifying the container (i.e. player), handling any rewards etc. (this might need to track the previous value as well, depending on incrementing and things like that)

Simple achievements, for things that can only go 1 direction (like increasing playtime, kills) only require that the metric is tracked in the specified container. If it could change (like whether a player is on lunar or not), another stat that is static needs to be created.

## TODO
- [ ] GUI display
- [x] Single Increasing Achievements
- [ ] Single decreasing Achievements
- [ ] Combined Achievements
- [ ] Correct notification/reward handling (i.e. not saying completed more than once)
- [ ] Loader
- [ ] Config
- [ ] Config support (load some/certain achievements from config, like dungeons)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
