### PR TITLE
Fix skill deadlock waiting for teleport

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Blink.java
@@ -29,7 +29,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
 
 import java.util.WeakHashMap;
-import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -157,10 +156,8 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
     public boolean activate(Player player, int level) {
         double maxDistance = getMaxTravelDistance(level);
         final Location origin = player.getLocation();
-        CompletableFuture<Boolean> activateFuture = new CompletableFuture<>();
         UtilLocation.teleportForward(player, maxDistance, false, success -> {
             if (!Boolean.TRUE.equals(success)) {
-                activateFuture.complete(false);
                 return;
             }
 
@@ -174,9 +171,8 @@ public class Blink extends Skill implements InteractSkill, CooldownSkill, Listen
             championsManager.getCooldowns().use(player, "Deblink", 0.25, false);
             player.getWorld().playEffect(origin, Effect.BLAZE_SHOOT, 0);
             player.getWorld().playEffect(lineEnd, Effect.BLAZE_SHOOT, 0);
-            activateFuture.complete(true);
         });
-        return activateFuture.join();
+        return true;
     }
 
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
@@ -32,7 +32,6 @@ import org.bukkit.event.block.Action;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -163,17 +162,14 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
     @Override
     public boolean activate(Player player, int level) {
         final Location origin = player.getLocation();
-        CompletableFuture<Boolean> activatedFuture = new CompletableFuture<>();
         UtilLocation.teleportForward(player, teleportDistance, false, success -> {
             if (!Boolean.TRUE.equals(success)) {
-                activatedFuture.complete(false);
                 return;
             }
 
             // Lessen charges and add cooldown to prevent from instantly getting a flash charge if they're full
             FlashData flashData = charges.get(player);
             if (flashData == null) {
-                activatedFuture.complete(false);
                 return;
             }
 
@@ -196,10 +192,8 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
 
             player.getWorld().playSound(origin, Sound.ENTITY_WITHER_SHOOT, 0.4F, 1.2F);
             player.getWorld().playSound(origin, Sound.ENTITY_SILVERFISH_DEATH, 1.0F, 1.6F);
-            activatedFuture.complete(true);
-
         });
-        return activatedFuture.join();
+        return true;
     }
 
     @UpdateEvent(delay = 100)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -37,7 +37,6 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.util.RayTraceResult;
 
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @BPvPListener
@@ -88,7 +87,6 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
     @Override
     public boolean activate(Player player, int level) {
         final Location originalLocation = player.getLocation();
-        CompletableFuture<Boolean> activatedFuture = new CompletableFuture<>();
         UtilLocation.teleportForward(player, getDistance(level), false, success -> {
             final Location lineStart = originalLocation.add(0.0, player.getHeight() / 2, 0.0);
             Particle.SWEEP_ATTACK.builder()
@@ -100,7 +98,6 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0F, 1.6F);
 
             if (Boolean.FALSE.equals(success)) {
-                activatedFuture.complete(false);
                 return;
             }
 
@@ -127,9 +124,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
                                     .map(LivingEntity.class::cast)
                                     .forEach(hit -> hit(player, level, hit)),
                             () -> UtilMessage.message(player, getClassType().getName(), "You missed <alt>%s</alt>.", getName()));
-            activatedFuture.complete(true);
         });
-        return activatedFuture.join();
+        return true;
     }
 
     private void hit(Player caster, int level, LivingEntity hit) {


### PR DESCRIPTION
## Describe your changes
Fix an issue with skill using `UtilLocation.teleportForward` waiting for teleportation to be completed by calling `CompletableFuture#join` on the main thread. Since the main thread was blocked by the joined thread, the async teleport task in `teleportForward` could not delegate the destination chunk's load to it.

This caused a deadlock where the main thread (skill execution) was waiting for teleportation, and the teleport thread was waiting for the main thread to load the chunk.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
