### PR TITLE
Better config parsing for Numbers

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -225,7 +225,7 @@ public abstract class Skill implements IChampionsSkill {
         return path;
     }
 
-    protected <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+    protected <T> T getConfig(String name, T defaultValue, Class<T> type) {
         return champions.getConfig("skills/skills").getOrSaveObject(getPath(name), defaultValue, type);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/passives/Swordsmanship.java
@@ -138,7 +138,7 @@ public class Swordsmanship extends Skill implements PassiveSkill, OffensiveSkill
         timeBetweenCharges = getConfig("timeBetweenCharges", 2.0, Double.class);
         timeBetweenChargesDecreasePerLevel = getConfig("timeBetweenChargesDecreasePerLevel", 0.0, Double.class);
         timeOutOfCombat = getConfig("timeOutOfCombat", 2.5, Double.class);
-        timeOutOfCombatDecreasePerLevel = getConfig("timeOutOfCombat", 0, Double.class);
+        timeOutOfCombatDecreasePerLevel = getConfig("timeOutOfCombat", 0d, Double.class);
         baseDamagePerCharge = getConfig("baseDamagePerCharge", 1.0, Double.class);
         damageIncreasePerLevel = getConfig("damageIncreasePerLevel", 0.0, Double.class);
     }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/CustomOre.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/fields/model/CustomOre.java
@@ -24,7 +24,7 @@ public abstract class CustomOre implements FieldsOre {
         this.respawnDelay = delay;
     }
 
