### PR TITLE
Fix incorrect logic for effect duration listening

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/listeners/EffectStatListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/listeners/EffectStatListener.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.core.client.stats.listeners;
 
-import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.client.stats.impl.core.EffectDurationStat;
@@ -8,12 +7,10 @@ import me.mykindos.betterpvp.core.client.stats.impl.utility.Relation;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
 import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public class EffectStatListener extends TimedStatListener {
     private final EffectManager effectManager;
@@ -56,11 +53,9 @@ public class EffectStatListener extends TimedStatListener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onEffectExpire(EffectReceiveEvent event) {
+    public void onEffectReceive(EffectReceiveEvent event) {
         if (event.getTarget() instanceof Player player) {
-            UtilServer.runTaskLater(JavaPlugin.getPlugin(Core.class), () -> {
-                doUpdate(player);
-            }, 1L);
+            doUpdate(player);
         }
     }
 }


### PR DESCRIPTION
Logic error, since the player does not have the effect when effect receive event is run, we want to update all the effects and set the last updated time to the start of the new effect (otherwise it will add incorrect time to the new effect)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes.
