### PR TITLE
Fix bloodlust level shown in chat / Fix overwhelm showing when killing a player

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Bloodlust.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Bloodlust.java
@@ -129,7 +129,7 @@ public class Bloodlust extends Skill implements PassiveSkill, BuffSkill, HealthS
         if (System.currentTimeMillis() > time.get(player)) {
             int tempStr = str.get(player);
             str.remove(player);
-            UtilMessage.simpleMessage(player, getClassType().getName(), "Your bloodlust has ended at level: <alt2>" + (Math.min(tempStr + 1, maxStacks)) + "</alt2>.");
+            UtilMessage.simpleMessage(player, getClassType().getName(), "Your bloodlust has ended at level: <alt2>" + (Math.min(tempStr, maxStacks)) + "</alt2>.");
             time.remove(player);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Overwhelm.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/passives/Overwhelm.java
@@ -88,6 +88,8 @@ public class Overwhelm extends Skill implements PassiveSkill, DamageSkill {
                 // Add a flat damage modifier based on health difference
                 double damageToAdd = difference * bonusDamage;
                 event.getDamageModifiers().addModifier(ModifierType.DAMAGE, damageToAdd, getName(), ModifierValue.FLAT, ModifierOperation.INCREASE);
+                // Register Overwhelm as a damage reason
+                event.addReason(getName());
             }
         }
     }


### PR DESCRIPTION
## Describe your changes
### Show overwhelm when killing a player in chat
<img width="668" height="264" alt="2025-07-27_23 25 39" src="https://github.com/user-attachments/assets/ac5425b5-d4a6-4b7a-93b3-ab730e0bd54a" />

### Fix bloodlust level shown in chat
## Old
<img width="671" height="264" alt="2025-07-27_23 08 41" src="https://github.com/user-attachments/assets/4b542fae-53a9-4259-89dc-b2f90b4246a4" />

## New
<img width="660" height="173" alt="2025-07-27_23 29 14" src="https://github.com/user-attachments/assets/af7bd1c5-f782-4a4e-abb1-f7c7b3aab6e1" />

## Link to issue (if applicable)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
