### PR TITLE
Add `DescriptionComponent` for handling item description rendering

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/DescriptionComponent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/DescriptionComponent.java
@@ -1,0 +1,46 @@
+package me.mykindos.betterpvp.core.item.component.impl;
+
+import lombok.EqualsAndHashCode;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.component.AbstractItemComponent;
+import me.mykindos.betterpvp.core.item.component.LoreComponent;
+import me.mykindos.betterpvp.core.utilities.ComponentWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+public class DescriptionComponent extends AbstractItemComponent implements LoreComponent {
+
+    public static final int FIRST = -Integer.MAX_VALUE;
+    public static final int LAST = Integer.MAX_VALUE;
+
+    private final int renderPriority;
+    private final Component component;
+
+    public DescriptionComponent(int renderPriority, Component description) {
+        super("description");
+        this.renderPriority = renderPriority;
+        this.component = description;
+    }
+
+    @Override
+    public DescriptionComponent copy() {
+        return new DescriptionComponent(renderPriority, component);
+    }
+
+    @Override
+    public List<Component> getLines(ItemInstance item) {
+        final Style style = Style.style().decorate(TextDecoration.ITALIC).color(NamedTextColor.GRAY).build();
+        final Component normalized = component.applyFallbackStyle(style);
+        return ComponentWrapper.wrapLine(normalized, 30);
+    }
+
+    @Override
+    public int getRenderPriority() {
+        return renderPriority;
+    }
+}


### PR DESCRIPTION
## Describe your changes
- Describes an item with a custom render priority (most commonly at the top). Useful for miscellaneous items with unclear use.
- Used in dungeon/raid keys.

<img width="367" height="213" alt="image" src="https://github.com/user-attachments/assets/d3d69557-0d39-414d-90c4-f8d2834f13f0" />


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
