### PR TITLE
Fix resilience removing flag slowness

### DIFF
--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
@@ -48,7 +48,7 @@ public class FlagPlayerHandler implements HatProvider, ItemProvider, Lifecycled 
     }
 
     public void tick(Player holder) {
-        effectManager.addEffect(holder, holder,EffectTypes.SLOWNESS, "Flag", 1, 600 * 1000);
+        effectManager.addEffect(holder, holder,EffectTypes.SLOWNESS, "Flag", 1, 100, true);
     }
     
     public void drop(Player holder) {

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagPlayerHandler.java
@@ -48,9 +48,7 @@ public class FlagPlayerHandler implements HatProvider, ItemProvider, Lifecycled 
     }
 
     public void tick(Player holder) {
-        if (!effectManager.hasEffect(holder, EffectTypes.SLOWNESS, "Flag")) {
-            effectManager.addEffect(holder, EffectTypes.SLOWNESS, "Flag", 1, Long.MAX_VALUE);
-        }
+        effectManager.addEffect(holder, holder,EffectTypes.SLOWNESS, "Flag", 1, 600 * 1000);
     }
     
     public void drop(Player holder) {


### PR DESCRIPTION
An interaction between Long.MAX_VALUE and resilience was causing flag slow to not effect those players

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
