### PR TITLE
Overwhelm Fix 

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Overwhelm.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Overwhelm.java
@@ -84,9 +84,9 @@ public class Overwhelm extends Skill implements PassiveSkill, DamageSkill {
             LivingEntity ent = event.getDamagee();
             double difference = (player.getHealth() - ent.getHealth()) / healthOverTarget;
             if (difference > 0) {
-                difference = Math.min(difference, getMaxDamage(level));
-                // Add a flat damage modifier based on health difference
+                // Calculate damage first, THEN cap it
                 double damageToAdd = difference * bonusDamage;
+                damageToAdd = Math.min(damageToAdd, getMaxDamage(level));
                 event.getDamageModifiers().addModifier(ModifierType.DAMAGE, damageToAdd, getName(), ModifierValue.FLAT, ModifierOperation.INCREASE);
             }
         }


### PR DESCRIPTION
The original code was applying the damage cap to the health difference ratio (difference) before multiplying by bonusDamage. This meant the maximum possible damage was actually maxDamage * bonusDamage instead of just maxDamage.

The Solution
The fix moves the cap check to after the damage calculation. Now the code: Calculates the health difference ratio
Multiplies by bonus damage to get the actual damage value Then applies the damage cap

Example Calculation (Level 1)
Configuration Values:
bonusDamage: 0.5
healthOverTarget: 2.0
baseMaxDamage: 1.0

Scenario: Player has 20 HP, Enemy has 10 HP

Before Fix (Incorrect):
Health difference: 20 - 10 = 10
Ratio: 10 / 2.0 = 5
Capped ratio: min(5, 1.0) = 1.0
Final damage: 1.0 * 0.5 = 0.5 damage ❌

After Fix (Correct):
Health difference: 20 - 10 = 10
Ratio: 10 / 2.0 = 5
Damage calculation: 5 * 0.5 = 2.5
Capped damage: min(2.5, 1.0) = 1.0 damage ✓

Impact on Gameplay
Before Fix
Players could never reach the advertised maximum bonus damage At level 1, maximum achievable damage was 0.5 instead of 1.0 At level 3, maximum achievable damage was 1.0 instead of 2.0

After Fix
Players can now properly achieve the full bonus damage as designed The skill correctly rewards maintaining a health advantage Damage scaling matches the skill description

## Describe your changes

## Link to issue (if applicable)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
