### PR TITLE
Add keepSameTeam Attribute, which prevents players from being assigned to a different team

### DIFF
--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/configuration/TeamGameConfiguration.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/configuration/TeamGameConfiguration.java
@@ -14,6 +14,7 @@ import me.mykindos.betterpvp.game.framework.model.attribute.team.AllowOversizedT
 import me.mykindos.betterpvp.game.framework.model.attribute.team.AutoBalanceOnDeathAttribute;
 import me.mykindos.betterpvp.game.framework.model.attribute.team.DurationBeforeAutoBalanceAttribute;
 import me.mykindos.betterpvp.game.framework.model.attribute.team.ForceBalanceAttribute;
+import me.mykindos.betterpvp.game.framework.model.attribute.team.KeepSameTeamAttribute;
 import me.mykindos.betterpvp.game.framework.model.attribute.team.MaxImbalanceAttribute;
 import me.mykindos.betterpvp.game.framework.model.team.GenericTeamBalancerProvider;
 import me.mykindos.betterpvp.game.framework.model.team.TeamBalancerProvider;
@@ -37,6 +38,7 @@ public class TeamGameConfiguration extends GenericGameConfiguration {
     @Getter(AccessLevel.NONE) @Builder.Default Boolean autoBalanceOnDeath = null;
     @Getter(AccessLevel.NONE) @Builder.Default Boolean forceBalance = null;
     @Getter(AccessLevel.NONE) @Builder.Default Boolean allowOversizedTeams = null;
+    @Getter(AccessLevel.NONE) @Builder.Default Boolean keepSameTeams = null;
 
 
     private transient MaxImbalanceAttribute maxImbalanceAttribute;
@@ -44,6 +46,7 @@ public class TeamGameConfiguration extends GenericGameConfiguration {
     private transient AutoBalanceOnDeathAttribute autoBalanceOnDeathAttribute;
     private transient ForceBalanceAttribute forceBalanceAttribute;
     private transient AllowOversizedTeamsAttribute allowOversizedTeamsAttribute;
+    private transient KeepSameTeamAttribute keepSameTeamAttribute;
 
 
     @Inject
@@ -53,6 +56,7 @@ public class TeamGameConfiguration extends GenericGameConfiguration {
             AutoBalanceOnDeathAttribute autoBalanceOnDeathAttribute,
             ForceBalanceAttribute forceBalanceAttribute,
             AllowOversizedTeamsAttribute allowOversizedTeamsAttribute,
+            KeepSameTeamAttribute keepSameTeamAttribute,
             GameAttributeManager gameAttributeManager
     ) {
         this.maxImbalanceAttribute = maxImbalanceAttribute;
@@ -60,12 +64,14 @@ public class TeamGameConfiguration extends GenericGameConfiguration {
         this.autoBalanceOnDeathAttribute = autoBalanceOnDeathAttribute;
         this.forceBalanceAttribute = forceBalanceAttribute;
         this.allowOversizedTeamsAttribute = allowOversizedTeamsAttribute;
+        this.keepSameTeamAttribute = keepSameTeamAttribute;
 
         gameAttributeManager.registerAttribute(maxImbalanceAttribute);
         gameAttributeManager.registerAttribute(durationBeforeAutoBalanceAttribute);
         gameAttributeManager.registerAttribute(autoBalanceOnDeathAttribute);
         gameAttributeManager.registerAttribute(forceBalanceAttribute);
         gameAttributeManager.registerAttribute(allowOversizedTeamsAttribute);
+        gameAttributeManager.registerAttribute(keepSameTeamAttribute);
 
         if (maxImbalance != null) {
             maxImbalanceAttribute.setValue(maxImbalance);
@@ -85,6 +91,9 @@ public class TeamGameConfiguration extends GenericGameConfiguration {
 
         if (allowOversizedTeams != null) {
             allowOversizedTeamsAttribute.setValue(allowOversizedTeams);
+        }
+        if (keepSameTeams != null) {
+            keepSameTeamAttribute.setValue(keepSameTeams);
         }
     }
 

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/AllowOversizedTeamsAttribute.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/AllowOversizedTeamsAttribute.java
@@ -16,7 +16,7 @@ public class AllowOversizedTeamsAttribute extends BoundAttribute<Boolean> {
 
     @Inject
     public AllowOversizedTeamsAttribute() {
-        super("game.allow-oversized-teams", true);
+        super("game.team.allow-oversized-teams", true);
     }
 
     @Override

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/AutoBalanceOnDeathAttribute.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/AutoBalanceOnDeathAttribute.java
@@ -16,7 +16,7 @@ public class AutoBalanceOnDeathAttribute extends BoundAttribute<Boolean> {
 
     @Inject
     public AutoBalanceOnDeathAttribute() {
-        super("game.balance-on-death", false);
+        super("game.team.balance-on-death", false);
     }
 
     @Override

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/DurationBeforeAutoBalanceAttribute.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/DurationBeforeAutoBalanceAttribute.java
@@ -15,7 +15,7 @@ public class DurationBeforeAutoBalanceAttribute extends BoundAttribute<Duration>
 
         @Inject
         public DurationBeforeAutoBalanceAttribute() {
-            super("game.auto-balance-duration", Duration.ofSeconds(10));
+            super("game.team.auto-balance-duration", Duration.ofSeconds(10));
         }
 
         @Override

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/KeepSameTeamAttribute.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/KeepSameTeamAttribute.java
@@ -8,15 +8,15 @@ import me.mykindos.betterpvp.game.guice.GameScoped;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+
 /**
- * Attribute for forcing a player from one team to move to another team if the game is unbalanced
+ * When balancing teams mid game, whether or not to keep players on their initial team
  */
 @GameScoped
-public class ForceBalanceAttribute extends BoundAttribute<Boolean> {
-
+public class KeepSameTeamAttribute extends BoundAttribute<Boolean> {
     @Inject
-    public ForceBalanceAttribute() {
-        super("game.team.force-balance", true);
+    public KeepSameTeamAttribute() {
+        super("game.team.keep-same-team", true);
     }
 
     @Override

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/MaxImbalanceAttribute.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/attribute/team/MaxImbalanceAttribute.java
@@ -14,7 +14,7 @@ public class MaxImbalanceAttribute extends BoundAttribute<Integer> {
 
     @Inject
     public MaxImbalanceAttribute() {
-        super("game.max-imbalance", 1);
+        super("game.team.max-imbalance", 1);
     }
 
     @Override

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/GenericTeamBalancerProvider.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/GenericTeamBalancerProvider.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.game.GamePlugin;
@@ -19,19 +20,28 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
-
+@CustomLog
 public class GenericTeamBalancerProvider implements TeamBalancerProvider {
 
     /**
      * Balances teams by moving players between teams to ensure they are evenly distributed
      * @param teamGame The team game to balance
      */
-    public void balanceTeams(TeamGame<?> teamGame) {
-        final PlayerController playerController = JavaPlugin.getPlugin(GamePlugin.class).getInjector().getInstance(PlayerController.class);
-        boolean allowLateJoins = teamGame.getConfiguration().getAllowLateJoinsAttribute().getValue();
-        boolean forceBalance = teamGame.getConfiguration().getForceBalanceAttribute().getValue();
+    @Override
 
+    public void balanceTeams(TeamGame<?> teamGame, boolean firstBalance) {
+
+        final PlayerController playerController = JavaPlugin.getPlugin(GamePlugin.class).getInjector().getInstance(PlayerController.class);
+        final boolean allowLateJoins = teamGame.getConfiguration().getAllowLateJoinsAttribute().getValue();
+        final boolean forceBalance = teamGame.getConfiguration().getForceBalanceAttribute().getValue();
+        final boolean keepSameTeams = teamGame.getConfiguration().getKeepSameTeamAttribute().getValue();
+
+        //reset player history if this is the first balance
+        if (firstBalance) {
+            teamGame.resetPlayerHistory();
+        }
 
         List<Participant> participants = new ArrayList<>(playerController.getParticipants().values());
         //if we allow late joins, add all this game spectators to unassigned players
@@ -79,18 +89,14 @@ public class GenericTeamBalancerProvider implements TeamBalancerProvider {
                     .min(Comparator.comparingInt(team -> teamSizes.getOrDefault(team, 0)))
                     .orElse(null);
 
-            if (targetTeam != null) {
-                teamGame.removePlayerFromTeam(participant);
-                if (teamGame.addPlayerToTeam(participant, targetTeam)) {
-                    //since unassigned players might be spectating, we need to remove that before assigning teams
-                    playerController.setSpectating(participant.getPlayer(), participant, false, false);
-                    teamSizes.put(targetTeam, teamSizes.getOrDefault(targetTeam, 0) + 1);
-                }
-
+            Team assignedTeam = assignToATeam(participant, targetTeam, teamGame, playerController);
+            if (assignedTeam != null) {
+                teamSizes.put(assignedTeam, teamSizes.getOrDefault(targetTeam, 0) + 1);
             }
         }
 
-        if (forceBalance) {
+        //only reassign players on the first balance and only if force balance is true (and we dont keep teams the same)
+        if (firstBalance && forceBalance || forceBalance && !keepSameTeams && !isBalanced(teamGame)) {
             // Second, if teams are still unbalanced, move players from overpopulated teams
             List<Participant> playersToReassign = new ArrayList<>();
             Map<Team, Integer> excessPlayers = new HashMap<>();
@@ -142,6 +148,66 @@ public class GenericTeamBalancerProvider implements TeamBalancerProvider {
             if (teamGame.getPlayerTeam(participant.getPlayer()) != null) continue;
             playerController.setSpectating(participant.getPlayer(), participant, true, false);
         }
+        //reset player history if this is the first balance
+        if (firstBalance) {
+            teamGame.resetPlayerHistory();
+        }
+    }
+
+    /**
+     * Assigns a player to the target team. If that team is not valid, will look for a potentially valid team to assign the player too
+     * @param participant
+     * @param targetTeam
+     * @param teamGame
+     * @param playerController
+     * @return the {@link Team} the participant was assigned to or {@code null} if no valid team
+     */
+    @Override
+    public @Nullable Team assignToATeam(Participant participant, Team targetTeam, TeamGame<?> teamGame, PlayerController playerController) {
+        final boolean keepSameTeams = teamGame.getConfiguration().getKeepSameTeamAttribute().getValue();
+        if (targetTeam != null) {
+            //if player is on a different team, do not add them to the target team
+            if (keepSameTeams &&
+                    teamGame.isOnAnotherTeam(participant, targetTeam) &&
+                    !targetTeam.getPlayerHistory().contains(participant.getPlayer().getUniqueId())) {
+                //try and find another team to assign them to, there might be a valid one
+
+                final int maxImbalance = teamGame.getConfiguration().getMaxImbalanceAttribute().getValue();
+                final int lowest = teamGame.getParticipants().stream()
+                        .map(team -> team.getParticipants().size())
+                        .min(Integer::compareTo).orElse(0);
+                final Team finalTargetTeam = targetTeam;
+                List<Team> ownTeams = teamGame.getTeams().values().stream().filter(team -> !team.equals(finalTargetTeam))
+                        .filter(team -> team.getPlayerHistory().contains(participant.getPlayer().getUniqueId()))
+                        .toList();
+                Team newTarget = null;
+                for (Team team : ownTeams) {
+                    final int size = team.getParticipants().size();
+                    if ((size + 1) - lowest <= maxImbalance) {
+                        newTarget = team;
+                        break;
+                    }
+                }
+
+                if (newTarget != null) {
+                    targetTeam = newTarget;
+                } else {
+                    //there is no valid team, leave them spectating
+                    return null;
+                }
+
+
+            }
+            teamGame.removePlayerFromTeam(participant);
+            if (teamGame.addPlayerToTeam(participant, targetTeam)) {
+                //since unassigned players might be spectating, we need to remove that before assigning teams
+                playerController.setSpectating(participant.getPlayer(), participant, false, false);
+
+                return targetTeam;
+            }
+            return null;
+        }
+        return null;
     }
 
     /**

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/Team.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/Team.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.game.framework.model.team;
 
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -18,6 +19,10 @@ public class Team implements ForwardingAudience {
 
     TeamProperties properties;
     @EqualsAndHashCode.Exclude Set<Participant> participants;
+    /**
+     * All UUID's of players that were on this team for this game
+     */
+    @EqualsAndHashCode.Exclude Set<UUID> playerHistory;
 
     public Set<Player> getPlayers() {
         return participants.stream().map(Participant::getPlayer).collect(Collectors.toSet());

--- a/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/TeamBalancerProvider.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/framework/model/team/TeamBalancerProvider.java
@@ -1,13 +1,29 @@
 package me.mykindos.betterpvp.game.framework.model.team;
 
 import me.mykindos.betterpvp.game.framework.TeamGame;
+import me.mykindos.betterpvp.game.framework.model.player.Participant;
+import me.mykindos.betterpvp.game.framework.model.player.PlayerController;
+import org.jetbrains.annotations.Nullable;
 
 public interface TeamBalancerProvider {
+
     /**
      * Balances teams by moving players between teams to ensure they are evenly distributed
      * @param teamGame The team game to balance
+     * @param firstBalance if this is the first time this game is being balanced (i.e. start)
      */
-    void balanceTeams(TeamGame<?> teamGame);
+    void balanceTeams(TeamGame<?> teamGame, boolean firstBalance);
+
+    /**
+     * Assigns a particpant to the target team
+     * @param participant
+     * @param targetTeam
+     * @param teamGame
+     * @param playerController
+     * @return
+     */
+    @Nullable
+    Team assignToATeam(Participant participant, Team targetTeam, TeamGame<?> teamGame, PlayerController playerController);
 
     /**
      * Returns true if the teams are balanced,

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/CaptureTheFlag.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/CaptureTheFlag.java
@@ -37,6 +37,7 @@ public class CaptureTheFlag extends TeamGame<CTFConfiguration> {
                 .durationBeforeAutoBalance(Duration.ofSeconds(999))
                 .autoBalanceOnDeath(false)
                 .forceBalance(true)
+                .keepSameTeams(true)
                 .build());
     }
 

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/listener/SuddenDeathListener.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/listener/SuddenDeathListener.java
@@ -1,26 +1,43 @@
 package me.mykindos.betterpvp.game.impl.ctf.listener;
 
 import com.google.inject.Inject;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.game.GamePlugin;
 import me.mykindos.betterpvp.game.framework.listener.player.event.ParticipantPreRespawnEvent;
+import me.mykindos.betterpvp.game.framework.model.player.PlayerController;
+import me.mykindos.betterpvp.game.framework.model.player.event.ParticipantStopSpectatingEvent;
 import me.mykindos.betterpvp.game.guice.GameScoped;
 import me.mykindos.betterpvp.game.impl.ctf.controller.GameController;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
 
 @GameScoped
 public class SuddenDeathListener implements Listener {
 
     private final GameController gameController;
+    private final PlayerController playerController;
 
     @Inject
-    public SuddenDeathListener(GameController gameController) {
+    public SuddenDeathListener(GameController gameController, PlayerController playerController) {
         this.gameController = gameController;
+        this.playerController = playerController;
     }
 
     @EventHandler
     public void onPlayerRespawn(ParticipantPreRespawnEvent event) {
         if (gameController.isSuddenDeath()) {
             event.setCancelled(true); // No respawning in sudden death
+        }
+    }
+
+    @EventHandler
+    public void onPlayerStopSpectate(ParticipantStopSpectatingEvent event) {
+        if (gameController.isSuddenDeath()) {
+            //kill the player if it is sudden death
+            UtilServer.runTaskLater(JavaPlugin.getPlugin(GamePlugin.class), () -> {
+                playerController.setAlive(event.getPlayer(), event.getParticipant(), false);
+            }, 1);
         }
     }
 }

--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/domination/Domination.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/domination/Domination.java
@@ -40,6 +40,7 @@ public class Domination extends TeamGame<DominationConfiguration> {
                 .durationBeforeAutoBalance(Duration.ofSeconds(999))
                 .autoBalanceOnDeath(false)
                 .forceBalance(true)
+                .keepSameTeams(true)
                 .build());
     }
 


### PR DESCRIPTION
Add keepSameTeam attribute, which when true will keep players on the same team, no matter what. If when a player is assigned to a team and it is not valid (i.e. they are on another team), check to see if there is a valid team for them to join with the current game settings/state.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes.
