### PR TITLE
Excessive Force QoL change

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
@@ -209,7 +209,7 @@ public class ExcessiveForce extends Skill implements InteractSkill, CooldownSkil
 
     @Override
     public boolean shouldDisplayActionBar(Gamer gamer) {
-        return !active.containsKey(gamer.getPlayer());  // only show if the player is actively using the skill
+        return !active.containsKey(gamer.getPlayer());  // only show if the player is actively NOT using the skill
     }
 
     @Override


### PR DESCRIPTION
- Updated a little excessive force cleanup logic
- Changed it so that the ability's cooldown doesn't "start" (or "show") until _after_ the knockback duration has ended. This makes the ability's _true_ cooldown clearer.

## Describe your changes
<img width="1920" height="1080" alt="2025-09-13_14 56 38" src="https://github.com/user-attachments/assets/4beacc99-5e32-4826-8239-47146913ba6d" />

## Demo
https://medal.tv/games/minecraft/clips/l62LiClXa0qmGvT-J?invite=cr-MSxMZlksMzk5NTIyMjcw&v=8

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
