### PR TITLE
Fix teleport skills blocking thread execution and starving resources. Change to completable future for activate (that is used to track whether a skill was used or not)

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -79,10 +79,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.Map;
 import java.util.WeakHashMap;
 
 @Singleton
@@ -198,9 +198,7 @@ public class SkillListener implements Listener {
         int level = event.getLevel();
 
         if (skill instanceof InteractSkill interactSkill) {
-            if (!interactSkill.activate(player, level)) {
-                event.setCancelled(true);
-            }
+            event.setActivated(interactSkill.activate(player, level));
         } else if (skill instanceof ToggleSkill toggleSkill) {
             toggleSkill.toggle(player, level);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
@@ -154,14 +154,12 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         double maxDistance = getMaxTravelDistance(level);
         final Location origin = player.getLocation();
-        CompletableFuture<Boolean> activateFuture = new CompletableFuture<>();
-        UtilLocation.teleportForward(player, maxDistance, false, success -> {
+        return UtilLocation.teleportForward(player, maxDistance, false).thenApply(success -> {
             if (!Boolean.TRUE.equals(success)) {
-                activateFuture.complete(false);
-                return;
+                return false;
             }
 
             final Location lineStart = origin.add(0.0, player.getHeight() / 2, 0.0);
@@ -174,9 +172,8 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
             championsManager.getCooldowns().use(player, "Deblink", 0.25, false);
             player.getWorld().playEffect(origin, Effect.BLAZE_SHOOT, 0);
             player.getWorld().playEffect(lineEnd, Effect.BLAZE_SHOOT, 0);
-            activateFuture.complete(true);
+            return true;
         });
-        return activateFuture.join();
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.axe;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.champions.Champions;
 import me.mykindos.betterpvp.champions.champions.ChampionsManager;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
@@ -36,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
+@CustomLog
 public class Flash extends Skill implements InteractSkill, Listener, MovementSkill {
 
     private final WeakHashMap<Player, FlashData> charges = new WeakHashMap<>();
@@ -161,20 +163,17 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         final Location origin = player.getLocation();
-        CompletableFuture<Boolean> activatedFuture = new CompletableFuture<>();
-        UtilLocation.teleportForward(player, teleportDistance, false, success -> {
+        return UtilLocation.teleportForward(player, teleportDistance, false).thenApply(success -> {
             if (!Boolean.TRUE.equals(success)) {
-                activatedFuture.complete(false);
-                return;
+                return false;
             }
 
             // Lessen charges and add cooldown to prevent from instantly getting a flash charge if they're full
             FlashData flashData = charges.get(player);
             if (flashData == null) {
-                activatedFuture.complete(false);
-                return;
+                return false;
             }
 
             final int curCharges = flashData.getCharges();
@@ -196,10 +195,9 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
 
             player.getWorld().playSound(origin, Sound.ENTITY_WITHER_SHOOT, 0.4F, 1.2F);
             player.getWorld().playSound(origin, Sound.ENTITY_SILVERFISH_DEATH, 1.0F, 1.6F);
-            activatedFuture.complete(true);
+            return true;
 
         });
-        return activatedFuture.join();
     }
 
     @UpdateEvent(delay = 100)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
@@ -29,6 +29,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.util.Vector;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class Leap extends Skill implements InteractSkill, CooldownSkill, Listener, MovementSkill {
@@ -69,12 +71,12 @@ public class Leap extends Skill implements InteractSkill, CooldownSkill, Listene
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (!wallKick(player)) {
             doLeap(player, false);
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(false);
     }
 
     public void doLeap(Player player, boolean wallkick) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -23,6 +23,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
@@ -106,10 +108,10 @@ public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -20,6 +20,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
@@ -99,10 +101,10 @@ public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
@@ -24,6 +24,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -77,13 +78,13 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (!active.contains(player.getUniqueId())) {
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
             active.add(player.getUniqueId());
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -24,6 +24,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -83,13 +84,13 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (!active.contains(player.getUniqueId())) {
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
             active.add(player.getUniqueId());
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -22,6 +22,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class Concussion extends PrepareSkill implements CooldownSkill, Listener, DebuffSkill, OffensiveSkill {
@@ -109,9 +111,9 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -39,6 +39,7 @@ import org.bukkit.util.Vector;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -124,7 +125,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
             direction.multiply(new Vector(-1, 1, -1)); // flip horizontal
         }
 
-        UtilLocation.teleportToward(player, direction, distance, false, success -> {
+        UtilLocation.teleportToward(player, direction, distance, false).thenAccept(success -> {
             if (!Boolean.TRUE.equals(success)) {
                 return;
             }
@@ -232,10 +233,10 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
         handRaisedTime.put(player.getUniqueId(), System.currentTimeMillis());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/ExcessiveForce.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -114,14 +115,14 @@ public class ExcessiveForce extends Skill implements InteractSkill, CooldownSkil
 
     // entrypoint
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
 
         // current time + duration in milliseconds = time in future when ability expires
         final long expirationTimeInMillis = System.currentTimeMillis() + (long) (getDuration(level) * 1000L);
         active.put(player, expirationTimeInMillis);
 
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ILLUSIONER_PREPARE_MIRROR, 1f, 1.7f);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -86,10 +86,9 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         final Location originalLocation = player.getLocation();
-        CompletableFuture<Boolean> activatedFuture = new CompletableFuture<>();
-        UtilLocation.teleportForward(player, getDistance(level), false, success -> {
+        return UtilLocation.teleportForward(player, getDistance(level), false).thenApply(success -> {
             final Location lineStart = originalLocation.add(0.0, player.getHeight() / 2, 0.0);
             Particle.SWEEP_ATTACK.builder()
                     .location(lineStart.clone().add(player.getLocation().getDirection()))
@@ -100,8 +99,7 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0F, 1.6F);
 
             if (Boolean.FALSE.equals(success)) {
-                activatedFuture.complete(false);
-                return;
+                return false;
             }
 
             final Location teleportLocation = player.getLocation();
@@ -127,9 +125,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
                                     .map(LivingEntity.class::cast)
                                     .forEach(hit -> hit(player, level, hit)),
                             () -> UtilMessage.message(player, getClassType().getName(), "You missed <alt>%s</alt>.", getName()));
-            activatedFuture.complete(true);
+            return true;
         });
-        return activatedFuture.join();
     }
 
     private void hit(Player caster, int level, LivingEntity hit) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -205,7 +206,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         Vector vec = new Vector(0, 1.3, 0);
         VelocityData velocityData = new VelocityData(vec, 1, false, 0, 1.0, 1, true);
         UtilVelocity.velocity(player, null, velocityData, VelocityType.CUSTOM);
@@ -230,7 +231,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
             }
         }.runTaskLater(champions, 15);
         jumps.put(player, task);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Skullsplitter.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Skullsplitter.java
@@ -30,6 +30,7 @@ import org.bukkit.util.Vector;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -94,8 +95,8 @@ public class Skullsplitter extends Skill implements InteractSkill, Listener, Coo
     }
 
     @Override
-    public boolean activate(Player player, int level) {
-        if (!isHolding(player)) return false;
+    public CompletableFuture<Boolean> activate(Player player, int level) {
+        if (!isHolding(player)) return CompletableFuture.completedFuture(false);
 
         SkullsplitterProjectile existing = data.remove(player);
         if (existing != null) {
@@ -124,7 +125,7 @@ public class Skullsplitter extends Skill implements InteractSkill, Listener, Coo
         projectile.redirect(direction);
 
         data.put(player, projectile);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -199,7 +200,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     }
 
     @Override
-    public boolean activate(Player player, int leel) {
+    public CompletableFuture<Boolean> activate(Player player, int leel) {
         Vector vec = player.getLocation().getDirection();
         VelocityData velocityData = new VelocityData(vec, velocityStrength, false, 0.0D, 0.4D, 0.6D, false);
         UtilVelocity.velocity(player, null, velocityData, VelocityType.CUSTOM);
@@ -211,7 +212,7 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
             }
         }, 1000));
         active.put(player, System.currentTimeMillis());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -108,7 +109,7 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_GROWL, 2.0F, 2.0F);
 
         Location start = player.getEyeLocation().add(player.getEyeLocation().getDirection().normalize().multiply(startDistance));
@@ -125,7 +126,7 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
 
         ThreateningShoutData data = new ThreateningShoutData(points, 0, new HashSet<>(), new HashSet<>());
         playerDataMap.put(player, data);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BattleTaunt.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BattleTaunt.java
@@ -31,6 +31,7 @@ import org.bukkit.event.block.Action;
 
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -136,8 +137,8 @@ public class BattleTaunt extends ChannelSkill implements InteractSkill, Cooldown
     }
 
     @Override
-    public boolean activate(Player player, int level) {
-        return active.add(player.getUniqueId());
+    public CompletableFuture<Boolean> activate(Player player, int level) {
+        return CompletableFuture.completedFuture(active.add(player.getUniqueId()));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BlockToss.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/BlockToss.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -145,7 +146,7 @@ public class BlockToss extends ChargeSkill implements Listener, InteractSkill, C
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         final Location feetLocation = player.getLocation();
 
         // Clone the blocks under the player to add realism
@@ -166,7 +167,7 @@ public class BlockToss extends ChargeSkill implements Listener, InteractSkill, C
         }
 
         if (chargingMap.containsKey(player)) {
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
 
         final BlockTossObject boulder = new BlockTossObject(clonedBlocks, this, player);
@@ -175,7 +176,7 @@ public class BlockToss extends ChargeSkill implements Listener, InteractSkill, C
         final BoulderChargeData chargeData = new BoulderChargeData((float) getChargePerSecond(level), boulder);
         chargingMap.put(player, chargeData);
         boulders.computeIfAbsent(player, key -> new ArrayList<>()).add(boulder);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
@@ -28,6 +28,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkill, CrowdControlSkill, DamageSkill {
 
@@ -86,7 +88,7 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         Vector vector = player.getLocation().toVector();
         vector.setY(vector.getY() + 2);
 
@@ -105,7 +107,7 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
             }
         }
         createWhirlwind(player, level);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private void createWhirlwind(Player player, int level) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
@@ -36,6 +36,7 @@ import org.bukkit.event.block.Action;
 
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -87,12 +88,12 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         championsManager.getEffects().addEffect(player, EffectTypes.SPEED, getName(), speedStrength, (long) (getSpeedDuration(level) * 1000L));
         UtilSound.playSound(player.getWorld(), player, Sound.ENTITY_ENDERMAN_SCREAM, 1.5F, 0);
         player.getWorld().playEffect(player.getLocation(), Effect.STEP_SOUND, Material.OBSIDIAN);
         running.put(player.getUniqueId(), System.currentTimeMillis() + (long)(getSpeedDuration(level) * 1000));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/HoldPosition.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/HoldPosition.java
@@ -29,6 +29,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -101,7 +102,7 @@ public class HoldPosition extends Skill implements InteractSkill, CooldownSkill,
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         long duration = (long) (getDuration(level) * 1000);
         championsManager.getEffects().addEffect(player, player, EffectTypes.RESISTANCE, resistanceStrength, duration);
         championsManager.getEffects().addEffect(player, player, EffectTypes.SLOWNESS, slownessStrength, duration);
@@ -126,7 +127,7 @@ public class HoldPosition extends Skill implements InteractSkill, CooldownSkill,
                 ticksRun++;
             }
         }.runTaskTimer(champions, 0, 1);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private void spawnMobSpellParticles(Player player) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/MagneticAxe.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/MagneticAxe.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static me.mykindos.betterpvp.core.utilities.Resources.ItemModel.INVISIBLE;
 
@@ -124,8 +125,8 @@ public class MagneticAxe extends Skill implements InteractSkill, Listener, Coold
     }
 
     @Override
-    public boolean activate(Player player, int level) {
-        if (!isHolding(player)) return false;
+    public CompletableFuture<Boolean> activate(Player player, int level) {
+        if (!isHolding(player)) return CompletableFuture.completedFuture(false);
 
         ItemStack axeItem = player.getInventory().getItemInMainHand();
         int slot = player.getInventory().getHeldItemSlot();
@@ -153,7 +154,7 @@ public class MagneticAxe extends Skill implements InteractSkill, Listener, Coold
         projectile.redirect(direction);
 
         data.computeIfAbsent(player, key -> new ArrayList<>()).add(projectile);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
@@ -42,6 +42,7 @@ import org.bukkit.util.Vector;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -120,7 +121,7 @@ public class ShieldSmash extends Skill implements InteractSkill, CooldownSkill, 
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         final Location bashLocation = player.getLocation().add(0, 0.8, 0);
         bashLocation.add(player.getLocation().getDirection().setY(0).normalize().multiply(1.5));
 
@@ -193,7 +194,7 @@ public class ShieldSmash extends Skill implements InteractSkill, CooldownSkill, 
         } else {
             UtilMessage.simpleMessage(player, "Skill", "You missed <alt>%s</alt>.", getName());
         }
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/UnstoppableForce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/UnstoppableForce.java
@@ -43,6 +43,7 @@ import org.bukkit.util.RayTraceResult;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @BPvPListener
 @Singleton
@@ -83,14 +84,14 @@ public class UnstoppableForce extends ChannelSkill implements InteractSkill, Ene
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (championsManager.getCooldowns().hasCooldown(player, getName())) {
             UtilMessage.simpleMessage(player, "Cooldown", "You cannot use <alt>%s %s</alt> for <alt>%s</alt> seconds.", getName(), level,
                     Math.max(0, championsManager.getCooldowns().getAbilityRecharge(player, getName()).getRemaining()));
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Battlebind.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Battlebind.java
@@ -26,6 +26,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -89,7 +90,7 @@ public class Battlebind extends Skill implements InteractSkill, Listener, Cooldo
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ITEM_TRIDENT_THROW, 1.0F, 2.0F);
 
         BattlebindProjectile existing = data.remove(player);
@@ -113,7 +114,7 @@ public class Battlebind extends Skill implements InteractSkill, Listener, Cooldo
         data.redirect(player.getLocation().getDirection().multiply(getSpeed()));
 
         this.data.put(player, data);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/DefensiveStance.java
@@ -35,6 +35,7 @@ import org.bukkit.util.Vector;
 
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -186,9 +187,9 @@ public class DefensiveStance extends ChannelSkill implements CooldownSkill, Inte
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Ride.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Ride.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -68,7 +69,7 @@ public class Ride extends Skill implements InteractSkill, CooldownSkill, Listene
         };
     }
 
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
 
         player.getWorld().playSound(player.getLocation(), Sound.ITEM_GOAT_HORN_SOUND_0, 2.0f, 1f);
 
@@ -88,7 +89,7 @@ public class Ride extends Skill implements InteractSkill, CooldownSkill, Listene
         long calculatedLifespan = (long) (lifespan + (level - 1)) * 1000;
         HorseData data = new HorseData(horse, System.currentTimeMillis(), calculatedLifespan);
         horseData.put(player, data);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent(delay = 500)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 
 @Singleton
@@ -160,12 +161,12 @@ public class Riposte extends ChannelSkill implements CooldownSkill, InteractSkil
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 2.0f, 1.3f);
 
         Particle.LARGE_SMOKE.builder().location(player.getLocation().add(0, 0.25, 0)).receivers(20).extra(0).spawn();
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/VanguardsMight.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -197,10 +198,10 @@ public class VanguardsMight extends ChannelSkill implements CooldownSkill, Inter
 
     // entry pt
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
         data.put(player, new VanguardsMightData(0f, VanguardsMightAbilityPhase.CHANNELING));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
@@ -33,6 +33,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -100,7 +101,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         championsManager.getEffects().addEffect(player, player, EffectTypes.HEALTH_BOOST, getName(), healthBoostStrength, (long) (getDuration(level) * 1000L));
         AttributeInstance playerMaxHealth = player.getAttribute(Attribute.MAX_HEALTH);
         player.playSound(player, Sound.ENTITY_ZOMBIE_VILLAGER_CONVERTED, 1f, 0.8f);
@@ -159,7 +160,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
             }
         }.runTaskTimer(champions, 0, 1);
 
