### PR TITLE
Vanguards Might QoL & Improvement

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/VanguardsMightData.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/VanguardsMightData.java
@@ -43,4 +43,8 @@ public class VanguardsMightData extends ChargeData {
         this.phase = phase;
     }
 
+    @Override
+    public void setCharge(float newCharge) {
+        super.setCharge(Math.min(newCharge, 1f));  // cant go higher than 1
+    }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -15,6 +15,9 @@ import me.mykindos.betterpvp.champions.champions.skills.types.DefensiveSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.InteractSkill;
 import me.mykindos.betterpvp.champions.champions.skills.types.OffensiveSkill;
 import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.combat.damage.ModifierOperation;
+import me.mykindos.betterpvp.core.combat.damage.ModifierType;
+import me.mykindos.betterpvp.core.combat.damage.ModifierValue;
 import me.mykindos.betterpvp.core.combat.events.CustomDamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
@@ -342,16 +345,13 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
         final double rateAtDamageTaken = chargePerDamageTaken / 100.0;
         final double addedCharge = event.getDamage() * rateAtDamageTaken;
         float newCharge = abilityData.getCharge() + (float) addedCharge;
-        if (newCharge > 1f) {
-            newCharge = 1f;  // Cap the charge at 1
-        }
 
-        // update charge + play old defensive stance sound
+        // Update charge & play sound
         abilityData.setCharge(newCharge);
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_POWER_SELECT, 0.8F, 2.0F);
 
+        event.getDamageModifiers().addModifier(ModifierType.DAMAGE, 100, getName(), ModifierValue.PERCENTAGE, ModifierOperation.DECREASE);
         event.setKnockback(false);
