### PR TITLE
Assassin Passive B: Deathwish

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/data/deathwish/DeathwishData.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/data/deathwish/DeathwishData.java
@@ -1,0 +1,19 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.data.deathwish;
+
+import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+
+@Data
+public class DeathwishData {
+    private @NotNull DeathwishThreshold currentThreshold = DeathwishThreshold.NONE;
+
+    /**
+     * The time at which the last effect was applied, used to determine when to remove the effect after the duration expires.
+     * <p>
+     * Note: If a player reaches a new threshold while an effect is active, the timer will reset to the time of the new
+     * effect application, so the effect will last for the full duration from that point.
+     */
+    private long lastEffectTime = -1;
+
+    private boolean reachedMaxThreshold = false;
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/data/deathwish/DeathwishThreshold.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/data/deathwish/DeathwishThreshold.java
@@ -1,0 +1,21 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.data.deathwish;
+
+import lombok.Getter;
+import org.bukkit.Color;
+
+public enum DeathwishThreshold {
+    NONE(0, Color.GRAY),
+    DAMAGE(1, Color.YELLOW),
+    ATTACK_SPEED(2, Color.RED);
+
+    DeathwishThreshold(int level, Color color) {
+        this.level = level;
+        this.color = color;
+    }
+
+    @Getter
+    private final int level;
+
+    @Getter
+    private final Color color;
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
@@ -175,9 +175,8 @@ public class Deathwish extends Skill implements Listener {
             return;
         }
 
-        // Player is above both thresholds, so we clear any active effects; player will be removed from map during
-        // update event
-        clearAttackSpeedEffect(player);
+        // Player is above both thresholds
+        abilityData.setLastEffectTime(currentTime);  // clear gray particles after times up
     }
 
     /**
@@ -209,6 +208,7 @@ public class Deathwish extends Skill implements Listener {
             final long effectDurationMillis = (long) (getEffectDuration(level) * 1000L);
             final boolean hasTimeElapsed = UtilTime.elapsed(abilityData.getLastEffectTime(), effectDurationMillis);
 
+            // Case: threshold advanced and either time is up or player healed too much
             if (hasTimeElapsed || UtilPlayer.getHealthPercentage(player) > getDamageIncreaseThreshold(level)) {
                 if (abilityData.getCurrentThreshold().getLevel() > DeathwishThreshold.NONE.getLevel()) {
                     clearAttackSpeedEffect(player);
@@ -216,9 +216,15 @@ public class Deathwish extends Skill implements Listener {
 
                     // FX
                     spawnEndEffectParticles(player);
-                    player.playSound(player, Sound.BLOCK_BEACON_ACTIVATE, 1f, 2f);
                     return;
                 }
+            }
+
+            // Case: time is up but threshold never advanced past NONE
+            if (hasTimeElapsed) {
+                spawnEndEffectParticles(player);
+                iterator.remove();
+                return;
             }
 
             spawnThresholdParticles(player, abilityData.getCurrentThreshold());
@@ -226,6 +232,7 @@ public class Deathwish extends Skill implements Listener {
     }
 
     private void spawnEndEffectParticles(@NotNull Player player) {
+        player.playSound(player, Sound.BLOCK_BEACON_ACTIVATE, 1f, 2f);
         Location base = player.getLocation();
 
         for (int degree = 0; degree < 360; degree += 10) {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
@@ -1,0 +1,296 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.ChampionsManager;
+import me.mykindos.betterpvp.champions.champions.skills.Skill;
+import me.mykindos.betterpvp.champions.champions.skills.skills.assassin.data.deathwish.DeathwishData;
+import me.mykindos.betterpvp.champions.champions.skills.skills.assassin.data.deathwish.DeathwishThreshold;
+import me.mykindos.betterpvp.champions.combat.damage.SkillDamageModifier;
+import me.mykindos.betterpvp.core.combat.cause.DamageCauseCategory;
+import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
+import me.mykindos.betterpvp.core.utilities.UtilTime;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.IntToDoubleFunction;
+
+@BPvPListener
+@Singleton
+public class Deathwish extends Skill implements Listener {
+
+    private final Map<Player, DeathwishData> data = new WeakHashMap<>();
+
+    private double damageIncreaseThreshold;
+    private double damageIncreaseAmount;
+    private double attackSpeedIncreaseThreshold;
+
+    /**
+     * Attack speed increase is a percentage, so 20 means 20% increased attack speed
+     */
+    private int attackSpeedIncreaseAmount;
+    private double effectDuration;
+    private double effectDurationIncreasePerLevel;
+
+    @Inject
+    public Deathwish(Champions champions, ChampionsManager championsManager) {
+        super(champions, championsManager);
+    }
+
+    @Override
+    public String[] getDescription(int level) {
+        // Note: thresholds are somewhat hard coded since the damage increase threshold is always higher than the attack
+        // speed increase threshold.
+
+        final @NotNull String damageThreshold = getValueStringPercentage(this::getDamageIncreaseThreshold, level, 100);
+
+        return new String[]{
+                "At " + damageThreshold + " health, gain " + getValueString(this::getDamageIncreaseAmount, level)
+                        + " increased",
+                "melee damage.",
+                "",
+                "At " + getValueStringPercentage(this::getAttackSpeedIncreaseThreshold, level, 100) + " health, gain "
+                        + getValueStringPercentage(this::getAttackSpeedIncreaseAmount, level, 1)
+                        + " increased",
+                "attack speed.",
+                "",
+                "Effects last for " + getValueString(this::getEffectDuration, level) + " seconds",
+                "and end if you heal above " + damageThreshold + " health.",
+        };
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="Config Getters / Description Helpers">
+    private @NotNull String getValueStringPercentage(@NotNull IntToDoubleFunction provider, int level, int multiplier) {
+        return getValueString(provider, level, multiplier, "%", 0);
+    }
+
+    private double getDamageIncreaseThreshold(int level) {
+        return damageIncreaseThreshold;
+    }
+
+    private double getDamageIncreaseAmount(int level) {
+        return damageIncreaseAmount;
+    }
+
+    private double getAttackSpeedIncreaseThreshold(int level) {
+        return attackSpeedIncreaseThreshold;
+    }
+
+    private double getAttackSpeedIncreaseAmount(int level) {
+        return attackSpeedIncreaseAmount;
+    }
+
+    private double getEffectDuration(int level) {
+        return effectDuration + (level - 1) * effectDurationIncreasePerLevel;
+    }
+    // </editor-fold>
+
+    /**
+     * Handles both applying the damage increase modifier when the player damages an entity and checking if the player
+     * has reached a new threshold when they take damage.
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onDamage(DamageEvent event) {
+        if (!event.isDamageeLiving()) return;
+
+        if (event.getDamagee() instanceof Player target) {
+            final int level = getLevel(target);
+            if (level <= 0) return;
+
+            data.putIfAbsent(target, new DeathwishData());
+
+            updateThreshold(target);
+            return;
+        }
+
+        if (event.getDamager() instanceof Player damager && event.getCause().getCategories().contains(DamageCauseCategory.MELEE)) {
+            final int level = getLevel(damager);
+            if (level <= 0) return;
+
+            data.putIfAbsent(damager, new DeathwishData());
+
+            final @NotNull DeathwishData abilityData = data.get(damager);
+            if (abilityData.getCurrentThreshold().getLevel() < DeathwishThreshold.DAMAGE.getLevel()) {
+                // Player has not reached the damage increase threshold, so we dont apply the damage increase modifier
+                return;
+            }
+
+            final double damageIncrease = getDamageIncreaseAmount(level);
+            event.addModifier(new SkillDamageModifier.Flat(this, damageIncrease));
+
+            event.addReason(getName());
+
+            final float pitch = switch (abilityData.getCurrentThreshold()) {
+                case DAMAGE -> 1f;
+                case ATTACK_SPEED -> 1.5f;
+                default -> 1f;  // unreachable
+            };
+
+            damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_GOAT_MILK, 2f, pitch);
+        }
+    }
+
+    /**
+     * Checks if the player has reached a new threshold when they take damage and applies the appropriate effects.
+     */
+    private void updateThreshold(@NotNull Player player) {
+        final DeathwishData abilityData = data.get(player);
+        final double healthPercentage = UtilPlayer.getHealthPercentage(player);
+        final int level = getLevel(player);
+        final long currentTime = System.currentTimeMillis();
+
+        // Since attack speed threshold is lower than damage increase threshold, we check for it first.
+        if (healthPercentage <= getAttackSpeedIncreaseThreshold(level) && !abilityData.isReachedMaxThreshold()) {
+            abilityData.setCurrentThreshold(DeathwishThreshold.ATTACK_SPEED);
+            abilityData.setLastEffectTime(currentTime);
+
+            final int attackSpeedIncreaseAmount = (int) getAttackSpeedIncreaseAmount(level);
+            final long effectDurationMillis = (long) (getEffectDuration(level) * 1000L);
+
+            championsManager.getEffects().addEffect(player, EffectTypes.ATTACK_SPEED, getName(), attackSpeedIncreaseAmount,
+                    effectDurationMillis);
+
+            return;
+        }
+
+        if (healthPercentage <= getDamageIncreaseThreshold(level) && !abilityData.isReachedMaxThreshold()) {
+            abilityData.setCurrentThreshold(DeathwishThreshold.DAMAGE);
+            abilityData.setLastEffectTime(currentTime);
+            return;
+        }
+
+        // Player is above both thresholds, so we clear any active effects; player will be removed from map during
+        // update event
+        clearAttackSpeedEffect(player);
+    }
+
+    /**
+     * This method is responsible for cleaning up the attack speed effect when the duration expires or when the player
+     * heals above the damage increase threshold.
+     */
+    @UpdateEvent
+    public void onUpdate() {
+        final Iterator<Player> iterator = data.keySet().iterator();
+        while (iterator.hasNext()) {
+            final @Nullable Player player = iterator.next();
+            final @NotNull DeathwishData abilityData = data.get(player);
+
+            // Probably dont need is dead check and is invalid check together but can never be too safe
+            if (player == null || !player.isOnline() || player.isDead() || !player.isValid()) {
+                clearAttackSpeedEffect(player);
+                iterator.remove();
+                continue;
+            }
+
+            // Player is not null at this point so that's why the check is down here instead of at the start of the loop
+            final int level = getLevel(player);
+            if (level <= 0) {
+                clearAttackSpeedEffect(player);
+                iterator.remove();
+                continue;
+            }
+
+            final long effectDurationMillis = (long) (getEffectDuration(level) * 1000L);
+            final boolean hasTimeElapsed = UtilTime.elapsed(abilityData.getLastEffectTime(), effectDurationMillis);
+
+            if (hasTimeElapsed || UtilPlayer.getHealthPercentage(player) > getDamageIncreaseThreshold(level)) {
+                if (abilityData.getCurrentThreshold().getLevel() > DeathwishThreshold.NONE.getLevel()) {
+                    clearAttackSpeedEffect(player);
+                    iterator.remove();
+
+                    // FX
+                    spawnEndEffectParticles(player);
+                    player.playSound(player, Sound.BLOCK_BEACON_ACTIVATE, 1f, 2f);
+                    return;
+                }
+            }
+
+            spawnThresholdParticles(player, abilityData.getCurrentThreshold());
+        }
+    }
+
+    private void spawnEndEffectParticles(@NotNull Player player) {
+        Location base = player.getLocation();
+
+        for (int degree = 0; degree < 360; degree += 10) {
+            double radius = 0.5;
+            double radians = Math.toRadians(degree);
+
+            double addX = radius * Math.cos(radians);
+            double addZ = radius * Math.sin(radians);
+
+            Location particleLoc = base.clone().add(addX, player.getHeight() / 2, addZ);
+
+            Particle.END_ROD
+                    .builder()
+                    .location(particleLoc)
+                    .receivers(45)
+                    .count(1)
+                    .spawn();
+        }
+    }
+
+    private void spawnThresholdParticles(@NotNull Player player, @NotNull DeathwishThreshold threshold) {
+        Particle.DUST
+                .builder()
+                .color(threshold.getColor())
+                .location(player.getLocation())
+                .offset(0.5, 0.5, 0.5)
+                .receivers(45)
+                .count(2)
+                .extra(0)
+                .spawn();
+    }
+
+    /**
+     * Removes the attack speed effect from the player if they have it. This is called when the player heals above the
+     * damage increase threshold or when the effect duration expires.
+     */
+    private void clearAttackSpeedEffect(@Nullable Player player) {
+        if (player == null) return;
+
+        // not sure if we need a hasEffect check here
+        championsManager.getEffects().removeEffect(player, EffectTypes.ATTACK_SPEED, getName());
+    }
+
+    @Override
+    public String getName() {
+        return "Deathwish";
+    }
+
+    @Override
+    public Role getClassType() {
+        return Role.ASSASSIN;
+    }
+
+    @Override
+    public SkillType getType() {
+        return SkillType.PASSIVE_B;
+    }
+
+    @Override
+    public void loadSkillConfig() {
+        damageIncreaseThreshold = getConfig("damageIncreaseThreshold", 0.75, Double.class);
+        damageIncreaseAmount = getConfig("damageIncreaseAmount", 1.0, Double.class);
+        attackSpeedIncreaseThreshold = getConfig("attackSpeedIncreaseThreshold", 0.5, Double.class);
+        attackSpeedIncreaseAmount = getConfig("attackSpeedIncreaseAmount", 20, Integer.class);
+        effectDuration = getConfig("effectDuration", 3.0, Double.class);
+        effectDurationIncreasePerLevel = getConfig("effectDurationIncreasePerLevel", 2.0, Double.class);
+    }
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Deathwish.java
@@ -216,7 +216,7 @@ public class Deathwish extends Skill implements Listener {
 
                     // FX
                     spawnEndEffectParticles(player);
-                    return;
+                    continue;
                 }
             }
 
@@ -224,7 +224,7 @@ public class Deathwish extends Skill implements Listener {
             if (hasTimeElapsed) {
                 spawnEndEffectParticles(player);
                 iterator.remove();
-                return;
+                continue;
             }
 
             spawnThresholdParticles(player, abilityData.getCurrentThreshold());

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -20,6 +20,15 @@ skills:
       baseDuration: 1.0
       durationIncreasePerLevel: 1.0
       hitDistance: 4.0
+    deathwish:
+      enabled: true
+      maxlevel: 3
+      damageIncreaseThreshold: 0.75
+      damageIncreaseAmount: 1.0
+      attackSpeedIncreaseThreshold: 0.5
+      attackSpeedIncreaseAmount: 20
+      effectDuration: 3.0
+      effectDurationIncreasePerLevel: 2.0
     shockingstrikes:
       enabled: true
       maxlevel: 3


### PR DESCRIPTION
## Describe your changes

### A boring meta
Assassin has always had lackluster passives in terms of both visual appeal and combat viability. Skills such as **Combo Attack** and **Backstab** have always been viable but are bland while **Silencing Strikes**, **Shocking Strikes**, and **Viper Strikes**\* have more interesting possibilities to them but suck pretty bad.

### Enter: Deathwish
Deathwish is a versatile skill rewarding players who thrive playing as a glass cannon; yet, also provides unique mechanics like boosted *Attack Speed* and an interesting health mechanic.

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/c63062ec-92e4-4253-90c5-fc68a3d4a0a3" />

### Demo
https://medal.tv/games/minecraft/clips/mv3g9a8WH6rPcuri3?invite=cr-MSx3bmQsMzQxNDU1NjM4

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
