### PR TITLE
Issue 1710: Fix UnstoppableForce Slab Issue

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/UnstoppableForce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/UnstoppableForce.java
@@ -39,7 +39,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.RayTraceResult;
-import org.bukkit.util.Vector;
 
 import java.util.Iterator;
 import java.util.Optional;
@@ -128,9 +127,10 @@ public class UnstoppableForce extends ChannelSkill implements InteractSkill, Ene
                 championsManager.getEffects().addEffect(player, EffectTypes.NO_JUMP, getName(), 1, 100, true);
 
                 final Location newLocation = UtilPlayer.getMidpoint(player).clone();
-                final Vector chargeDirection = getChargeDirection(player);
+                final double lookY = player.getLocation().getDirection().getY();
 
-                VelocityData velocityData = new VelocityData(chargeDirection, 0.5, false, 0.0, 0.0, 0.0, false);
+                // Keep forward speed pitch-independent while applying a downward Y cap to avoid bounce.
+                VelocityData velocityData = new VelocityData(player.getLocation().getDirection().clone().setY(0.0D), 0.5, false, 0.0, lookY, -0.08D, false);
                 UtilVelocity.velocity(player, null, velocityData);
 
                 final Optional<LivingEntity> hit = UtilEntity.interpolateCollision(newLocation,
@@ -161,16 +161,6 @@ public class UnstoppableForce extends ChannelSkill implements InteractSkill, Ene
                 UtilSound.playSound(player.getWorld(), player, Sound.ENTITY_PLAYER_SMALL_FALL, 0.5f, 0.7f);
             }
         }
-    }
-
-    private Vector getChargeDirection(Player player) {
-        // Build horizontal movement from yaw, then use Location#getDirection() for a small downward floor.
-        // This avoids upward bounce while keeping charge grounded enough to step slabs reliably.
-        final double yawRadians = Math.toRadians(player.getLocation().getYaw());
-        final Vector direction = new Vector(-Math.sin(yawRadians), 0, Math.cos(yawRadians));
-        final double lookY = player.getLocation().getDirection().getY();
-        direction.setY(Math.min(lookY, -0.08D));
-        return direction;
     }
 
     private void finishUnstoppableForce(Player player) {


### PR DESCRIPTION
Current problem hypothesis is that setY(0) overwrites game's settling onto slabs. 

## Describe your changes
- Implemented small negative Y using VelocityData to press player into ground but still trigger the step-up.

## Link to test
https://github.com/user-attachments/assets/6afa0840-849e-43dd-886f-7f313ca7bb60

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.

## Alternative / extensions (NOT IMPLEMENTED).
- Implement sliding window to track recent isGrounded flags to provide grace period for slabs.
### Would be addressing these cases:

https://github.com/user-attachments/assets/effb5bd3-2760-4030-9457-8682928e1eed


https://github.com/user-attachments/assets/aaa3f9e9-599a-4e4a-9c5a-311f0b12a3f3

