### PR TITLE
Mage Buffs & Fixes

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -128,10 +128,6 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         center.getWorld().playSound(center, Sound.BLOCK_GLASS_BREAK, 1f, 0.8f);
 
         for (Location loc : UtilMath.sphere(center, sphereSize, true)) {
-            if (loc.getBlockX() == center.getBlockX() && loc.getBlockZ() == center.getBlockZ()) {
-                continue;
-            }
-
             if (UtilBlock.isRedstone(loc.getBlock())) continue;
             if (loc.getBlock().getType() == Material.AIR || UtilBlock.airFoliage(loc.getBlock())) {
                 int level = getLevel((Player) throwableItem.getThrower());

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/HolyLight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/HolyLight.java
@@ -26,12 +26,10 @@ import org.bukkit.entity.Player;
 public class HolyLight extends Skill implements PassiveSkill, HealthSkill, TeamSkill, DefensiveSkill, BuffSkill {
 
     public double baseRadius;
-
     public double radiusIncreasePerLevel;
+    public int allyRegenerationStrength;
     public int regenerationStrength;
-
     public double baseDuration;
-
     public double durationIncreasePerLevel;
 
     @Inject
@@ -49,8 +47,9 @@ public class HolyLight extends Skill implements PassiveSkill, HealthSkill, TeamS
 
         return new String[]{
                 "Create an aura that gives",
-                "yourself and all allies within",
-                getValueString(this::getRadius, level) + " blocks <effect>Regeneration " + UtilFormat.getRomanNumeral(regenerationStrength) + "</effect>"
+                "yourself <effect>Regeneration " + UtilFormat.getRomanNumeral(regenerationStrength) + "</effect>",
+                "and allies within " + getValueString(this::getRadius, level) + " blocks",
+                "<effect>Regeneration " + UtilFormat.getRomanNumeral(allyRegenerationStrength) + "</effect>.",
         };
     }
 
@@ -75,7 +74,7 @@ public class HolyLight extends Skill implements PassiveSkill, HealthSkill, TeamS
     private void activate(Player player, int level) {
         championsManager.getEffects().addEffect(player, EffectTypes.REGENERATION, getName(), regenerationStrength, (long) getDuration(level) * 1000, true);
         for (var target : UtilPlayer.getNearbyPlayers(player, player.getLocation(), getRadius(level), EntityProperty.FRIENDLY)) {
-            championsManager.getEffects().addEffect(target.getKey(), player, EffectTypes.REGENERATION, getName(), regenerationStrength, (long) getDuration(level) * 1000, true);
+            championsManager.getEffects().addEffect(target.getKey(), player, EffectTypes.REGENERATION, getName(), allyRegenerationStrength, (long) getDuration(level) * 1000, true);
         }
     }
 
@@ -94,10 +93,9 @@ public class HolyLight extends Skill implements PassiveSkill, HealthSkill, TeamS
     public void loadSkillConfig() {
         baseRadius = getConfig("baseRadius", 8.0, Double.class);
         radiusIncreasePerLevel = getConfig("radiusIncreasePerLevel", 1.0, Double.class);
-
         baseDuration = getConfig("baseDuration", 7.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 0.0, Double.class);
-
         regenerationStrength = getConfig("regenerationStrength", 1, Integer.class);
+        allyRegenerationStrength = getConfig("allyRegenerationStrength", 2, Integer.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/passives/Immolate.java
@@ -42,7 +42,6 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
     private double fireTrailDurationIncreasePerLevel;
     private int speedStrength;
     private int strengthLevel;
-    private int vulnerabilityStrength;
 
     @Inject
     public Immolate(Champions champions, ChampionsManager championsManager) {
@@ -61,8 +60,7 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
                 "Drop your Sword / Axe to toggle",
                 "",
                 "Ignite yourself in flaming fury, gaining",
-                "<effect>Speed " + UtilFormat.getRomanNumeral(speedStrength) + "</effect>, <effect>Strength "
-                        + UtilFormat.getRomanNumeral(strengthLevel) + "</effect>, and <effect>Vulnerability " + UtilFormat.getRomanNumeral(vulnerabilityStrength) + "</effect>",
+                "<effect>Speed " + UtilFormat.getRomanNumeral(speedStrength) + "</effect> and <effect>Strength " + UtilFormat.getRomanNumeral(strengthLevel) + "</effect>.",
                 "",
                 "You leave a trail of fire, which",
                 "ignites enemies for " + getValueString(this::getFireTickDuration, level) + " seconds",
@@ -72,9 +70,7 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
                 "",
                 "While active, you are also immune to fire damage",
                 "",
-                EffectTypes.STRENGTH.getDescription(strengthLevel),
-                EffectTypes.VULNERABILITY.getDescription(vulnerabilityStrength)
-
+                EffectTypes.STRENGTH.getDescription(strengthLevel)
         };
     }
 
@@ -162,7 +158,6 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
         } else if (championsManager.getEffects().hasEffect(player, EffectTypes.SILENCE) && !canUseWhileSilenced()) {
             return false;
         } else {
-            championsManager.getEffects().addEffect(player, EffectTypes.VULNERABILITY, getName(), vulnerabilityStrength, 1250, true);
             championsManager.getEffects().addEffect(player, EffectTypes.SPEED, getName(), speedStrength, 1250, true);
             championsManager.getEffects().addEffect(player, EffectTypes.FIRE_RESISTANCE, getName(), 1, 1250, true);
             championsManager.getEffects().addEffect(player, EffectTypes.STRENGTH, getName(), strengthLevel, 1250, true);
@@ -208,6 +203,5 @@ public class Immolate extends ActiveToggleSkill implements EnergySkill, Throwabl
         fireTrailDurationIncreasePerLevel = getConfig("fireTrailDurationIncreasePerLevel", 0.0, Double.class);
         speedStrength = getConfig("speedStrength", 1, Integer.class);
         strengthLevel = getConfig("strengthLevel", 1, Integer.class);
-        vulnerabilityStrength = getConfig("vulnerabilityStrength", 2, Integer.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/legendaries/AlligatorsTooth.java
@@ -219,7 +219,7 @@ public class AlligatorsTooth extends ChannelWeapon implements InteractWeapon, Le
 
             // Effects
             final LivingEntity hitEntity = hitEntityOpt.get();
-            this.effectManager.addEffect(hitEntity, player, EffectTypes.PIN, HURL_ABILITY, getStrikePinAmplifier(), (long) (getStrikeEffectDuration() * 1000));
+//            this.effectManager.addEffect(hitEntity, player, EffectTypes.PIN, HURL_ABILITY, getStrikePinAmplifier(), (long) (getStrikeEffectDuration() * 1000));
             this.effectManager.addEffect(hitEntity, player, EffectTypes.BLEED, HURL_ABILITY, 1, (long) (getStrikeEffectDuration() * 1000));
             UtilMessage.simpleMessage(player, "Gator Strike", "You hit <alt2>%s</alt2> with <alt>%s</alt>", hitEntity.getName(), HURL_ABILITY);
             UtilMessage.simpleMessage(hitEntity, "Gator Strike", "<alt2>%s</alt2> hit you with <alt>%s</alt>.", player.getName(), HURL_ABILITY);

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -397,7 +397,7 @@ skills:
     iceprison:
       enabled: true
       maxlevel: 5
-      cooldown: 25.0
+      cooldown: 26.0
       sphereSize: 4
       speed: 1.5
       cooldownDecreasePerLevel: 2.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -486,14 +486,12 @@ skills:
     void:
       enabled: true
       maxlevel: 3
-      energy: 28
-      baseDamageReduction: 2.0
+      energy: 24
+      baseDamageReduction: 1.5
       damageReductionIncreasePerLevel: 0.5
-      baseEnergyReduction: 2.5
-      energyReductionDecreasePerLevel: 0.5
+      baseEnergyReduction: 3.5
+      energyReductionDecreasePerLevel: 0.2
       slownessStrength: 3
-      damageReduction: 5
-      energyReduction: 20
       energyDecreasePerLevel: 2.0
       energyStartCost: 10.0
       energyStartCostDecreasePerLevel: 0.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -360,11 +360,11 @@ skills:
       damage: 8.0
       slowDuration: 1.5
       cooldownDecreasePerLevel: 1.0
-      baseDamage: 8.0
-      damageIncreasePerLevel: 0.0
-      baseSlowDuration: 1.5
+      baseDamage: 6.0
+      damageIncreasePerLevel: 0.5
+      baseSlowDuration: 3.0
       slowDurationIncreasePerLevel: 0.0
-      slowStrength: 3
+      slowStrength: 2
     inferno:
       enabled: true
       maxlevel: 3

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -462,16 +462,20 @@ skills:
     blizzard:
       enabled: true
       maxlevel: 5
-      energy: 25
+      energy: 40
       baseSlowDuration: 2.0
       slowDurationIncreasePerLevel: 0.0
-      slowStrength: 3
+      slowStrength: 1
       slowDuration: 2.0
-      energyDecreasePerLevel: 1.0
-      pushForwardStrength: 0.3
-      pushUpwardStrength: 0.15
+      energyDecreasePerLevel: 0.5
+      pushForwardStrength: 0.5
       pushForwardIncreasePerLevel: 0.0
+      pushUpwardStrength: 0.35
       pushUpwardIncreasePerLevel: 0.0
+      pushbackVerticalStrength: 0.3
+      pushbackVerticalIncreasePerLevel: 0.0
+      pushbackHorizontalStrength: 0.2
+      pushbackHorizontalIncreasePerLevel: 0.0
     glacialblade:
       enabled: true
       maxlevel: 3

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -429,16 +429,15 @@ skills:
     immolate:
       enabled: true
       maxlevel: 3
-      energy: 36
+      energy: 24
       baseFireTickDuration: 4.0
       fireTickDurationIncreasePerLevel: 0.0
       baseFireTrailDuration: 2.0
       fireTrailDurationIncreasePerLevel: 0.0
       speedStrength: 1
       strengthLevel: 1
-      vulnerabilityStrength: 2
       energyDecreasePerLevel: 4.0
-      energyStartCost: 15.0
+      energyStartCost: 10.0
       energyStartCostDecreasePerLevel: 0.0
     magmablade:
       enabled: true
@@ -523,11 +522,11 @@ skills:
     holylight:
       enabled: true
       maxlevel: 3
-      baseRadius: 8.0
-      radiusIncreasePerLevel: 1.0
-      baseDuration: 7.0
-      durationIncreasePerLevel: 0.0
-      regenerationStrength: 1
+      baseRadius: 6.0
+      radiusIncreasePerLevel: 0.8
+      baseDuration: 3.0
+      durationIncreasePerLevel: 0.5
+      regenerationStrength: 2
     polymorph:
       enabled: false
       maxlevel: 3

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -429,7 +429,7 @@ skills:
     immolate:
       enabled: true
       maxlevel: 3
-      energy: 24
+      energy: 30
       baseFireTickDuration: 4.0
       fireTickDurationIncreasePerLevel: 0.0
       baseFireTrailDuration: 2.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -619,7 +619,7 @@ skills:
       maxlevel: 5
       cooldown: 20.0
       cooldownDecreasePerLevel: 1.0
-      baseBleedSeconds: 4.0
+      baseBleedSeconds: 2.0
       bleedSecondsPerLevel: 0.5
       projectileSpeed: 40.0
       pullStrength: 2.5

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -494,7 +494,7 @@ skills:
       energyStartCost: 10.0
       energyStartCostDecreasePerLevel: 0.0
     fissure:
-      enabled: true
+      enabled: false
       maxLevel: 5
       cooldown: 12.0
       cooldownDecreasePerLevel: 1.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -559,7 +559,7 @@ skills:
       poisonDurationIncreasePerLevel: 1.0
       poisonLevel: 2
       radius: 8.0
-      speed: 2.0
+      speed: 40.0
       radiusIncreasePerLevel: 0.0
       hitboxSize: 0.7
       expirySeconds: 2.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -526,7 +526,8 @@ skills:
       radiusIncreasePerLevel: 0.8
       baseDuration: 3.0
       durationIncreasePerLevel: 0.5
-      regenerationStrength: 2
+      regenerationStrength: 1
+      allyRegenerationStrength: 2
     polymorph:
       enabled: false
       maxlevel: 3


### PR DESCRIPTION
## Describe your changes
> # Champions Release 2025-05-08
> 
> ## Combat
> - Remove Pin effect from Gator Strike (Alligator's Tooth)
> 
> ### Brute
> - Skullsplitter base bleed seconds 4 → 2 Seconds
> 
> ### Mage
> - Fix Pestilence travel speed
> - Remove Ice Prison center dome gap
> - Increase Ice Prison cooldown from 25 → 26 seconds
> - Disable Fissure
> - Rework Blizzard to have pushback and more horizontal velocity
> - Rework Rupture to use display entities and fix its trajectory
> - Reduce Rupture slowness strength 3 → 1
> - Increase Rupture slowness duration 1.5 → 3.0 Seconds
> - Decrease Rupture base damage 8.0 → 6.0 HP
> - Increase Rupture damage per level 0 → 0.5 HP
> - Decrease Void base energy usage 28 → 24 energy per tick
> - Decrease Void damage reduction 2.0 → 1.5 HP
> - Increase Void energy reduction on hit 2.5 → 3.5
> - Decrease Void energy reduction per level 0.5 → 0.2
> - Remove Immolate vulnerability
> - Reduce Immolate energy usage per tick 36 → 30 energy per tick
> - Reduce Holy Light base radius 8 → 6 blocks  
> - Reduce Holy Light radius increase per level 1.0 → 0.8 blocks
> - Reduce Holy Light regeneration duration 7.0 → 3.0 seconds
> - Increase Holy Light regeneration duration increase per level 0 → 0.5  seconds
> - Holy Light now gives regeneration 2 to teammates in radius. Still only grants regeneration 1 to caster.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