-        return true;
+        return CompletableFuture.completedFuture(true);
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/FireBlast.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 import static me.mykindos.betterpvp.core.combat.cause.DamageCauseCategory.RANGED;
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.FIRE;
@@ -231,14 +232,14 @@ public class FireBlast extends Skill implements InteractSkill, CooldownSkill, Li
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         LargeFireball fireball = player.launchProjectile(LargeFireball.class, player.getLocation().getDirection().multiply(speed));
         fireball.setYield(0);
         fireball.setIsIncendiary(false);
 
         fireballs.add(fireball);
         fireball.getWorld().playSound(fireball.getLocation(), Sound.ENTITY_BLAZE_SHOOT, 1.0f, 1.5f);
-        return true;
+        return CompletableFuture.completedFuture(true);
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -44,6 +44,7 @@ import org.bukkit.event.block.Action;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 
 @Singleton
@@ -128,9 +129,9 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
         return true;
     }
 
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         activeCasts.add(createFissure(player, level));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -36,6 +36,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @CustomLog
 @Singleton
@@ -152,7 +153,7 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         Item item = player.getWorld().dropItem(player.getEyeLocation(), new ItemStack(Material.ICE));
         item.setVelocity(player.getLocation().getDirection().multiply(speed));
         ThrowableItem throwableItem = new ThrowableItem(this, item, player, getName(), 10000, true);
