### PR TITLE
fixed bug where vanguards might would break after being cancelled

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -21,6 +21,7 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
@@ -194,6 +195,16 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
     @Override
     public boolean shouldDisplayActionBar(Gamer gamer) {
         return !handRaisedTime.containsKey(gamer.getPlayer()) && isHolding(gamer.getPlayer());
+    }
+
+    @Override
+    public void doWhenAbilityCancelled(Player player) {
+        final @Nullable VanguardsMightData abilityData = data.get(player);
+        if (abilityData == null) return;  // unreachable
+
+        handRaisedTime.remove(player);
+        abilityData.setCharge(0f);  // lets go straight to the failure msg
+        abilityData.setPhase(VanguardsMightAbilityPhase.STRENGTH_EFFECT);
     }
 
     /**

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChannelSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChannelSkill.java
@@ -36,6 +36,7 @@ public abstract class ChannelSkill extends Skill implements Listener {
     }
 
     public void cancel(Player player) {
+        doWhenAbilityCancelled(player);
         active.remove(player.getUniqueId());
     }
 
@@ -71,4 +72,6 @@ public abstract class ChannelSkill extends Skill implements Listener {
     public boolean shouldShowShield(Player player) {
         return false;
     }
+
+    public void doWhenAbilityCancelled(Player player) {}
 }


### PR DESCRIPTION
## Describe your changes
- note: because of the way that `ChannelSkill` works, you *can* kind of use the skill in water. `ChannelSkill` only "cancels" it if the player moves around in water so if you drop directly into water and don't change your block, you can still keep using it.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
