### PR TITLE
Refactor Clan Kill logs.

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/KillLogsSubCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/commands/subcommands/KillLogsSubCommand.java
@@ -40,7 +40,7 @@ public class KillLogsSubCommand extends ClanSubCommand {
             UtilMessage.message(player, "Clans", "You must be in a Clan to run this command");
             return;
         }
-        new ClanKillLogMenu(clan, clanManager, clientManager).show(player);
+        new ClanKillLogMenu(clan, clanManager).show(player);
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/repository/ClanRepository.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/repository/ClanRepository.java
@@ -575,7 +575,7 @@ public class ClanRepository implements IRepository<Clan> {
                         startValue,
                         amountValue);
             }
-            try (CachedRowSet result = database.executeQuery(statement)) {
+            try (CachedRowSet result = database.executeQuery(statement).join()) {
                 return processClanKillLogs(result, clanManager);
             } catch (SQLException ex) {
                 log.error("Failed to get Clan Kill Paged logs", ex).submit();
@@ -598,7 +598,7 @@ public class ClanRepository implements IRepository<Clan> {
         String query = "CALL GetClanKillLogs(?)";
 
         return CompletableFuture.supplyAsync(() -> {
-            try (CachedRowSet result = database.executeQuery(new Statement(query, new UuidStatementValue(clan.getId())))) {
+            try (CachedRowSet result = database.executeQuery(new Statement(query, new UuidStatementValue(clan.getId()))).join()) {
                 return processClanKillLogs(result, clanManager);
             } catch (SQLException ex) {
                 log.error("Failed to get Clan Kill logs", ex).submit();

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/combat/ClansKillListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/combat/ClansKillListener.java
@@ -50,6 +50,6 @@ public class ClansKillListener implements Listener {
         }
 
 
-        clanManager.getRepository().addClanKill(event.getKillId(), killerClan, victimClan, dominance);
+        clanManager.getRepository().addClanKill(event.getKillId(), event.getKiller().getName(), killerClan, event.getVictim().getName(), victimClan, dominance);
     }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/logging/KillClanLog.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/logging/KillClanLog.java
@@ -34,4 +34,6 @@ public class KillClanLog {
         return UtilMessage.deserialize("<white>" + UtilTime.getDateTime(this.time));
     }
 
+
+
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/ClanKillLogMenu.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/ClanKillLogMenu.java
@@ -128,13 +128,17 @@ public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed 
                 return true;
             });
 
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             log.error("Error loading clan kill logs", ex).submit();
             setContent(List.of(new SimpleItem(ItemView.builder()
                     .material(Material.BARRIER)
                     .displayName(Component.text("Error! Check console!"))
                     .lore(Component.text("Please inform staff if you see this"))
                     .build())));
+            if (ex instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             return CompletableFuture.completedFuture(false);
         }
         finally {
@@ -171,7 +175,7 @@ public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed 
 
             return future.thenApply(logs -> {
                 this.killLogs = logs;
-                sort().join();;
+                sort().join();
                 setPage(pagedClanKillLogMenu.getCurrentPage());
                 UtilServer.runTask(JavaPlugin.getPlugin(Clans.class), () -> {
                     pagedClanKillLogMenu.findAllCurrentViewers().forEach(this::show);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/ClanKillLogMenu.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/ClanKillLogMenu.java
@@ -1,11 +1,11 @@
 package me.mykindos.betterpvp.clans.logging.menu;
 
 import lombok.CustomLog;
+import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.Clan;
 import me.mykindos.betterpvp.clans.clans.ClanManager;
 import me.mykindos.betterpvp.clans.logging.KillClanLog;
 import me.mykindos.betterpvp.clans.logging.button.ClanKillLogButton;
-import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.inventory.gui.AbstractPagedGui;
 import me.mykindos.betterpvp.core.inventory.gui.SlotElement;
 import me.mykindos.betterpvp.core.inventory.gui.structure.Markers;
@@ -23,27 +23,31 @@ import me.mykindos.betterpvp.core.menu.Windowed;
 import me.mykindos.betterpvp.core.menu.button.BackButton;
 import me.mykindos.betterpvp.core.menu.button.ForwardButton;
 import me.mykindos.betterpvp.core.menu.button.PreviousButton;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 @CustomLog
 public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed {
-
+    private final ReentrantLock updateLock = new ReentrantLock();
     private final Clan clan;
     private final ClanManager clanManager;
-    private final ClientManager clientManager;
-
     private IStringFilterButton categoryButton;
     private IStringFilterValueButton valueButton;
 
-    public ClanKillLogMenu(Clan clan, ClanManager clanManager, ClientManager clientManager) {
+    private List<KillClanLog> killLogs = new ArrayList<>();
+
+    public ClanKillLogMenu(Clan clan, ClanManager clanManager) {
         super(9, 5, false, new Structure(
                 "# # # # # # # C V",
                 "# x x x x x x x #",
@@ -61,7 +65,6 @@ public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed 
         );
         this.clan = clan;
         this.clanManager = clanManager;
-        this.clientManager = clientManager;
 
         if (getItem(8, 4) instanceof IRefreshButton refreshButton) {
             refreshButton.setRefresh(this::refresh);
@@ -69,12 +72,12 @@ public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed 
 
         if (getItem(7, 0) instanceof IStringFilterButton filterButton) {
             this.categoryButton = filterButton;
-            filterButton.setRefresh(this::refresh);
+            filterButton.setRefresh(this::sort);
         }
 
         if (getItem(8, 0) instanceof IStringFilterValueButton logContextFilterValueButton) {
             this.valueButton = logContextFilterValueButton;
-            logContextFilterValueButton.setRefresh(this::refresh);
+            logContextFilterValueButton.setRefresh(this::sort);
         }
         setContent(List.of(new SimpleItem(ItemView.builder()
                 .material(Material.PAPER)
@@ -84,49 +87,103 @@ public class ClanKillLogMenu extends AbstractPagedGui<Item> implements Windowed 
         refresh();
     }
 
-    private CompletableFuture<Boolean> refresh() {
-        CompletableFuture<List<Item>> future = new CompletableFuture<>();
-        valueButton.setSelectedContext(categoryButton.getSelectedFilter());
-        valueButton.getContextValues().clear();
-        future.completeAsync(() -> {
-            List<KillClanLog> logs = clanManager.getRepository().getClanKillLogs(clan, clanManager, clientManager);
-            logs.forEach(killClanLog -> {
-                valueButton.addValue("Clan", killClanLog.getKillerClanName());
-                valueButton.addValue("Clan", killClanLog.getVictimClanName());
-                valueButton.addValue("Client", killClanLog.getKillerName());
-                valueButton.addValue("Client", killClanLog.getVictimName());
+    /**
+     * Updates and
+     * @return completable future that completes as true when sort has been completed and applied
+     */
+    private CompletableFuture<Boolean> sort() {
+        try {
+            if (!updateLock.tryLock(30, TimeUnit.SECONDS)) {
+                return CompletableFuture.completedFuture(false);
+            }
+            //TODO this might not need to be async
+            return CompletableFuture.supplyAsync(() -> {
+                valueButton.setSelectedContext(categoryButton.getSelectedFilter());
+                valueButton.getContextValues().clear();
+                killLogs.forEach(killClanLog -> {
+                    valueButton.addValue("Clan", killClanLog.getKillerClanName());
+                    valueButton.addValue("Clan", killClanLog.getVictimClanName());
+                    valueButton.addValue("Client", killClanLog.getKillerName());
+                    valueButton.addValue("Client", killClanLog.getVictimName());
 
+                });
+                List<Item> newContent = killLogs.stream()
+                        .filter(killClanLog -> {
+                            String context = categoryButton.getSelectedFilter();
+                            String selectedValue = valueButton.getSelected();
+                            if (Objects.equals(context, "All")) {
+                                return true;
+                            }
+                            if (context.equals("Clan") && (killClanLog.getKillerClanName().equals(selectedValue) ||
+                                    killClanLog.getVictimClanName().equals(selectedValue))) {
+                                return true;
+                            }
+
+                            return context.equals("Client") && (killClanLog.getKillerName().equals(selectedValue) ||
+                                    killClanLog.getVictimName().equals(selectedValue));
+                        })
+                        .map(killClanLog -> new ClanKillLogButton(clan, killClanLog, clanManager))
+                        .map(Item.class::cast).toList();
+                setContent(newContent);
+                return true;
             });
-            return logs.stream()
-                    .filter(killClanLog -> {
-                        String context = categoryButton.getSelectedFilter();
-                        String selectedValue = valueButton.getSelected();
-                        if (Objects.equals(context, "All")) {
-                            return true;
-                        }
-                        if (context.equals("Clan") && (killClanLog.getKillerClanName().equals(selectedValue) ||
-                                killClanLog.getVictimClanName().equals(selectedValue))) {
-                            return true;
-                        }
 
-                        return context.equals("Client") && (killClanLog.getKillerName().equals(selectedValue) ||
-                                killClanLog.getVictimName().equals(selectedValue));
-                    })
-                    .map(killClanLog -> new ClanKillLogButton(clan, killClanLog, clanManager))
-                    .map(Item.class::cast).toList();
-        });
-        future = future.exceptionally((throwable -> {
-            log.error("Error loading clan kill logs", throwable).submit();
-            return List.of(new SimpleItem(ItemView.builder()
+        } catch (Exception ex) {
+            log.error("Error loading clan kill logs", ex).submit();
+            setContent(List.of(new SimpleItem(ItemView.builder()
                     .material(Material.BARRIER)
                     .displayName(Component.text("Error! Check console!"))
                     .lore(Component.text("Please inform staff if you see this"))
-                    .build()));
-        }));
-        return future.thenApply(logs -> {
-            setContent(logs);
-            return true;
-        });
+                    .build())));
+            return CompletableFuture.completedFuture(false);
+        }
+        finally {
+            updateLock.unlock();
+        }
+    }
+
+    private CompletableFuture<Boolean> refresh() {
+        if (!updateLock.tryLock()) {
+            return CompletableFuture.completedFuture(false);
+        }
+        try {
+            CompletableFuture<List<KillClanLog>> future = clanManager.getRepository().getClanKillLogs(clan, clanManager);
+            future = future.exceptionally((throwable -> {
+                log.error("Error loading clan kill logs", throwable).submit();
+                setContent(List.of(new SimpleItem(ItemView.builder()
+                        .material(Material.BARRIER)
+                        .displayName(Component.text("Error! Check console!"))
+                        .lore(Component.text("Please inform staff if you see this"))
+                        .build())));
+                return List.of();
+            }));
+            //temporary menu
+            PagedClanKillLogMenu pagedClanKillLogMenu = new PagedClanKillLogMenu(
+                    clan,
+                    categoryButton.getSelectedFilter(),
+                    valueButton.getSelected(),
+                    clanManager
+            );
+            pagedClanKillLogMenu.setPage(getCurrentPage());
+            UtilServer.runTask(JavaPlugin.getPlugin(Clans.class), () -> {
+                findAllCurrentViewers().forEach(pagedClanKillLogMenu::show);
+            });
+
+            return future.thenApply(logs -> {
+                this.killLogs = logs;
+                sort().join();;
+                setPage(pagedClanKillLogMenu.getCurrentPage());
+                UtilServer.runTask(JavaPlugin.getPlugin(Clans.class), () -> {
+                    pagedClanKillLogMenu.findAllCurrentViewers().forEach(this::show);
+                });
+
+                return true;
+            });
+
+        }
+        finally {
+            updateLock.unlock();
+        }
     }
 
     @Override

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/PagedClanKillLogMenu.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/PagedClanKillLogMenu.java
@@ -65,16 +65,12 @@ public class PagedClanKillLogMenu extends PagedCollectionMenu<ClanKillLogButton>
             this.categoryButton.setStatic(true);
             if (filterType == null) filterType = "All";
             switch (filterType) {
-                case ("Clan") -> {
+                case ("Clan") ->
                     this.categoryButton.setSelected(1);
-                    break;
-                } case ("Client") -> {
+                case ("Client") ->
                     this.categoryButton.setSelected(2);
-                    break;
-                }
-                default -> {
+                default ->
                     this.categoryButton.setSelected(0);
-                }
             }
         }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/PagedClanKillLogMenu.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/logging/menu/PagedClanKillLogMenu.java
@@ -1,0 +1,120 @@
+package me.mykindos.betterpvp.clans.logging.menu;
+
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.logging.button.ClanKillLogButton;
+import me.mykindos.betterpvp.core.inventory.gui.structure.Markers;
+import me.mykindos.betterpvp.core.inventory.gui.structure.Structure;
+import me.mykindos.betterpvp.core.logging.menu.button.RefreshButton;
+import me.mykindos.betterpvp.core.logging.menu.button.StringFilterButton;
+import me.mykindos.betterpvp.core.logging.menu.button.StringFilterValueButton;
+import me.mykindos.betterpvp.core.logging.menu.button.type.IRefreshButton;
+import me.mykindos.betterpvp.core.logging.menu.button.type.IStringFilterButton;
+import me.mykindos.betterpvp.core.logging.menu.button.type.IStringFilterValueButton;
+import me.mykindos.betterpvp.core.menu.Menu;
+import me.mykindos.betterpvp.core.menu.Windowed;
+import me.mykindos.betterpvp.core.menu.button.BackButton;
+import me.mykindos.betterpvp.core.menu.button.ForwardButton;
+import me.mykindos.betterpvp.core.menu.button.PreviousButton;
+import me.mykindos.betterpvp.core.menu.impl.PagedCollectionMenu;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class PagedClanKillLogMenu extends PagedCollectionMenu<ClanKillLogButton> implements Windowed {
+    private final ClanManager clanManager;
+    private final Clan clan;
+    private @Nullable String filterType;
+    private @Nullable String filterValue;
+
+    private IStringFilterButton categoryButton;
+    private IStringFilterValueButton valueButton;
+
+    protected PagedClanKillLogMenu(Clan clan, @Nullable String filterType, @Nullable String filterValue, ClanManager clanManager) {
+        super(new Structure(
+                "# # # # # # # C V",
+                "# x x x x x x x #",
+                "# x x x x x x x #",
+                "# x x x x x x x #",
+                "# # # < - > # # R")
+                .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+                .addIngredient('#', Menu.BACKGROUND_ITEM)
+                .addIngredient('<', new PreviousButton())
+                .addIngredient('-', new BackButton(null))
+                .addIngredient('>', new ForwardButton())
+                .addIngredient('R', new RefreshButton<>())
+                .addIngredient('C', new StringFilterButton<>("Select Category", List.of("All", "Clan", "Client"), 9, Material.WRITABLE_BOOK, 0))
+                .addIngredient('V', new StringFilterValueButton<>(9)));
+        this.clan = clan;
+        this.filterType = filterType;
+        if (this.filterType != null && filterType.equalsIgnoreCase("All")) {
+            this.filterType = null;
+        }
+        this.filterValue = filterValue;
+        this.clanManager = clanManager;
+        if (getItem(8, 4) instanceof IRefreshButton refreshButton) {
+            refreshButton.setRefreshing(true);
+        }
+
+        if (getItem(7, 0) instanceof IStringFilterButton filterButton) {
+            this.categoryButton = filterButton;
+            this.categoryButton.setStatic(true);
+            if (filterType == null) filterType = "All";
+            switch (filterType) {
+                case ("Clan") -> {
+                    this.categoryButton.setSelected(1);
+                    break;
+                } case ("Client") -> {
+                    this.categoryButton.setSelected(2);
+                    break;
+                }
+                default -> {
+                    this.categoryButton.setSelected(0);
+                }
+            }
+        }
+
+        if (getItem(8, 0) instanceof IStringFilterValueButton logContextFilterValueButton) {
+            this.valueButton = logContextFilterValueButton;
+            this.valueButton.setStatic(true);
+            if (filterValue != null) {
+                this.valueButton.addValue(filterType, filterValue);
+                this.valueButton.setSelectedContext(filterType);
+            }
+        }
+
+        update();
+    }
+
+    @Override
+    public @NotNull Component getTitle() {
+        return Component.text(clan.getName() + "'s Kill Logs");
+    }
+
+    /**
+     * Retrieves the content for the specified page number
+     *
+     * @param page   the page number (0 is first)
+     * @param amount (the number of items per page)
+     * @return the list of items for the page
+     */
+    @Override
+    protected CompletableFuture<List<ClanKillLogButton>> getPage(int page, int amount) {
+            int start = page * amount;
+            int end = (page + 1) * amount;
+            return clanManager.getRepository().getClanKillLogs(
+                            this.clan,
+                            start,
+                            end,
+                            this.filterType,
+                            this.filterValue,
+                            this.clanManager
+                    ).thenApply(logs -> logs.stream()
+                    .map(log -> new ClanKillLogButton(clan, log, clanManager))
+                    .toList());
+    }
+}

--- a/clans/src/main/resources/clans-migrations/V4__Update_kill_logs.sql
+++ b/clans/src/main/resources/clans-migrations/V4__Update_kill_logs.sql
@@ -1,0 +1,47 @@
+ALTER TABLE `clans_kills`
+	ADD COLUMN `KillerName` VARCHAR(16) NOT NULL AFTER `KillId`,
+	ADD COLUMN `VictimName` VARCHAR(16) NOT NULL AFTER `KillerClan`;
+
+DROP PROCEDURE IF EXISTS GetClanKillLogs;
+CREATE PROCEDURE GetClanKillLogs(IN clanId_param varchar(36))
+BEGIN
+SELECT KillerName, Killer, KillerClan, VictimName, Victim, VictimClan, Dominance, Time FROM clans_kills
+    INNER JOIN kills ON kills.Id = clans_kills.KillId
+WHERE KillerClan = clanId_param OR VictimClan = clanId_param
+ORDER BY Time DESC;
+END;
+
+DROP PROCEDURE IF EXISTS GetClanKillLogsPaged;
+CREATE PROCEDURE GetClanKillLogsPaged(IN clanId_param varchar(36), IN offset_param bigint, IN amount_param bigint)
+BEGIN
+SELECT KillerName, Killer, KillerClan, VictimName, Victim, VictimClan, Dominance, Time FROM clans_kills
+    INNER JOIN kills ON kills.Id = clans_kills.KillId
+WHERE (KillerClan = clanId_param OR VictimClan = clanId_param)
+ORDER BY Time DESC
+LIMIT amount_param
+OFFSET offset_param;
+END;
+
+DROP PROCEDURE IF EXISTS GetClanKillLogsWithClientName;
+CREATE PROCEDURE GetClanKillLogsWithClientName(IN clanId_param varchar(36), IN name_param varchar(16), IN offset_param bigint, IN amount_param bigint)
+BEGIN
+SELECT KillerName, Killer, KillerClan, VictimName, Victim, VictimClan, Dominance, Time FROM clans_kills
+    INNER JOIN kills ON kills.Id = clans_kills.KillId
+WHERE (KillerClan = clanId_param OR VictimClan = clanId_param)
+AND (KillerName = name_param OR VictimName = name_param)
+ORDER BY Time DESC
+LIMIT amount_param
+OFFSET offset_param;
+END;
+
+DROP PROCEDURE IF EXISTS GetClanKillLogsWithClanId;
+CREATE PROCEDURE GetClanKillLogsWithClanId(IN clanId_param varchar(36), IN filterClanId_param varchar(36), IN offset_param bigint, IN amount_param bigint)
+BEGIN
+SELECT KillerName, Killer, KillerClan, VictimName, Victim, VictimClan, Dominance, Time FROM clans_kills
+    INNER JOIN kills ON kills.Id = clans_kills.KillId
+WHERE (KillerClan = clanId_param OR VictimClan = clanId_param)
+AND (KillerClan = filterClanId_param OR VictimClan = filterClanId_param)
+ORDER BY Time DESC
+LIMIT amount_param
+OFFSET offset_param;
+END;

--- a/core/src/main/java/me/mykindos/betterpvp/core/inventory/gui/AbstractPagedGui.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/inventory/gui/AbstractPagedGui.java
@@ -95,7 +95,7 @@ public abstract class AbstractPagedGui<C> extends me.mykindos.betterpvp.core.inv
         // page 0 always exist, every positive page exist for infinite pages
         if (page == 0 || (infinitePages && page > 0))
             return page;
-        
+
         // 0 <= page < pageAmount
         return Math.max(0, Math.min(page, getPageAmount() - 1));
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/StringFilterButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/StringFilterButton.java
@@ -24,6 +24,8 @@ import java.util.function.Supplier;
 
 public class StringFilterButton<G extends Gui> extends ControlItem<G> implements IStringFilterButton {
 
+    @Setter
+    private boolean isStatic;
 
     @Getter
     private final List<String> contexts;
@@ -67,6 +69,8 @@ public class StringFilterButton<G extends Gui> extends ControlItem<G> implements
         this.customModelData = customModelData;
         this.selected = 0;
         this.selectedFilter = contexts.get(0);
+
+        this.isStatic = false;
     }
 
     @Override
@@ -78,9 +82,10 @@ public class StringFilterButton<G extends Gui> extends ControlItem<G> implements
         contexts.sort(String::compareToIgnoreCase);
     }
 
-    private void setSelected(int selected) {
+    public void setSelected(int selected) {
         this.selected = selected;
         this.selectedFilter = contexts.get(selected);
+        if (refresh == null) return;
         refresh.get().whenCompleteAsync(((aBoolean, throwable) -> {
             if (aBoolean.equals(Boolean.TRUE)) {
                 this.notifyWindows();
@@ -114,6 +119,7 @@ public class StringFilterButton<G extends Gui> extends ControlItem<G> implements
      */
     @Override
     public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
+        if (isStatic) return;
         if (clickType.isLeftClick()) {
             increase();
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/StringFilterValueButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/StringFilterValueButton.java
@@ -26,7 +26,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 public class StringFilterValueButton<G extends Gui> extends ControlItem<G> implements IStringFilterValueButton {
-
+    @Setter
+    private boolean isStatic;
     @Getter
     private final HashMap<String, List<String>> contextValues = new HashMap<>();
     @Setter
@@ -108,6 +109,7 @@ public class StringFilterValueButton<G extends Gui> extends ControlItem<G> imple
      */
     @Override
     public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
+        if (isStatic) return;
         if (clickType.isLeftClick()) {
             increase();
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IRefreshButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IRefreshButton.java
@@ -5,4 +5,5 @@ import java.util.function.Supplier;
 
 public interface IRefreshButton {
     void setRefresh(Supplier<CompletableFuture<Boolean>> refresh);
+    void setRefreshing(boolean isRefreshing);
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterButton.java
@@ -2,7 +2,11 @@ package me.mykindos.betterpvp.core.logging.menu.button.type;
 
 import java.util.List;
 
-public interface IStringFilterButton extends IRefreshButton{
+public interface IStringFilterButton extends IRefreshButton {
+    @Override
+    default void setRefreshing(boolean isRefreshing) {
+        return;
+    }
     void add(String newFilter);
 
     List<String> getContexts();
@@ -10,4 +14,11 @@ public interface IStringFilterButton extends IRefreshButton{
     String getSelectedFilter();
 
     void setSelectedFilter(String selectedFilter);
+    void setSelected(int selected);
+
+    /**
+     * Set whether this button can be used
+     * @param isStatic
+     */
+    void setStatic(boolean isStatic);
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterButton.java
@@ -5,7 +5,6 @@ import java.util.List;
 public interface IStringFilterButton extends IRefreshButton {
     @Override
     default void setRefreshing(boolean isRefreshing) {
-        return;
     }
     void add(String newFilter);
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterValueButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterValueButton.java
@@ -2,14 +2,25 @@ package me.mykindos.betterpvp.core.logging.menu.button.type;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.List;
 
 public interface IStringFilterValueButton extends IRefreshButton {
+    @Override
+    default void setRefreshing(boolean isRefreshing) {
+        return;
+    }
+
     void addValue(String context, String value);
 
     @Nullable String getSelected();
 
     void setSelectedContext(String newContext);
 
-    java.util.HashMap<String, List<String>> getContextValues();
+    HashMap<String, List<String>> getContextValues();
+    /**
+     * Set whether this button can be used
+     * @param isStatic whether this button is static or not
+     */
+    void setStatic(boolean isStatic);
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterValueButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/logging/menu/button/type/IStringFilterValueButton.java
@@ -8,7 +8,6 @@ import java.util.List;
 public interface IStringFilterValueButton extends IRefreshButton {
     @Override
     default void setRefreshing(boolean isRefreshing) {
-        return;
     }
 
     void addValue(String context, String value);

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/ForwardButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/ForwardButton.java
@@ -18,7 +18,12 @@ public class ForwardButton extends PageItem {
     public ItemProvider getItemProvider(PagedGui<?> gui) {
         final ItemView.ItemViewBuilder builder = ItemView.builder().material(Material.GREEN_STAINED_GLASS_PANE);
         if (gui.hasNextPage()) {
-            builder.displayName(UtilMessage.deserialize("<green>Next Page <gray>(<white>%d</white>/%d)", gui.getCurrentPage() + 2, gui.getPageAmount()));
+            if (gui.hasInfinitePages()) {
+                builder.displayName(UtilMessage.deserialize("<green>Next Page <gray>(<white>%d</white>)", gui.getCurrentPage() + 2));
+            } else {
+                builder.displayName(UtilMessage.deserialize("<green>Next Page <gray>(<white>%d</white>/%d)", gui.getCurrentPage() + 2, gui.getPageAmount()));
+            }
+
         } else {
             builder.displayName(Component.text("No next page", NamedTextColor.RED));
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/button/PreviousButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/button/PreviousButton.java
@@ -18,7 +18,12 @@ public class PreviousButton extends PageItem {
     public ItemProvider getItemProvider(PagedGui<?> gui) {
         final ItemView.ItemViewBuilder builder = ItemView.builder().material(Material.RED_STAINED_GLASS_PANE);
         if (gui.hasPreviousPage()) {
-            builder.displayName(UtilMessage.deserialize("<red>Previous Page <gray>(<white>%d</white>/%d)", gui.getCurrentPage(), gui.getPageAmount()));
+            if (gui.hasInfinitePages()) {
+                builder.displayName(UtilMessage.deserialize("<red>Previous Page <gray>(<white>%d</white>)", gui.getCurrentPage()));
+            } else {
+                builder.displayName(UtilMessage.deserialize("<red>Previous Page <gray>(<white>%d</white>/%d)", gui.getCurrentPage(), gui.getPageAmount()));
+            }
+
         } else {
             builder.displayName(Component.text("No previous page", NamedTextColor.RED));
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/impl/PagedCollectionMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/impl/PagedCollectionMenu.java
@@ -1,0 +1,230 @@
+package me.mykindos.betterpvp.core.menu.impl;
+
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.inventory.gui.AbstractGui;
+import me.mykindos.betterpvp.core.inventory.gui.PagedGui;
+import me.mykindos.betterpvp.core.inventory.gui.SlotElement;
+import me.mykindos.betterpvp.core.inventory.gui.structure.Structure;
+import me.mykindos.betterpvp.core.inventory.item.Item;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
+
+/**
+ * Represents a paged menu that retrieves its page content when the page is updated, not at create time
+ * setContent is not supported
+ * @param <C> The item type of the content
+ */
+@CustomLog
+public abstract class PagedCollectionMenu<C extends Item> extends AbstractGui implements PagedGui<C> {
+    private final Structure structure;
+    private int currentPage;
+    private List<BiConsumer<Integer, Integer>> pageChangeHandlers;
+    private final ReentrantLock updateLock = new ReentrantLock();
+
+
+    protected PagedCollectionMenu(Structure structure) {
+        super(structure.getWidth(), structure.getHeight());
+        this.structure = structure;
+        this.currentPage = 0;
+        applyStructure(structure);
+    }
+
+
+    /**
+     * Retrieves the content for the specified page number
+     * @param page the page number (0 is first)
+     * @param amount (the number of items per page)
+     * @return the list of items for the page
+     */
+    protected abstract CompletableFuture<List<C>> getPage(int page, int amount);
+
+    protected void update() {
+        correctCurrentPage();
+        updateControlItems();
+        updatePageContent();
+    }
+
+    private void correctCurrentPage() {
+        int correctedPage = correctPage(currentPage);
+        if (correctedPage != currentPage)
+            setPage(correctedPage);
+    }
+
+    private void updatePageContent() {
+        if (!updateLock.tryLock()) {
+            //TODO remove
+            log.info("PagedCollectionMenu fail lock").submit();
+            return;
+        }
+        try {
+            int contentSize = getContentListSlots().length;
+            getPage(currentPage, contentSize).handle((items, throwable) -> {
+                if (throwable != null) {
+                    log.error("Error updating page {} in PagedCollectionMenu", currentPage, throwable).submit();
+                    return false;
+                }
+                List<SlotElement.ItemSlotElement> slotElements = items.stream()
+                        .map(SlotElement.ItemSlotElement::new)
+                        .toList();
+                for (int i = 0; i < contentSize; i++) {
+                    if (slotElements.size() > i) setSlotElement(getContentListSlots()[i], slotElements.get(i));
+                    else remove(getContentListSlots()[i]);
+                }
+                return true;
+            });
+        } finally {
+            updateLock.unlock();
+        }
+    }
+
+    /**
+     * Gets the amount of pages this {@link PagedGui} has.
+     *
+     * @return The amount of pages this {@link PagedGui} has.
+     */
+    @Override
+    public int getPageAmount() {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Gets the current page of this {@link PagedGui} as an index.
+     *
+     * @return Gets the current page of this {@link PagedGui} as an index.
+     */
+    @Override
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    /**
+     * Sets the current page of this {@link PagedGui}.
+     *
+     * @param page The page to set.
+     */
+    @Override
+    public void setPage(int page) {
+        int previousPage = currentPage;
+        int newPage = correctPage(page);
+
+        if (previousPage == newPage)
+            return;
+
+        currentPage = newPage;
+        update();
+
+        if (getPageChangeHandlers() != null) {
+            getPageChangeHandlers().forEach(handler -> handler.accept(previousPage, newPage));
+        }
+    }
+
+    private int correctPage(int page) {
+        // page 0 always exist
+
+        return Math.max(page, 0);
+        // 0 <= page < pageAmount
+    }
+
+    /**
+     * Checks if there is a next poge
+     * Updates the maxPages if there is a next page
+     * @return whether there is a next page or not
+     */
+    @Override
+    public boolean hasNextPage() {
+        return true;
+    }
+
+    /**
+     * Checks if there is a previous page.
+     *
+     * @return Whether there is a previous page.
+     */
+    @Override
+    public boolean hasPreviousPage() {
+        return currentPage > 0;
+    }
+
+    /**
+     * Gets if there are infinite pages in this {@link PagedGui}.
+     *
+     * @return Whether there are infinite pages in this {@link PagedGui}.
+     */
+    @Override
+    public boolean hasInfinitePages() {
+        return true;
+    }
+
+    /**
+     * Displays the next page if there is one.
+     */
+    @Override
+    public void goForward() {
+        if (hasNextPage())
+            setPage(currentPage + 1);
+    }
+
+    /**
+     * Displays the previous page if there is one.
+     */
+    @Override
+    public void goBack() {
+        if (hasPreviousPage())
+            setPage(currentPage - 1);
+    }
+
+    /**
+     * Gets the slot indices that are used to display content in this {@link PagedGui}.
+     *
+     * @return The slot indices that are used to display content in this {@link PagedGui}.
+     */
+    @Override
+    public int[] getContentListSlots() {
+        return structure.getIngredientList().findContentListSlots();
+    }
+
+    /**
+     * Unused
+     */
+    @Override
+    public void setContent(@Nullable List<@NotNull C> content) {
+        throw new UnsupportedOperationException("setContent is not usable for this");
+    }
+
+    @Override
+    public void bake() {
+        throw new UnsupportedOperationException("bake is not usable for this");
+    }
+
+    @Override
+    public void addPageChangeHandler(@NotNull BiConsumer<Integer, Integer> pageChangeHandler) {
+        if (getPageChangeHandlers() == null) {
+            setPageChangeHandlers(new ArrayList<>());
+        }
+
+        getPageChangeHandlers().add(pageChangeHandler);
+    }
+
+    @Override
+    public void removePageChangeHandler(@NotNull BiConsumer<Integer, Integer> pageChangeHandler) {
+        if (getPageChangeHandlers() != null) {
+            getPageChangeHandlers().remove(pageChangeHandler);
+        }
+    }
+
+    @Override
+    public void setPageChangeHandlers(@Nullable List<@NotNull BiConsumer<Integer, Integer>> handlers) {
+        this.pageChangeHandlers = handlers;
+    }
+
+    @Nullable
+    public List<BiConsumer<Integer, Integer>> getPageChangeHandlers() {
+        return pageChangeHandlers;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/impl/PagedCollectionMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/impl/PagedCollectionMenu.java
@@ -58,8 +58,6 @@ public abstract class PagedCollectionMenu<C extends Item> extends AbstractGui im
 
     private void updatePageContent() {
         if (!updateLock.tryLock()) {
-            //TODO remove
-            log.info("PagedCollectionMenu fail lock").submit();
             return;
         }
         try {


### PR DESCRIPTION
Store player name in kill logs to avoid joins or fetching client.
Don't re-fetch logs everytime a filter is updated.
On load and reload switch to a temporary menu that loads by page, unfilterable.
Add PagedCollectionMenu, a PagedGui that fetches the new page contents when changed to that page.
Use locks to prevent concurrent modification of certain lists.

Fixes #1454

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
