### PR TITLE
Prevent using most passive skills while in spectator. Prevent some delayed actions skills from triggering in spectator

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
@@ -2,6 +2,10 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.brute.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -29,6 +33,7 @@ import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.math.VelocityData;
 import org.bukkit.Effect;
+import org.bukkit.GameMode;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -40,11 +45,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -113,7 +113,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
             Map.Entry<Player, SeismicSlamData> entry = slamIterator.next();
             Player player = entry.getKey();
 
-            if (player != null) {
+            if (player != null && player.getGameMode() != GameMode.SPECTATOR) {
                 boolean isPlayerGrounded = UtilBlock.isGrounded(player) || player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isSolid();;
 
                 if (isPlayerGrounded) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Skullsplitter.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Skullsplitter.java
@@ -2,6 +2,9 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.brute.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
 import lombok.Getter;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
@@ -17,6 +20,7 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -25,10 +29,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -134,7 +134,7 @@ public class Skullsplitter extends Skill implements InteractSkill, Listener, Coo
             Player player = entry.getKey();
             SkullsplitterProjectile data = entry.getValue();
 
-            if (player == null || !player.isOnline() || !hasSkill(player) || data.isMarkForRemoval() || data.isExpired()) {
+            if (player == null || !player.isOnline() || !hasSkill(player) || data.isMarkForRemoval() || data.isExpired() || player.getGameMode() == GameMode.SPECTATOR) {
                 data.remove();
                 iterator.remove();
                 continue; // Remove if no player is not online, no skill, or expired

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -2,6 +2,10 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.brute.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -31,6 +35,7 @@ import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.math.VelocityData;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -42,11 +47,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
-
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -158,6 +158,10 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
 
 
             if (UtilBlock.isGrounded(player) && UtilTime.elapsed(next.getValue(), 750L)) {
+                it.remove();
+            }
+
+            if (player.getGameMode() == GameMode.SPECTATOR) {
                 it.remove();
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/FastRecovery.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/FastRecovery.java
@@ -78,6 +78,11 @@ public class FastRecovery extends Skill implements PassiveSkill, BuffSkill {
     }
 
     @Override
+    public boolean enabledInSpectator() {
+        return true;
+    }
+
+    @Override
     public void loadSkillConfig(){
         basePercentage = getConfig("basePercentage", 0.15, Double.class);
         percentagePerLevel = getConfig("percentagePerLevel", 0.10, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/LevelField.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/global/LevelField.java
@@ -2,12 +2,16 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.global;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.champions.champions.skills.types.DamageSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.DefensiveSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.OffensiveSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.PassiveSkill;
 import me.mykindos.betterpvp.core.client.gamer.Gamer;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
@@ -28,16 +32,11 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
-public class LevelField extends Skill implements Listener, DefensiveSkill, OffensiveSkill, DamageSkill {
+public class LevelField extends Skill implements PassiveSkill, DefensiveSkill, OffensiveSkill, DamageSkill {
 
     private double radius;
     private double radiusIncreasePerLevel;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Deflection.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Deflection.java
@@ -2,6 +2,8 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.UUID;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -20,9 +22,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.HashMap;
-import java.util.UUID;
 
 @Singleton
 @BPvPListener
@@ -129,6 +128,11 @@ public class Deflection extends Skill implements PassiveSkill, DefensiveSkill {
             }
         }
 
+    }
+
+    @Override
+    public boolean enabledInSpectator() {
+        return true;
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.knight.passives;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.WeakHashMap;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -23,8 +24,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import java.util.WeakHashMap;
 
 @Singleton
 @BPvPListener
@@ -125,6 +124,11 @@ public class Swordsmanship extends Skill implements PassiveSkill, OffensiveSkill
             }
         }
 
+    }
+
+    @Override
+    public boolean enabledInSpectator() {
+        return true;
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PassiveSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/PassiveSkill.java
@@ -4,4 +4,7 @@ import me.mykindos.betterpvp.core.components.champions.IChampionsSkill;
 import org.bukkit.event.Listener;
 
 public interface PassiveSkill extends IChampionsSkill, Listener {
+    default boolean enabledInSpectator() {
+        return false;
+    }
 }


### PR DESCRIPTION
Prevent holy light, seisimic slam, takedown, and skullsplitter from activating in while in spectator. PassiveSkills are disabled by default, but certain skills like deflection and swordsmanship are enabled.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
