### PR TITLE
Fix being unable to pickup energy from breaking blocks while in protection

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/components/clans/events/ClansDropEnergyEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/components/clans/events/ClansDropEnergyEvent.java
@@ -4,11 +4,16 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import me.mykindos.betterpvp.core.framework.events.CustomEvent;
 import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class ClansDropEnergyEvent extends CustomEvent {
 
+    /**
+     * The {@link LivingEntity} that caused this event (i.e. block breaker, killer)
+     */
+    private final LivingEntity livingEntity;
     private final Location location;
     private final int amount;
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
@@ -1,15 +1,6 @@
 package me.mykindos.betterpvp.core.effects;
 
 import com.google.inject.Singleton;
-import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
-import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
-import me.mykindos.betterpvp.core.framework.manager.Manager;
-import me.mykindos.betterpvp.core.utilities.UtilEffect;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.potion.PotionEffect;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -19,6 +10,15 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
+import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
+import me.mykindos.betterpvp.core.framework.manager.Manager;
+import me.mykindos.betterpvp.core.utilities.UtilEffect;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.potion.PotionEffect;
+import org.jetbrains.annotations.Nullable;
 
 @Singleton
 public class EffectManager extends Manager<List<Effect>> {
@@ -119,7 +119,7 @@ public class EffectManager extends Manager<List<Effect>> {
     }
 
 
-    public Optional<Effect> getEffect(LivingEntity target, EffectType type) {
+    public Optional<Effect> getEffect(@Nullable LivingEntity target, EffectType type) {
         if (target == null) {
             return Optional.empty();
         }
@@ -134,8 +134,8 @@ public class EffectManager extends Manager<List<Effect>> {
         }
     }
 
-    public Optional<Effect> getEffect(LivingEntity target, EffectType type, String name) {
-
+    public Optional<Effect> getEffect(@Nullable LivingEntity target, EffectType type, String name) {
+        if (target == null) return Optional.empty();
         Optional<List<Effect>> effectsOptional = getObject(target.getUniqueId().toString());
         if (effectsOptional.isPresent()) {
             List<Effect> effects = effectsOptional.get();
@@ -149,15 +149,16 @@ public class EffectManager extends Manager<List<Effect>> {
 
     }
 
-    public boolean hasEffect(LivingEntity target, EffectType type) {
+    public boolean hasEffect(@Nullable LivingEntity target, EffectType type) {
         return getEffect(target, type).isPresent();
     }
 
-    public boolean hasEffect(LivingEntity target, EffectType type, String name) {
+    public boolean hasEffect(@Nullable LivingEntity target, EffectType type, String name) {
         return getEffect(target, type, name).isPresent();
     }
 
-    public List<Effect> getEffects(LivingEntity target, Class<? extends EffectType> typeClass) {
+    public List<Effect> getEffects(@Nullable LivingEntity target, Class<? extends EffectType> typeClass) {
+        if (target == null) return List.of();
         Optional<List<Effect>> effectsOptional = getObject(target.getUniqueId().toString());
         if (effectsOptional.isPresent()) {
             List<Effect> effects = effectsOptional.get();

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
@@ -5,6 +5,12 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.Rank;
@@ -48,13 +54,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.WeakHashMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @BPvPListener
 @Singleton
@@ -282,7 +281,7 @@ public class FishingListener implements Listener {
         player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 5f, 0F);
 
         if(UtilMath.RANDOM.nextDouble() > 0.8) {
-            UtilServer.callEvent(new ClansDropEnergyEvent(player.getLocation(), 10));
+            UtilServer.callEvent(new ClansDropEnergyEvent(player, player.getLocation(), 10));
         }
 
         UtilServer.callEvent(new PlayerStopFishingEvent(player, caught, PlayerStopFishingEvent.FishingResult.CATCH));


### PR DESCRIPTION
Change ClansDropEnergyEvent to take a LivingEntity (i.e. killer/block breaker/fisher).
If that entity is a player and has protection, reserve the dropped item

Must also merge https://github.com/Mykindos/BetterPvP-Private/pull/54

Fixes #1554

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