@@ -160,7 +161,7 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
         throwableItem.setCanHitFriendlies(true);
         championsManager.getThrowables().addThrowable(throwableItem);
         throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.ENTITY_SILVERFISH_HURT, 2f, 1f);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/LightningOrb.java
@@ -34,6 +34,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class LightningOrb extends Skill implements InteractSkill, CooldownSkill, Listener, ThrowableListener, OffensiveSkill, DamageSkill, DebuffSkill {
@@ -152,7 +154,7 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         Item orb = player.getWorld().dropItem(player.getEyeLocation().add(player.getLocation().getDirection().multiply(velocityStrength)), new ItemStack(Material.DIAMOND_BLOCK));
         orb.setVelocity(player.getLocation().getDirection());
         orb.setCanPlayerPickup(false);
@@ -160,7 +162,7 @@ public class LightningOrb extends Skill implements InteractSkill, CooldownSkill,
         ThrowableItem throwableItem = new ThrowableItem(this, orb, player, "Lightning Orb", 5000, false);
         championsManager.getThrowables().addThrowable(throwableItem);
         throwableItem.getLastLocation().getWorld().playSound(throwableItem.getLastLocation(), Sound.ENTITY_SILVERFISH_HURT, 2f, 1f);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Rupture.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Rupture.java
@@ -45,6 +45,7 @@ import org.joml.Vector3f;
 
 import java.util.ArrayList;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -119,7 +120,7 @@ public class Rupture extends Skill implements Listener, InteractSkill, CooldownS
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         // calculate it from player yaw
         final double yaw = Math.toRadians(player.getLocation().getYaw() + 90.0F);
         final Vector vector = new Vector(Math.cos(yaw), 0, Math.sin(yaw)).normalize().multiply(0.6D);
@@ -209,7 +210,7 @@ public class Rupture extends Skill implements Listener, InteractSkill, CooldownS
                 cooldownJump.get(player).clear();
             }
         }.runTaskLater(champions, 40);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private Block getNearestSolidBlock(Location location) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Blizzard.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Blizzard.java
