### PR TITLE
Only apply the highest amplifier vanilla effect

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
@@ -1,16 +1,6 @@
 package me.mykindos.betterpvp.core.effects;
 
 import com.google.inject.Singleton;
-import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
-import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
-import me.mykindos.betterpvp.core.framework.manager.Manager;
-import me.mykindos.betterpvp.core.utilities.UtilEffect;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.potion.PotionEffect;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -21,6 +11,15 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
+import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
+import me.mykindos.betterpvp.core.framework.manager.Manager;
+import me.mykindos.betterpvp.core.utilities.UtilEffect;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.potion.PotionEffect;
+import org.jetbrains.annotations.Nullable;
 
 @Singleton
 public class EffectManager extends Manager<ConcurrentHashMap<EffectType, List<Effect>>> {
@@ -304,6 +303,32 @@ public class EffectManager extends Manager<ConcurrentHashMap<EffectType, List<Ef
         }
 
         return 0L;
+    }
+
+    /**
+     * Gets the highest {@link Effect#getAmplifier()} currently active for a given {@link EffectType}
+     * @param target the {@link LivingEntity} to check
+     * @param type the {@link EffectType} to search for
+     * @return the highest {@link Effect#getAmplifier()} or {@code 0} if the target does not have this effect
+     */
+    public int getAmplifier(LivingEntity target, EffectType type) {
+        if (target == null) {
+            return 0;
+        }
+        Optional<ConcurrentHashMap<EffectType, List<Effect>>> effectsOptional = getObject(target.getUniqueId().toString());
+        if (effectsOptional.isPresent()) {
+            ConcurrentHashMap<EffectType, List<Effect>> effects = effectsOptional.get();
+            List<Effect> effectList = effects.get(type);
+            if (effectList != null) {
+                return effectList.stream().filter(effect -> effect.getUuid().equalsIgnoreCase(target.getUniqueId().toString())
+                                && effect.getEffectType() == type)
+                        .max(Comparator.comparingInt(Effect::getAmplifier))
+                        .map(Effect::getAmplifier).orElse(0);
+
+            }
+        }
+
+        return 0;
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/VanillaEffectType.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/VanillaEffectType.java
@@ -19,7 +19,9 @@ public abstract class VanillaEffectType extends EffectType {
     }
 
     public void checkActive(LivingEntity livingEntity, Effect effect) {
-        UtilEffect.applyCraftEffect(livingEntity, new PotionEffect(getVanillaPotionType(), effect.getRemainingVanillaDuration(), effect.getAmplifier() - 1));
+        if (!UtilEffect.hasPotionEffect(livingEntity, getVanillaPotionType(), effect.getRemainingVanillaDuration(), effect.getAmplifier() - 1)) {
+            UtilEffect.applyCraftEffect(livingEntity, new PotionEffect(getVanillaPotionType(), effect.getRemainingVanillaDuration(), effect.getAmplifier() - 1));
+        }
     }
 
     public abstract PotionEffectType getVanillaPotionType();

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEffect.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.utilities;
 
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
@@ -8,8 +9,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.stream.Stream;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UtilEffect {
@@ -24,9 +23,27 @@ public class UtilEffect {
         craftLivingEntity.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect), craftLivingEntity.getHandle(), EntityPotionEffectEvent.Cause.PLUGIN, false);
     }
 
-    public static boolean hasPotionEffect(LivingEntity ent, PotionEffectType type, int amplifier) {
-        return ent.getActivePotionEffects().stream().anyMatch(potionEffect -> potionEffect.getType() == type
-                && potionEffect.getAmplifier() >= amplifier);
+    /**
+     * Check to see if a {@link LivingEntity} has the specified {@link PotionEffectType} with the correct {@link PotionEffect#getAmplifier()} and {@link PotionEffect#getDuration()}
+     * @param ent the target {@link LivingEntity}
+     * @param type the {@link PotionEffectType}
+     * @param duration the {@link PotionEffect#getDuration()}
+     * @param amplifier the {@link PotionEffect#getAmplifier()}
+     * @return {@code true} if the target {@link LivingEntity} has a {@link PotionEffect} with the following:
+     * <p>{@link PotionEffect#getAmplifier()} {@code >} the supplied {@code amplifier}</p>
+     * <p>{@link PotionEffect#getAmplifier()} {@code =} the supplied {@code amplifier} and {@link PotionEffect#getDuration()} {@code >=} the supplied {@code duration}</p>
+     * {@code false} otherwise
+     */
+    public static boolean hasPotionEffect(LivingEntity ent, PotionEffectType type, int duration, int amplifier) {
+        //return true if the living entity already has an effect with a higher amplifier
+        if (ent.getActivePotionEffects().stream().anyMatch(potionEffect -> potionEffect.getType() == type
+                && potionEffect.getAmplifier() > amplifier)) return true;
+        //else, return true if the living entity if there exists a potion effect with an equal or greater than length of the same amplifier
+        return ent.getActivePotionEffects().stream()
+                .anyMatch(potionEffect -> potionEffect.getType() == type &&
+                                potionEffect.getAmplifier() == amplifier &&
+                                (potionEffect.getDuration() >= duration || potionEffect.getDuration() == -1));
+
     }
 
 }


### PR DESCRIPTION
Only apply the highest amplifier -> highest duration vanilla effect. This fixes an issue where adrenaline and stampede would flicker between level 2 and 3. In general, now only 1 vanilla effect is applied on a player at a time.


Fixes #1594

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
