### PR TITLE
Make flag DisplayBlock glow

### DIFF
--- a/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagBlock.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/impl/ctf/model/FlagBlock.java
@@ -38,6 +38,8 @@ public class FlagBlock {
                 ));
                 spawned.setShadowStrength(2.0f);
                 spawned.setPersistent(false);
+                spawned.setGlowColorOverride(flag.getTeam().getProperties().vanillaColor().getColor());
+                spawned.setGlowing(true);
                 spawned.teleport(currentLocation); // For rotation
             });;
         } else {


### PR DESCRIPTION
Make flag display block glow, to make it easier to find the flag in general, and when dropped in particular

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
