### PR TITLE
Refactor from PlayerLoginEvent. Make loadOnline clearer as to functionality.

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/PunishmentListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/punishments/PunishmentListener.java
@@ -24,7 +24,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.Date;
@@ -49,14 +49,14 @@ public class PunishmentListener implements Listener {
         this.clientManager = clientManager;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onLogin(PlayerLoginEvent event) {
-        final Client client = clientManager.search().online(event.getPlayer());
-
-        if (client.getUniqueId().equals(MYKINDOS)) {
-            event.setResult(PlayerLoginEvent.Result.ALLOWED);
+    @EventHandler(priority = EventPriority.LOW)
+    public void onLogin(AsyncPlayerPreLoginEvent event) {
+        if (event.getUniqueId().equals(MYKINDOS)) {
+            event.allow();
             return;
         }
+        //client is loaded in LOWEST
+        final Client client = clientManager.search().online(event.getUniqueId()).orElseThrow();
 
         Optional<Punishment> ban = client.getPunishment(PunishmentTypes.BAN);
         if (ban.isPresent()) {
@@ -76,7 +76,7 @@ public class PunishmentListener implements Listener {
                 banMessage = banMessage.append(Component.text("This ban will expire ", NamedTextColor.RED).append(Component.text(new PrettyTime().format(new Date(punishment.getExpiryTime())), NamedTextColor.GREEN)));
             }
 
-            event.disallow(PlayerLoginEvent.Result.KICK_BANNED, banMessage);
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_BANNED, banMessage);
             log.info("Player {} ({}) is banned and has been kicked.", client.getName(), client.getUniqueId()).submit();
         } else {
             log.info("Player {} ({}) is not banned and has logged in.", client.getName(), client.getUniqueId()).submit();

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogListener.java
@@ -23,7 +23,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.List;
@@ -131,11 +131,7 @@ public class CombatLogListener implements Listener {
     }
 
     @EventHandler
-    public void onLoggerReturn(PlayerLoginEvent event) {
-        if(event.getResult() == PlayerLoginEvent.Result.KICK_BANNED) {
-            return;
-        }
-
+    public void onLoggerReturn(PlayerJoinEvent event) {
         combatLogManager.getObject(event.getPlayer().getUniqueId().toString()).ifPresent(combatLog -> {
             combatLog.getCombatLogSheep().remove();
         });

--- a/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/menu/listener/MenuListener.java
@@ -24,7 +24,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -139,7 +139,7 @@ public class MenuListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onPlayerLogin(PlayerLoginEvent event) {
+    public void onPlayerLogin(PlayerJoinEvent event) {
         final Player player = event.getPlayer();
         for (Window window : WindowManager.getInstance().getWindows()) {
             if (window instanceof AbstractSingleWindow abstractSingleWindow) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/manager/PlayerManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/manager/PlayerManager.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.utilities.model.manager;
 
 import lombok.CustomLog;
+import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
 import me.mykindos.betterpvp.core.utilities.model.Unique;
 import me.mykindos.betterpvp.core.utilities.search.SearchEngineBase;
@@ -11,6 +12,7 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 @CustomLog
@@ -41,7 +43,7 @@ public abstract class PlayerManager<T extends Unique> {
      */
     protected abstract void load(T entity);
 
-    protected abstract Optional<T> loadOnline(UUID uuid, String name);
+    protected abstract CompletableFuture<Optional<Client>> loadOnline(UUID uuid, String name);
 
     protected abstract Optional<T> loadOffline(@Nullable final String name);
 


### PR DESCRIPTION
Fix listening to PlayerLoginEvent. Force login event to wait until a client is stored before continuing, change function definitions to allow better asynchronous handling

Might have also fixed some issues with getting a client before it was stored, as storing a client through loadOnline was done asynchronously, meaning it was possible to retrieve a client assumed to be online (as the call was after the loadOnline call) but the client had yet to be stored. This function now uses a CompletableFuture to be clearer about what is going on inside the function for callers.

Fixes #1844

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