@@ -31,6 +31,7 @@ import org.bukkit.util.Vector;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -196,13 +197,12 @@ public class Blizzard extends ChannelSkill implements InteractSkill, EnergyChann
     }
 
     @Override
-    public boolean activate(Player player, int level) {
-        //todo, does this double the initial energy cost?
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (championsManager.getEnergy().use(player, getName(), initialEnergyCost, true)) {
             active.add(player.getUniqueId());
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Inferno.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Inferno.java
@@ -41,6 +41,7 @@ import org.bukkit.util.Vector;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -115,9 +116,9 @@ public class Inferno extends ChannelSkill implements InteractSkill, EnergyChanne
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent(delay = 125)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Pestilence.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Pestilence.java
@@ -31,6 +31,7 @@ import org.bukkit.event.block.Action;
 
 import java.util.Iterator;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Singleton
@@ -187,9 +188,9 @@ public class Pestilence extends ChannelSkill implements InteractSkill, CooldownS
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         charging.put(player, new ChargeData((float) (0.1 + (level - 1) * 0.05) * 5));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/StaticLazer.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/StaticLazer.java
@@ -42,6 +42,7 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -144,9 +145,9 @@ public class StaticLazer extends ChargeSkill implements InteractSkill, EnergyCha
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         charging.put(player, new ChargeData((float) getChargePerSecond(level)));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     public boolean use(Player player, ChargeData charge, int level) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Swarm.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/sword/Swarm.java
@@ -42,6 +42,7 @@ import java.util.ListIterator;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.PROJECTILE;
 
@@ -222,13 +223,13 @@ public class Swarm extends ChannelSkill implements InteractSkill, EnergyChannelS
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
         if (!batData.containsKey(player)) {
             batData.put(player, new ArrayList<>());
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/Agility.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -180,14 +181,14 @@ public class Agility extends Skill implements InteractSkill, CooldownSkill, List
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         if (!active.containsKey(player.getUniqueId())) {
             championsManager.getEffects().addEffect(player, EffectTypes.SPEED, getName(), speedStrength, (long) (getDuration(level) * 1000));
             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 0.5F, 0.5F);
             active.put(player.getUniqueId(), (long) (System.currentTimeMillis() + (getDuration(level) * 1000L)));
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
-        return false;
+        return CompletableFuture.completedFuture(false);
     }
 
     public void deactivate(Player player) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WindBurst.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WindBurst.java
@@ -39,6 +39,7 @@ import org.bukkit.util.Vector;
 
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -117,9 +118,9 @@ public class WindBurst extends Skill implements InteractSkill, CooldownSkill, Li
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         windBurst(player, level);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private void windBurst(Player player, int level) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolfsFury.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/axe/WolfsFury.java
@@ -33,6 +33,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -180,11 +181,11 @@ public class WolfsFury extends Skill implements InteractSkill, CooldownSkill, Li
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_WOLF_GROWL, 2f, 1.2f);
         active.put(player, (long) (System.currentTimeMillis() + (getDuration(level) * 1000L)));
         championsManager.getEffects().addEffect(player, EffectTypes.STRENGTH, getName(), getStrengthLevel(level), (long) (getDuration(level) * 1000L));
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     public void deactivate(Player player) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/ExplosiveArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/ExplosiveArrow.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.PROJECTILE;
 
@@ -129,10 +130,10 @@ public class ExplosiveArrow extends PrepareArrowSkill implements DamageSkill, Of
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -22,6 +22,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill, DebuffSkill {
@@ -75,10 +77,10 @@ public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -109,10 +110,10 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/NapalmArrow.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.FIRE;
 
@@ -177,10 +178,10 @@ public class NapalmArrow extends PrepareArrowSkill implements ThrowableListener,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/RopedArrow.java
@@ -30,6 +30,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.util.Vector;
 
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @BPvPListener
 public class RopedArrow extends PrepareArrowSkill implements MovementSkill {
@@ -72,10 +74,10 @@ public class RopedArrow extends PrepareArrowSkill implements MovementSkill {
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StormSphere.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/StormSphere.java
@@ -40,6 +40,7 @@ import org.bukkit.metadata.FixedMetadataValue;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 
 @Singleton
@@ -113,10 +114,10 @@ public class StormSphere extends PrepareArrowSkill implements AreaOfEffectSkill,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent(delay = 100)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.PROJECTILE;
 
@@ -136,10 +137,10 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TriShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TriShot.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -127,7 +128,7 @@ public class TriShot extends PrepareArrowSkill implements OffensiveSkill {
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         UUID playerId = player.getUniqueId();
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BLAZE_AMBIENT, 2.5F, 2.0F);
         dataMap.put(playerId, new TriShotData(0, System.currentTimeMillis(), 0L));
@@ -136,7 +137,7 @@ public class TriShot extends PrepareArrowSkill implements OffensiveSkill {
 
         Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
         gamer.getActionBar().add(50, actionBarComponent);
-        return true;
+        return CompletableFuture.completedFuture(true);
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 
 @Singleton
@@ -123,12 +124,12 @@ public class Bullseye extends ChannelSkill implements CooldownSkill, InteractSki
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         UUID playerUUID = player.getUniqueId();
         active.add(playerUUID);
         BullsEyeData playerBullsEyeData = new BullsEyeData(player, new ChargeData((float) (0.01)), null, null, null);
         bullsEyeData.put(playerUUID, playerBullsEyeData);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Disengage.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Disengage.java
@@ -36,6 +36,7 @@ import org.bukkit.util.Vector;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -165,11 +166,11 @@ public class Disengage extends ChannelSkill implements CooldownSkill, InteractSk
     }
 
     @Override
-    public boolean activate(Player player, int level) {
-        UUID playerId = player.getUniqueId();
+    public CompletableFuture<Boolean> activate(Player player, int level) {
+        final UUID playerId = player.getUniqueId();
         active.add(playerId);
         handRaisedTime.put(playerId, System.currentTimeMillis());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WindDagger.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WindDagger.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -103,7 +104,7 @@ public class WindDagger extends Skill implements InteractSkill, Listener, Cooldo
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         player.getWorld().playSound(player.getLocation(), Sound.ITEM_TRIDENT_THROW, 1.0F, 2.0F);
 
         DaggerProjectile existingData = daggerDataMap.remove(player);
@@ -125,7 +126,7 @@ public class WindDagger extends Skill implements InteractSkill, Listener, Cooldo
         data.redirect(player.getLocation().getDirection().multiply(getSpeed()));
 
         daggerDataMap.put(player, data);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/BloodBarrier.java
@@ -39,6 +39,7 @@ import org.bukkit.util.Vector;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -193,7 +194,7 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         double healthReduction = getHealthReduction(level);
 
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_EVOKER_PREPARE_ATTACK, 2.0f, 1.0f);
@@ -234,7 +235,7 @@ public class BloodBarrier extends Skill implements InteractSkill, CooldownSkill,
                 }
             }
         }
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -29,6 +29,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, HealthSkill, OffensiveSkill, TeamSkill, BuffSkill {
@@ -102,7 +103,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         double healthReduction = getHealthReduction(level);
 
 
@@ -145,7 +146,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
                     this.cancel();
             }
         }.runTaskTimer(champions, 0, 1);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -30,6 +30,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.util.Vector;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -117,7 +118,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         double healthReduction = getHealthReduction(level);
 
 
@@ -165,7 +166,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
             }
         }
 
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Clone.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Clone.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -139,14 +140,14 @@ public class Clone extends Skill implements InteractSkill, CooldownSkill, Listen
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
 
         if (championsManager.getEffects().hasEffect(player, EffectTypes.PROTECTION)) {
             UtilMessage.message(player, "Clone", "You cannot use this skill with protection");
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
         //Check if player already has a clone - mainly to prevent op'd players from spamming clones
-        if (clones.containsKey(player)) return false;
+        if (clones.containsKey(player)) return CompletableFuture.completedFuture(false);
 
 
         double healthReduction = getHealthReduction(level);
@@ -178,7 +179,7 @@ public class Clone extends Skill implements InteractSkill, CooldownSkill, Listen
         MobPathfinder mobPathfinder = new MobPathfinder(champions, clone, initTarget);
         clones.put(player, new CloneData(clone, mobPathfinder, System.currentTimeMillis()));
         Bukkit.getMobGoals().addGoal(clone, 0, mobPathfinder);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent(delay = 100)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/TormentedSoil.java
@@ -36,6 +36,7 @@ import org.bukkit.event.block.Action;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -168,7 +169,7 @@ public class TormentedSoil extends Skill implements InteractSkill, CooldownSkill
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
 
         double healthReduction = getHealthReduction(level);
         UtilPlayer.slowHealth(champions, player, -healthReduction, 5, false);
@@ -184,7 +185,7 @@ public class TormentedSoil extends Skill implements InteractSkill, CooldownSkill
         }
         tormentList.add(new Torment(player, loc.add(0, 0.5, 0), level));
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ILLUSIONER_PREPARE_BLINDNESS, 2f, 1.3f);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/BloodSphere.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/BloodSphere.java
@@ -25,6 +25,7 @@ import org.bukkit.event.block.Action;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -119,7 +120,7 @@ public class BloodSphere extends Skill implements CooldownSkill, InteractSkill, 
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         BloodSphereProjectile projectile = new BloodSphereProjectile(player,
                 0.6,
                 player.getEyeLocation(),
@@ -137,7 +138,7 @@ public class BloodSphere extends Skill implements CooldownSkill, InteractSkill, 
         projectile.redirect(player.getLocation().getDirection());
         projectiles.put(player, projectile);
         UtilMessage.simpleMessage(player, getClassType().getName(), "You used <alt>%s %d</alt>.", getName(), level);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private float getGrowthPerSecond(int level) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Grasp.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Grasp.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 import static me.mykindos.betterpvp.core.combat.cause.DamageCauseCategory.RANGED;
 
@@ -157,7 +158,7 @@ public class Grasp extends Skill implements InteractSkill, CooldownSkill, Listen
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         Block block = player.getTargetBlock(null, (int) getDistance(level));
         Location startPos = player.getLocation();
 
@@ -231,7 +232,7 @@ public class Grasp extends Skill implements InteractSkill, CooldownSkill, Listen
             }
 
         }.runTaskLater(champions, 40);
