### PR TITLE
Prevent skills that only work on allies affect enemies and vice versa

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -134,7 +134,9 @@ public class UtilEntity {
 
         FetchNearbyEntityEvent<LivingEntity> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(source, location, livingEntities, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
-        fetchNearbyEntityEvent.getEntities().removeIf(pair -> !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
+        fetchNearbyEntityEvent.getEntities().removeIf(pair ->
+                !fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL) ||
+                !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
 
         return fetchNearbyEntityEvent.getEntities();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -134,9 +134,12 @@ public class UtilEntity {
 
         FetchNearbyEntityEvent<LivingEntity> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(source, location, livingEntities, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
-        fetchNearbyEntityEvent.getEntities().removeIf(pair ->
-                !fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL) ||
-                !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
+        fetchNearbyEntityEvent.getEntities().removeIf(pair -> {
+            if (fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL)) {
+                return false;
+            }
+            return !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue());
+        });
 
         return fetchNearbyEntityEvent.getEntities();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -1,6 +1,14 @@
 package me.mykindos.betterpvp.core.utilities;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import me.mykindos.betterpvp.core.framework.customtypes.CustomArmourStand;
@@ -26,15 +34,6 @@ import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UtilEntity {
@@ -135,6 +134,7 @@ public class UtilEntity {
 
         FetchNearbyEntityEvent<LivingEntity> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(source, location, livingEntities, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
+        fetchNearbyEntityEvent.getEntities().removeIf(pair -> !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
 
         return fetchNearbyEntityEvent.getEntities();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
@@ -6,6 +6,9 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.WrappedDataValue;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.CustomLog;
 import lombok.NoArgsConstructor;
@@ -25,10 +28,6 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @CustomLog
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -79,6 +78,7 @@ public class UtilPlayer {
 
         FetchNearbyEntityEvent<Player> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(player, location, players, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
+        fetchNearbyEntityEvent.getEntities().removeIf(pair -> !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
 
         return fetchNearbyEntityEvent.getEntities();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
@@ -78,10 +78,12 @@ public class UtilPlayer {
 
         FetchNearbyEntityEvent<Player> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(player, location, players, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
-        fetchNearbyEntityEvent.getEntities().removeIf(pair ->
-                !fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL) ||
-                !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
-
+        fetchNearbyEntityEvent.getEntities().removeIf(pair -> {
+            if (fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL)) {
+                return false;
+            }
+            return !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue());
+        });
         return fetchNearbyEntityEvent.getEntities();
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilPlayer.java
@@ -78,7 +78,9 @@ public class UtilPlayer {
 
         FetchNearbyEntityEvent<Player> fetchNearbyEntityEvent = new FetchNearbyEntityEvent<>(player, location, players, entityProperty);
         UtilServer.callEvent(fetchNearbyEntityEvent);
-        fetchNearbyEntityEvent.getEntities().removeIf(pair -> !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
+        fetchNearbyEntityEvent.getEntities().removeIf(pair ->
+                !fetchNearbyEntityEvent.getEntityProperty().equals(EntityProperty.ALL) ||
+                !fetchNearbyEntityEvent.getEntityProperty().equals(pair.getValue()));
 
         return fetchNearbyEntityEvent.getEntities();
     }

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/listener/team/TeamDamageListener.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/listener/team/TeamDamageListener.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.game.framework.listener.team;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.function.Function;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.core.combat.death.events.CustomDeathMessageEvent;
 import me.mykindos.betterpvp.core.combat.events.EntityCanHurtEntityEvent;
 import me.mykindos.betterpvp.core.combat.events.PreDamageEvent;
@@ -21,10 +23,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import java.util.function.Function;
-
 @BPvPListener
 @Singleton
+@CustomLog
 public class TeamDamageListener implements Listener {
 
     private final ServerController serverController;
@@ -87,6 +88,7 @@ public class TeamDamageListener implements Listener {
     // Remove dead players from nearby entity fetches, like AoE skills
     @EventHandler(priority = EventPriority.LOWEST)
     public void onFetchNearby(FetchNearbyEntityEvent<?> event) {
+
         if (!(event.getSource() instanceof Player player)) {
             return;
         }
@@ -102,6 +104,8 @@ public class TeamDamageListener implements Listener {
 
             if (inSameTeam(game, player, other)) {
                 pair.setValue(EntityProperty.FRIENDLY);
+            } else {
+                pair.setValue(EntityProperty.ENEMY);
             }
         });
     }


### PR DESCRIPTION
FetchNearbyEntityEvent was not being handled correctly by TeamDamageListener, it only set if friendly, it also needs to set if enemy.

Functions that used FetchNearbyEntityEvent were not checking if the entities being fetched actually matched the desired property.

Fixes #1571

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