-    protected <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+    protected <T> T getConfig(String name, T defaultValue, Class<T> type) {
         final String key = "fields.blocks." + getName().toLowerCase().replace(" ", "") + "." + name;
         return clans.getConfig().getOrSaveObject(key, defaultValue, type);
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/config/ExtendedYamlConfiguration.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/config/ExtendedYamlConfiguration.java
@@ -78,27 +78,27 @@ public class ExtendedYamlConfiguration extends YamlConfiguration {
         }
 
         if (type == Double.class) {
-            return (T) Double.valueOf(getDouble(path, defaultValue instanceof String ? Double.valueOf((String) defaultValue) : ((Double) defaultValue)));
+            return (T) Double.valueOf(getDouble(path, defaultValue instanceof String string ? Double.valueOf(string) : ((Double) defaultValue)));
         }
 
         if (type == Integer.class) {
-            return (T) Integer.valueOf(getInt(path, defaultValue instanceof String ? Integer.valueOf((String) defaultValue) : ((Integer) defaultValue)));
+            return (T) Integer.valueOf(getInt(path, defaultValue instanceof String string ? Integer.valueOf(string) : ((Integer) defaultValue)));
         }
 
         if (type == Byte.class) {
-            return (T) Byte.valueOf((byte) getInt(path, defaultValue instanceof String ? Byte.valueOf((String) defaultValue) : ((Byte) defaultValue)));
+            return (T) Byte.valueOf((byte) getInt(path, defaultValue instanceof String string ? Byte.valueOf(string) : ((Byte) defaultValue)));
         }
 
         if (type == Float.class) {
-            return (T) Float.valueOf(Double.valueOf(getDouble(path, defaultValue instanceof String ? Double.parseDouble((String) defaultValue) : ((Float) defaultValue).doubleValue())).floatValue());
+            return (T) Float.valueOf(Double.valueOf(getDouble(path, defaultValue instanceof String string ? Double.parseDouble(string) : ((Float) defaultValue).doubleValue())).floatValue());
         }
 
         if (type == Long.class) {
-            return (T) Long.valueOf(getLong(path, defaultValue instanceof String ? Long.valueOf((String) defaultValue) : ((Long) defaultValue)));
+            return (T) Long.valueOf(getLong(path, defaultValue instanceof String string ? Long.valueOf(string) : ((Long) defaultValue)));
         }
 
         if (type == Short.class) {
-            return (T) Short.valueOf((short) getInt(path, defaultValue instanceof String ? Short.valueOf((String) defaultValue) : ((Short) defaultValue)));
+            return (T) Short.valueOf((short) getInt(path, defaultValue instanceof String string ? Short.valueOf(string) : ((Short) defaultValue)));
         }
 
         var result = getObject(path, type);

--- a/core/src/main/java/me/mykindos/betterpvp/core/config/ExtendedYamlConfiguration.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/config/ExtendedYamlConfiguration.java
@@ -1,15 +1,16 @@
 package me.mykindos.betterpvp.core.config;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
 import lombok.CustomLog;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 
 @CustomLog
 public class ExtendedYamlConfiguration extends YamlConfiguration {
@@ -72,8 +73,32 @@ public class ExtendedYamlConfiguration extends YamlConfiguration {
             set(path, defaultValue);
         }
 
-        if(type == List.class) {
+        if (type == List.class) {
             return (T) Objects.requireNonNull(getList(path));
+        }
+
+        if (type == Double.class) {
+            return (T) Double.valueOf(getDouble(path, defaultValue instanceof String ? Double.valueOf((String) defaultValue) : ((Double) defaultValue)));
+        }
+
+        if (type == Integer.class) {
+            return (T) Integer.valueOf(getInt(path, defaultValue instanceof String ? Integer.valueOf((String) defaultValue) : ((Integer) defaultValue)));
+        }
+
+        if (type == Byte.class) {
+            return (T) Byte.valueOf((byte) getInt(path, defaultValue instanceof String ? Byte.valueOf((String) defaultValue) : ((Byte) defaultValue)));
+        }
+
+        if (type == Float.class) {
+            return (T) Float.valueOf(Double.valueOf(getDouble(path, defaultValue instanceof String ? Double.parseDouble((String) defaultValue) : ((Float) defaultValue).doubleValue())).floatValue());
+        }
+
+        if (type == Long.class) {
+            return (T) Long.valueOf(getLong(path, defaultValue instanceof String ? Long.valueOf((String) defaultValue) : ((Long) defaultValue)));
+        }
+
+        if (type == Short.class) {
+            return (T) Short.valueOf((short) getInt(path, defaultValue instanceof String ? Short.valueOf((String) defaultValue) : ((Short) defaultValue)));
         }
 
         var result = getObject(path, type);

--- a/core/src/main/java/me/mykindos/betterpvp/core/config/implementations/ConfigProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/config/implementations/ConfigProvider.java
@@ -53,7 +53,7 @@ public class ConfigProvider<T> implements Provider<T> {
         }
 
 
-        T value = plugin.getConfig(configName).getOrSaveObject(configPath, castedDefault, type);
+        T value = plugin.getConfig(configName).getOrSaveObject(configPath, (T) castedDefault, type);
         plugin.saveConfig();
 
         return value;

--- a/core/src/main/java/me/mykindos/betterpvp/core/config/implementations/ConfigProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/config/implementations/ConfigProvider.java
@@ -53,7 +53,7 @@ public class ConfigProvider<T> implements Provider<T> {
         }
 
 
-        T value = plugin.getConfig(configName).getOrSaveObject(configPath, (T) castedDefault, type);
+        T value = plugin.getConfig(configName).getOrSaveObject(configPath, castedDefault, type);
         plugin.saveConfig();
 
         return value;

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/config/Config.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/config/Config.java
@@ -79,7 +79,7 @@ public class Config {
      * @param <T>          The type of default value
      * @return returns the config value if exists, or the default value if it does not. Saves the default value if no value exists
      */
-    public <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+    public <T> T getConfig(String name, T defaultValue, Class<T> type) {
         return plugin.getConfig(path).getOrSaveObject(getPath(prefix + name), defaultValue, type);
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/tips/Tip.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/tips/Tip.java
@@ -50,7 +50,7 @@ public abstract class Tip {
         return Component.empty();
     }
 
-    protected <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+    protected <T> T getConfig(String name, T defaultValue, Class<T> type) {
         String path  = "tips." + getName().toLowerCase().replace(" ", "") + "." + name;
         return this.plugin.getConfig().getOrSaveObject(path, defaultValue, type);
     }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/ProgressionSkill.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/ProgressionSkill.java
@@ -44,7 +44,7 @@ public abstract class ProgressionSkill implements IProgressionSkill {
         }
     }
 
-    protected <T> T getConfig(String name, Object defaultValue, Class<T> type) {
+    protected <T> T getConfig(String name, T defaultValue, Class<T> type) {
         String path = "skills." + getName().toLowerCase().replace(" ", "_") + "." + name;
         return progression.getConfig("professions/" + getProgressionTree().toLowerCase()).getOrSaveObject(path, defaultValue, type);
     }


### PR DESCRIPTION
Change getOrSaveObject to use the relevant default getOrDefault for retrieval for Number based things. Keep support for String conversions for @Config annotations. Guards against incorrectly formatted number values in the config.

Fixes #1852

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