-        return true;
+        return CompletableFuture.completedFuture(true);
 
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Leech.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Leech.java
@@ -37,6 +37,7 @@ import org.bukkit.util.Vector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import static me.mykindos.betterpvp.core.combat.cause.DamageCauseCategory.MAGIC;
 
@@ -182,9 +183,9 @@ public class Leech extends PrepareSkill implements CooldownSkill, HealthSkill, O
     }
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Wreath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/sword/Wreath.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -264,10 +265,10 @@ public class Wreath extends Skill implements InteractSkill, Listener, HealthSkil
 
 
     @Override
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         WreathData wreathData = charges.get(player);
         if (wreathData == null) {
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
 
         final int curCharges = wreathData.getCharges();
@@ -280,7 +281,7 @@ public class Wreath extends Skill implements InteractSkill, Listener, HealthSkil
 
         final int newCharges = curCharges - 1;
         wreathData.setCharges(newCharges);
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChargeSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ChargeSkill.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.Player;
 
 import java.util.Iterator;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+
 @CustomLog
 public abstract class ChargeSkill extends ChannelSkill {
     protected final WeakHashMap<Player, ChargeData> charging = new WeakHashMap<>();
@@ -22,10 +24,10 @@ public abstract class ChargeSkill extends ChannelSkill {
         charging.remove(player);
     }
 
-    public boolean activate(Player player, int level) {
+    public CompletableFuture<Boolean> activate(Player player, int level) {
         charging.put(player, new ChargeData((float) getChargePerSecond(level)));
         active.add(player.getUniqueId());
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     @UpdateEvent

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/InteractSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/InteractSkill.java
@@ -4,15 +4,18 @@ import me.mykindos.betterpvp.core.components.champions.IChampionsSkill;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface InteractSkill extends IChampionsSkill {
 
     /**
-     * Returns true if this skill was used, false otherwise
+     * Activates the skill for the given player and level. The CompletableFuture should complete with true if the skill was successfully activated, or false if it failed to activate (e.g. due to cooldown, insufficient resources, etc.).
+     *
      * @param player
      * @param level
      * @return
      */
-    boolean activate(Player player, int level);
+    CompletableFuture<Boolean> activate(Player player, int level);
 
     Action[] getActions();
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/listeners/SkillStatListeners.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/listeners/SkillStatListeners.java
@@ -36,6 +36,16 @@ public class SkillStatListeners implements Listener {
                 .skill(event.getSkill())
                 .level(event.getLevel())
                 .build();
+        //only increment active skill if it was used
+        if (event.getActivated() != null) {
+            event.getActivated().thenApply(success -> {
+                if (success) {
+                    statContainer.incrementStat(skillStat, 1);
+                }
+                return null;
+            });
+            return;
+        }
         statContainer.incrementStat(skillStat, 1);
 
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/components/champions/events/PlayerUseSkillEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/components/champions/events/PlayerUseSkillEvent.java
@@ -5,6 +5,9 @@ import lombok.EqualsAndHashCode;
 import me.mykindos.betterpvp.core.components.champions.IChampionsSkill;
 import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -13,5 +16,7 @@ public class PlayerUseSkillEvent extends CustomCancellableEvent {
     private final Player player;
     private final IChampionsSkill skill;
     private final int level;
+    @Nullable
+    private CompletableFuture<Boolean> activated = null;
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilLocation.java
@@ -20,7 +20,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -67,11 +66,9 @@ public class UtilLocation {
      * @param entity           the {@link LivingEntity} to be teleported. Must not be null.
      * @param teleportDistance the distance (in blocks) to teleport the entity forward.
      * @param fallDamage       whether the entity should take fall damage as a result of the teleport.
-     * @param then             an optional {@link Consumer} that receives a boolean indicating whether the teleportation
-     *                         was successful. Can be null.
      */
-    public static void teleportForward(final @NotNull LivingEntity entity, double teleportDistance, boolean fallDamage, @Nullable Consumer<Boolean> then) {
-        teleportToward(entity, entity.getEyeLocation().getDirection(), teleportDistance, fallDamage, then);
+    public static CompletableFuture<Boolean> teleportForward(final @NotNull LivingEntity entity, double teleportDistance, boolean fallDamage) {
+        return teleportToward(entity, entity.getEyeLocation().getDirection(), teleportDistance, fallDamage);
     }
 
     /**
@@ -83,18 +80,14 @@ public class UtilLocation {
      * @param direction        The direction vector determining the teleportation direction. Must not be null.
      * @param teleportDistance The maximum distance the entity can be teleported.
      * @param fallDamage       Whether the entity should take fall damage upon teleportation.
-     * @param then             An optional callback to handle the result of the teleportation operation (true if successful, false otherwise).
      */
-    public static void teleportToward(final @NotNull LivingEntity entity, final @NotNull Vector direction, double teleportDistance, boolean fallDamage, @Nullable Consumer<Boolean> then) {
+    public static CompletableFuture<Boolean> teleportToward(final @NotNull LivingEntity entity, final @NotNull Vector direction, double teleportDistance, boolean fallDamage) {
         // Stop raying if we don't have line of sight
         Optional<Location> teleportLocationOpt = gracefulRayTrace(entity.getLocation(), direction, teleportDistance, entity.getBoundingBox(), entity::hasLineOfSight);
 
         if (teleportLocationOpt.isEmpty()) {
             // prevent teleport at all
-            if (then != null) {
-                then.accept(Boolean.FALSE);
-            }
-            return;
+            return CompletableFuture.completedFuture(false);
         }
 
         Location teleportLocation = teleportLocationOpt.get();
@@ -110,14 +103,15 @@ public class UtilLocation {
         // Asynchronously because, for some reason, spigot fires PlayerInteractEvent twice if the entity looks at a block
         // causing them to use the skill again after being teleported
         // teleportAsync somehow fixes that
-        entity.teleportAsync(teleportLocation).thenAccept(result -> {
+        return entity.teleportAsync(teleportLocation).thenApply(result -> {
             if (!fallDamage) {
                 entity.setFallDistance(0);
             }
 
-            if (then != null) {
-                then.accept(result);
-            }
+            return result;
+        }).exceptionally(ex -> {
+            log.warn("Failed to teleport entity to location: " + teleportLocation, ex).submit();
+            return false;
         });
     }
 


### PR DESCRIPTION
Teleport async wouldn't complete in time for a completable future join, which was only done so that the success of a skill usage could be more accurately tracked. Now, change that activation to a completable future and increment the stat when it is done.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
