### PR TITLE
Revert "Vanish adjustment"

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/AdminVanishCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/AdminVanishCommand.java
@@ -3,17 +3,27 @@ package me.mykindos.betterpvp.core.command.commands.admin;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.CustomLog;
+import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.Rank;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
+import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -74,4 +84,58 @@ public class AdminVanishCommand extends Command implements Listener {
         }
     }
 
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCommandVanish(EffectReceiveEvent event) {
+        if (event.getEffect().getEffectType() != EffectTypes.VANISH) return;
+        if (!effectName.equals(event.getEffect().getName())) return;
+        if (!(event.getTarget() instanceof Player target)) return;
+        Bukkit.getOnlinePlayers().forEach(viewer -> {
+            unlistPlayer(target, viewer);
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        if (effectManager.hasEffect(event.getPlayer(), EffectTypes.VANISH, effectName)) {
+            Bukkit.getOnlinePlayers().forEach(viewer -> {
+                unlistPlayer(event.getPlayer(), viewer);
+            });
+        }
+
+        effectManager.getAllEntitiesWithEffects().stream()
+                .filter(Player.class::isInstance)
+                .map(Player.class::cast)
+                .filter(target -> effectManager.hasEffect(target, EffectTypes.VANISH, effectName))
+                .forEach(target -> unlistPlayer(target, event.getPlayer()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCommandVanish(EffectExpireEvent event) {
+        if (event.getEffect().getEffectType() != EffectTypes.VANISH) return;
+        if (!effectName.equals(event.getEffect().getName())) return;
+        if (!(event.getTarget() instanceof Player target)) return;
+        //listing a player throws an error if the viewer cannot see the target
+        //vanish handles showing the target, so we have to run this after
+        UtilServer.runTaskLater(JavaPlugin.getPlugin(Core.class), () -> {
+            Bukkit.getOnlinePlayers().forEach(viewer -> {
+                listPlayer(target, viewer);
+            });
+        }, 1L);
+    }
+
+    private void unlistPlayer(Player target, Player viewer) {
+        if (clientManager.search().online(viewer).hasRank(Rank.HELPER)) {
+            //explicitly show staff commandVanished players
+            UtilServer.runTaskLater(JavaPlugin.getPlugin(Core.class), () -> {
+                viewer.showPlayer(JavaPlugin.getPlugin(Core.class), target);
+            }, 1L);
+            return;
+        }
+        viewer.unlistPlayer(target);
+    }
+
+    private void listPlayer(Player target, Player viewer) {
+        viewer.listPlayer(target);
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/positive/VanishEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/positive/VanishEffect.java
@@ -39,11 +39,7 @@ public class VanishEffect extends VanillaEffectType {
         UtilEffect.applyCraftEffect(livingEntity, new PotionEffect(PotionEffectType.INVISIBILITY, effect.getVanillaDuration(), 0, false, false, true));
 
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            if (onlinePlayer.isOp() && onlinePlayer.getGameMode().isInvulnerable()) continue;
             onlinePlayer.hideEntity(core, livingEntity);
-            if (livingEntity instanceof Player player) {
-                onlinePlayer.unlistPlayer(player);
-            }
         }
 
     }
@@ -53,11 +49,7 @@ public class VanishEffect extends VanillaEffectType {
         super.onExpire(livingEntity, effect, notify);
 
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            if (onlinePlayer.isOp()) continue;
             onlinePlayer.showEntity(core, livingEntity);
-            if (livingEntity instanceof Player player) {
-                onlinePlayer.listPlayer(player);
-            }
         }
     }
 
@@ -66,12 +58,8 @@ public class VanishEffect extends VanillaEffectType {
         UtilEffect.applyCraftEffect(livingEntity, new PotionEffect(PotionEffectType.INVISIBILITY, effect.getVanillaDuration(), 0, false, false, true));
 
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            if (onlinePlayer.isOp()) continue;
             if (onlinePlayer.canSee(livingEntity)) {
                 onlinePlayer.hideEntity(core, livingEntity);
-                if (livingEntity instanceof Player player) {
-                    onlinePlayer.unlistPlayer(player);
-                }
             }
         }
     }


### PR DESCRIPTION
Changes done in vanish adjustment seems to have broken vanish in some instances. Besides the fact that vanish should not by default unlist players.

Fixes #1739


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
