### PR TITLE
Fix NPE in DamageLogManager#getLastDamage

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/damagelog/DamageLogManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/damagelog/DamageLogManager.java
@@ -37,7 +37,7 @@ public class DamageLogManager extends Manager<String, ConcurrentLinkedDeque<Dama
 
     public DamageLog getLastDamage(LivingEntity damagee) {
         ConcurrentLinkedDeque<DamageLog> logQueue = objects.get(damagee.getUniqueId().toString());
-        if (logQueue.isEmpty()) {
+        if (logQueue == null || logQueue.isEmpty()) {
             return null;
         } else {
             return logQueue.getLast();


### PR DESCRIPTION
## Describe your changes
Adds a null check in `DamageLogManager#getLastDamage` to prevent an NPE when a player has no existing damage log queue.

### Root cause
`getLastDamage` called `logQueue.isEmpty()` without handling `logQueue == null`.
This can happen for deaths that bypass normal combat logging (e.g. `/kill`).

### Fix
Return `null` when `logQueue` is null or empty.

## Link to issue (if applicable)
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes