### PR TITLE
Load resource packs asynchronously to not block clients loading on first load.

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/DefaultResourcePackLoader.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/DefaultResourcePackLoader.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @CustomLog
 public class DefaultResourcePackLoader implements IResourcePackLoader {
@@ -24,20 +25,22 @@ public class DefaultResourcePackLoader implements IResourcePackLoader {
     }
 
     @Override
-    public ResourcePack loadResourcePack(String name) {
-        ExtendedYamlConfiguration resourcepacks = core.getConfig("resourcepacks");
+    public CompletableFuture<ResourcePack> loadResourcePack(String name) {
+        return CompletableFuture.supplyAsync(() -> {
+            ExtendedYamlConfiguration resourcepacks = core.getConfig("resourcepacks");
 
-        String url = resourcepacks.getString("packs." + name + ".url");
-        if(url == null) return null;
+            String url = resourcepacks.getString("packs." + name + ".url");
+            if(url == null) return null;
 
-        String hash = resourcepacks.getString("packs." + name + ".hash");
-        if(hash == null) {
-            hash = calculateSHA1(url);
-        }
+            String hash = resourcepacks.getString("packs." + name + ".hash");
+            if(hash == null) {
+                hash = calculateSHA1(url);
+            }
 
-        UUID uuid = UUID.nameUUIDFromBytes(url.getBytes(StandardCharsets.UTF_8));
+            UUID uuid = UUID.nameUUIDFromBytes(url.getBytes(StandardCharsets.UTF_8));
 
-        return new ResourcePack(uuid, url, hash);
+            return new ResourcePack(uuid, url, hash);
+        });
     }
 
     private String calculateSHA1(String fileUrl) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/IResourcePackLoader.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/IResourcePackLoader.java
@@ -1,7 +1,9 @@
 package me.mykindos.betterpvp.core.resourcepack;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface IResourcePackLoader {
 
-    ResourcePack loadResourcePack(String name);
+    CompletableFuture<ResourcePack> loadResourcePack(String name);
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/MineplexResourcePackLoader.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/MineplexResourcePackLoader.java
@@ -5,23 +5,27 @@ import com.mineplex.studio.sdk.modules.resourcepack.ResourcePackModule;
 import lombok.CustomLog;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @CustomLog
 public class MineplexResourcePackLoader implements IResourcePackLoader {
 
     @Override
-    public ResourcePack loadResourcePack(String name) {
-        ResourcePackModule resourcePackModule = MineplexModuleManager.getRegisteredModule(ResourcePackModule.class);
+    public CompletableFuture<ResourcePack> loadResourcePack(String name) {
+        return CompletableFuture.supplyAsync(() -> {
+            ResourcePackModule resourcePackModule = MineplexModuleManager.getRegisteredModule(ResourcePackModule.class);
 
-        Optional<com.mineplex.studio.sdk.modules.resourcepack.ResourcePack> resourcePackOptional = resourcePackModule.get(name);
-        if (resourcePackOptional.isEmpty()) {
-            log.error("Failed to load resource pack " + name).submit();
-            throw new RuntimeException("Failed to get resource pack from studio SDK");
-        }
+            Optional<com.mineplex.studio.sdk.modules.resourcepack.ResourcePack> resourcePackOptional = resourcePackModule.get(name);
+            if (resourcePackOptional.isEmpty()) {
+                log.error("Failed to load resource pack " + name).submit();
+                throw new RuntimeException("Failed to get resource pack from studio SDK");
+            }
 
-        com.mineplex.studio.sdk.modules.resourcepack.ResourcePack resourcePack = resourcePackOptional.get();
+            com.mineplex.studio.sdk.modules.resourcepack.ResourcePack resourcePack = resourcePackOptional.get();
 
-        return new ResourcePack(resourcePack.getUuid(), resourcePack.getUrl(), resourcePack.getSha1());
+            return new ResourcePack(resourcePack.getUuid(), resourcePack.getUrl(), resourcePack.getSha1());
+        });
+
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/ResourcePackHandler.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/ResourcePackHandler.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @CustomLog
@@ -19,8 +20,16 @@ public class ResourcePackHandler {
     private final HashMap<String, ResourcePack> resourcePacks = new HashMap<>();
     private IResourcePackLoader resourcePackLoader;
 
-    public ResourcePack getResourcePack(String name) {
-        return resourcePacks.computeIfAbsent(name, resourcePackLoader::loadResourcePack);
+    public CompletableFuture<ResourcePack> getResourcePack(String name) {
+        if (resourcePacks.containsKey(name)) {
+            return CompletableFuture.completedFuture(resourcePacks.get(name));
+        }
+        return resourcePackLoader.loadResourcePack(name).thenApply(
+                resourcePack -> {
+                    resourcePacks.put(name, resourcePack);
+                    return resourcePack;
+                }
+        );
     }
 
     @Inject

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/ResourcePackListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/ResourcePackListener.java
@@ -2,9 +2,11 @@ package me.mykindos.betterpvp.core.resourcepack;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.events.ClientJoinEvent;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -16,6 +18,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
 @Singleton
 @BPvPListener
@@ -35,20 +38,22 @@ public class ResourcePackListener implements Listener {
 
     @EventHandler
     public void onClientLogin(ClientJoinEvent event) {
+        UtilServer.runTaskAsync(JavaPlugin.getPlugin(Core.class), () -> {
+            Player player = event.getPlayer();
+            ResourcePack mainPack = resourcePackHandler.getResourcePack("main").join();
+            if (mainPack == null) return;
 
-        Player player = event.getPlayer();
-        ResourcePack mainPack = resourcePackHandler.getResourcePack("main");
-        if (mainPack == null) return;
+            Component message = Component.text("You must accept the resource pack to play on this server", NamedTextColor.RED);
+            player.setResourcePack(mainPack.getUuid(), mainPack.getUrl(), mainPack.getHashBytes(), message, true);
+        });
 
-        Component message = Component.text("You must accept the resource pack to play on this server", NamedTextColor.RED);
-        player.setResourcePack(mainPack.getUuid(), mainPack.getUrl(), mainPack.getHashBytes(), message, true);
 
     }
 
     @EventHandler
     public void onTexturepackStatus(PlayerResourcePackStatusEvent event) {
 
-        ResourcePack mainPack = resourcePackHandler.getResourcePack("main");
+        ResourcePack mainPack = resourcePackHandler.getResourcePack("main").join();
         if (mainPack == null) return;
 
         if (event.getID().equals(mainPack.getUuid())) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/commands/LoadPackCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/commands/LoadPackCommand.java
@@ -2,14 +2,17 @@ package me.mykindos.betterpvp.core.resourcepack.commands;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.resourcepack.ResourcePack;
 import me.mykindos.betterpvp.core.resourcepack.ResourcePackHandler;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +47,16 @@ public class LoadPackCommand extends Command {
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) return;
 
-        ResourcePack pack = resourcePackHandler.getResourcePack(args[1]);
-        if (pack == null) {
-            UtilMessage.simpleMessage(player, "Resource pack not found");
-            return;
-        }
+        UtilServer.runTaskAsync(JavaPlugin.getPlugin(Core.class), () -> {
+            ResourcePack pack = resourcePackHandler.getResourcePack(args[1]).join();
+            if (pack == null) {
+                UtilMessage.simpleMessage(player, "Resource pack not found");
+                return;
+            }
 
-        target.addResourcePack(pack.getUuid(), pack.getUrl(), pack.getHashBytes(), null, true);
+            target.addResourcePack(pack.getUuid(), pack.getUrl(), pack.getHashBytes(), null, true);
+        });
+
 
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/commands/UnloadPackCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/resourcepack/commands/UnloadPackCommand.java
@@ -44,7 +44,7 @@ public class UnloadPackCommand extends Command {
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) return;
 
-        ResourcePack pack = resourcePackHandler.getResourcePack(args[1]);
+        ResourcePack pack = resourcePackHandler.getResourcePack(args[1]).join();
         if (pack == null) {
             UtilMessage.simpleMessage(player, "Resource pack not found");
             return;


### PR DESCRIPTION
Make resource pack loading async, as on first load for the server with a poor internet connection will block the server for over 30s (and occasionally causing a crash), usually due to the SHA1 calculation.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [x] I have tested my changes.
