### PR TITLE
Magnetic Axe Fixes + QoL

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
@@ -28,17 +28,19 @@ public class AxeProjectile extends Projectile {
 
     private final ItemDisplay display;
     private final ItemStack itemStack;
+    private final int slot;
     private final double damage;
     private final Skill skill;
     private final float yaw;
     private final double speed;
 
-    public AxeProjectile(Player caster, double hitboxSize, Location location, long aliveTime, ItemStack axe, double damage, double speed, Skill skill) {
+    public AxeProjectile(Player caster, double hitboxSize, Location location, long aliveTime, ItemStack axe, int slot, double damage, double speed, Skill skill) {
         super(caster, hitboxSize, location, aliveTime);
         this.damage = damage;
         this.skill = skill;
         this.yaw = caster.getLocation().getYaw();
         this.itemStack = axe.clone();
+        this.slot = slot;
         this.speed = speed;
         this.gravity = Projectile.DEFAULT_GRAVITY;
         this.dragCoefficient = Projectile.DEFAULT_DRAG_COEFFICIENT;

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/skills/GhostHandle.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/weapons/impl/skills/GhostHandle.java
@@ -1,0 +1,78 @@
+package me.mykindos.betterpvp.champions.weapons.impl.skills;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.core.combat.weapon.Weapon;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilInventory;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Singleton
+@BPvPListener
+public class GhostHandle extends Weapon implements Listener {
+
+    @Inject
+    protected GhostHandle(Champions plugin) {
+        super(plugin, "ghost_handle");
+    }
+
+    @Override
+    public List<Component> getLore(ItemMeta meta) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("The remnant of a thrown axe", NamedTextColor.WHITE));
+        lore.add(Component.text("Only the handle remains", NamedTextColor.WHITE));
+        return lore;
+    }
+
+    @EventHandler
+    public void onInventoryInteract(InventoryClickEvent event) {
+        if (this.matches(event.getCurrentItem())) {
+            event.setCancelled(true);
+        }
+        if (this.matches(event.getCursor())) {
+            event.setCancelled(true);
+        }
+
+        if (event.getAction() != InventoryAction.HOTBAR_SWAP) return;
+        if (event.getClickedInventory() == null) return;
+        final ItemStack hotbarItem = event.getClickedInventory().getItem(event.getHotbarButton());
+        if (this.matches(hotbarItem)) {
+            event.setCancelled(true);
+        }
+
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        if (!this.matches(event.getItemDrop().getItemStack())) return;
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    //prevent this item from dropping on death
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Iterator<ItemStack> iterator = event.getPlayer().getInventory().iterator();
+
+        UtilInventory.remove(event.getPlayer(), this.getItemStack());
+        while (iterator.hasNext()) {
+            ItemStack current = iterator.next();
+            if (this.matches(current)) {
+                current.setAmount(0);
+            }
+        }
+    }
+}

--- a/champions/src/main/resources/champions-migrations/V20250612_1__Add_magnetic_axe_ghost_handle.sql
+++ b/champions/src/main/resources/champions-migrations/V20250612_1__Add_magnetic_axe_ghost_handle.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO items (Material, Namespace, Keyname, Name, ModelData, Glow, HasUUID) VALUES
+    ('STICK', 'champions', 'ghost_handle', '<yellow>Ghost Handle', 2, 0, 0);

--- a/core/src/main/java/me/mykindos/betterpvp/core/items/BPvPItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/items/BPvPItem.java
@@ -26,6 +26,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -131,7 +132,7 @@ public class BPvPItem implements IBPvPItem {
      * @param itemStack the item stack to compare to
      * @return true if the itemstack is an instance of this item
      */
-    public boolean matches(ItemStack itemStack) {
+    public boolean matches(@Nullable final ItemStack itemStack) {
         if (itemStack == null || itemStack.getType() != material) return false;
         ItemMeta itemMeta = itemStack.getItemMeta();
         PersistentDataContainer dataContainer = itemMeta.getPersistentDataContainer();


### PR DESCRIPTION
Prevent duplicating magnetic axe. Always return magnetic axe to the slot it was thrown from, add a placeholder item to reserve that slot.

Fixes #1730

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