-        event.setDamage(0);
     }
 
     /**

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -33,6 +33,7 @@ import me.mykindos.betterpvp.core.utilities.model.display.TimedComponent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -76,9 +77,9 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
                 if (abilityData == null) return null;
 
                 final int chargeAsPercentage = (int) (abilityData.getCharge() * 100);
-                return Component.text(chargeAsPercentage )
-                        .color(NamedTextColor.LIGHT_PURPLE)
-                        .append(Component.text("%").color(NamedTextColor.GRAY));
+
+                // ex: Charge: 5%
+                return createComponentMessage("Charge", String.valueOf(chargeAsPercentage), "%");
             }
     );
 
@@ -104,10 +105,10 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
                 final @Nullable VanguardsMightData abilityData = getValidAbilityData(gamer, VanguardsMightAbilityPhase.STRENGTH_EFFECT);
                 if (abilityData == null) return null;
 
-                String timeLeftWithOneDecimalPlace = UtilFormat.formatNumber(abilityData.getStrengthEffectTimeLeft(), 1);
-                return Component.text(timeLeftWithOneDecimalPlace)
-                        .color(NamedTextColor.LIGHT_PURPLE)
-                        .append(Component.text("s").color(NamedTextColor.GRAY));
+                final String timeLeft = UtilFormat.formatNumber(abilityData.getStrengthEffectTimeLeft(), 1, true);
+
+                // ex: Strength For: 4.2s
+                return createComponentMessage("Strength For", timeLeft, "s");
             }
     );
 
@@ -134,8 +135,8 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
         return new String[] {
                 "Right click with a Sword to channel",
                 "",
-                "While channeling, absorb all damage",
-                "damage, thus, charging this ability.",
+                "While channeling, build charge",
+                "over time and by absorbing damage.",
                 "",
                 "Stop channeling to gain <effect>Strength</effect>",
                 "for up to " + getValueString(this::getMaxStrengthDuration, level) + " seconds.",
@@ -155,6 +156,21 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
         if (abilityData == null || !phase.equals(abilityData.getPhase())) return null;
 
         return abilityData;
+    }
+
+    /**
+     * A helper method used to construct an adventure component given a few strings.
+     * <p>
+     * The returned component will be in this format:
+     * <code>`label`: `numberValue``symbol`</code>
+     * <p>
+     * Example:
+     * <code>Charge: 5%</code>
+     */
+    private @NotNull Component createComponentMessage(String label, String numberValue, String symbol) {
+        return Component.text(label + ":" + " ").color(NamedTextColor.WHITE).decorate(TextDecoration.BOLD)
+                .append(Component.text(numberValue).color(NamedTextColor.LIGHT_PURPLE).decoration(TextDecoration.BOLD, false))
+                .append(Component.text(symbol).color(NamedTextColor.GRAY).decoration(TextDecoration.BOLD, false));
     }
 
     /**

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -26,6 +26,7 @@ import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.display.DisplayComponent;
 import me.mykindos.betterpvp.core.utilities.model.display.PermanentComponent;
 import me.mykindos.betterpvp.core.utilities.model.display.TimedComponent;
@@ -330,7 +331,7 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
 
         // update charge + play old defensive stance sound
         abilityData.setCharge(newCharge);
-        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR, 1.0F, 2.0F);
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_POWER_SELECT, 0.8F, 2.0F);
 
         event.setKnockback(false);
         event.setDamage(0);
@@ -434,17 +435,17 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
         final Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
 
         // (condition) ? failure : success
-        final Sound soundToPlay;
+        final SoundEffect soundEffectToPlay;
         final double calculatedCharge;
 
         if (abilityData.getCharge() <= 0f) {
-            soundToPlay = Sound.BLOCK_BEACON_DEACTIVATE;  // failure sound
+            soundEffectToPlay = new SoundEffect(Sound.BLOCK_BEACON_DEACTIVATE, 0.5f);  // failure sound
             calculatedCharge = 0.0;
 
             final TextComponent message = Component.text("No Damage Absorbed").color(NamedTextColor.DARK_RED);
             gamer.getActionBar().add(400, new TimedComponent(noDamageAbsorbedMessageDuration, true, gmr -> message));
         } else {
-            soundToPlay = Sound.ENTITY_ENDER_DRAGON_GROWL;  // success sound
+            soundEffectToPlay = new SoundEffect(Sound.BLOCK_ANVIL_LAND, 1.5f);  // success sound
             calculatedCharge = abilityData.getCharge() * getMaxStrengthDuration(level);
             final long strengthDuration = (long) (calculatedCharge * 1000L);
 
@@ -455,7 +456,7 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
         }
 
         // Strength effect sound
-        player.getWorld().playSound(player.getLocation(), soundToPlay, 1f, 0.5f);
+        soundEffectToPlay.play(player.getLocation());
 
         // Start cooldown when strength effect phase ends
         UtilServer.runTaskLater(champions, () -> {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -159,7 +159,8 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
     }
 
     /**
-     * A helper method used to construct an adventure component given a few strings.
+     * A helper method used to construct an adventure component given a few strings. This method is only used in
+     * the action bars above.
      * <p>
      * The returned component will be in this format:
      * <code>`label`: `numberValue``symbol`</code>
@@ -169,7 +170,7 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
      */
     private @NotNull Component createComponentMessage(String label, String numberValue, String symbol) {
         return Component.text(label + ":" + " ").color(NamedTextColor.WHITE).decorate(TextDecoration.BOLD)
-                .append(Component.text(numberValue).color(NamedTextColor.LIGHT_PURPLE).decoration(TextDecoration.BOLD, false))
+                .append(Component.text(numberValue).color(NamedTextColor.GREEN).decoration(TextDecoration.BOLD, false))
                 .append(Component.text(symbol).color(NamedTextColor.GRAY).decoration(TextDecoration.BOLD, false));
     }
 

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -293,12 +293,13 @@ skills:
     vanguardsmight:
       enabled: true
       maxlevel: 3
+      passiveChargePerSecond: 0.5
       chargePerDamageTaken: 2.0
       blockDuration: 3.0
       transferencePhaseDuration: 0.5
       strengthLevel: 1
-      maxStrengthDuration: 6.0
-      maxStrengthDurationIncreasePerLevel: 1.0
+      maxStrengthDuration: 3.0
+      maxStrengthDurationIncreasePerLevel: 2.5
       noDamageAbsorbedMessageDuration: 2.0
       cooldown: 14.0
       cooldownDecreasePerLevel: 1.0


### PR DESCRIPTION
## Describe your changes
- Changed action bar messages to look **a lot** cleaner (no longer uses purple text).
- Changed strength effect duration scaling to be `3.0 -> 5.5 -> 8.0` instead of `6.0 -> 7.0 -> 8.0`
- Vanguards Might now passively charges `50` charge per second

<img width="1280" height="720" alt="2025-09-14_16 19 29" src="https://github.com/user-attachments/assets/ca5d02c0-6503-4353-84df-68db96ad93c0" />


## Demo
https://medal.tv/games/minecraft/clips/l6tKjeBJDTHBCv5Hj?invite=cr-MSxtUGQsMzk5NTIyMjcw&v=15

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
