### PR TITLE
Add damage modifier stats, handle stats with less than 1 second better, differentiate achievements better

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/combat/damage/SkillDamageModifier.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/combat/damage/SkillDamageModifier.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.champions.combat.damage;
 
+import lombok.Getter;
 import me.mykindos.betterpvp.champions.champions.skills.Skill;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.combat.modifiers.DamageModifier;
@@ -15,32 +16,34 @@ import me.mykindos.betterpvp.core.utilities.UtilFormat;
 public class SkillDamageModifier implements DamageModifier {
     
     protected final Skill skill;
-    protected final DamageOperator operator;
-    protected final double operand;
+    @Getter
+    protected final DamageOperator damageOperator;
+    @Getter
+    protected final double damageOperand;
     protected final int priority;
     
     /**
      * Creates a skill damage modifier
      * @param skill the skill this modifier is for
-     * @param operator the damage operator
-     * @param operand the damage operand
+     * @param damageOperator the damage operator
+     * @param damageOperand the damage operand
      * @param priority the priority of this modifier
      */
-    public SkillDamageModifier(Skill skill, DamageOperator operator, double operand, int priority) {
+    public SkillDamageModifier(Skill skill, DamageOperator damageOperator, double damageOperand, int priority) {
         this.skill = skill;
-        this.operator = operator;
+        this.damageOperator = damageOperator;
         this.priority = priority;
-        this.operand = operand;
+        this.damageOperand = damageOperand;
     }
     
     /**
      * Creates a skill damage modifier with default priority
      * @param skill the skill this modifier is for
-     * @param operator the damage operator
-     * @param operand the flat damage increase
+     * @param damageOperator the damage operator
+     * @param damageOperand the flat damage increase
      */
-    public SkillDamageModifier(Skill skill, DamageOperator operator, double operand) {
-        this(skill, operator, operand, 200);
+    public SkillDamageModifier(Skill skill, DamageOperator damageOperator, double damageOperand) {
+        this(skill, damageOperator, damageOperand, 200);
     }
     
     @Override
@@ -71,7 +74,7 @@ public class SkillDamageModifier implements DamageModifier {
     
     @Override
     public ModifierResult apply(DamageEvent event) {
-        return new ModifierResult(operand, operator, skill.getName());
+        return new ModifierResult(damageOperand, damageOperator, skill.getName());
     }
     
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/commands/AchievementsCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/commands/AchievementsCommand.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.Client;
-import me.mykindos.betterpvp.core.client.achievements.display.AchievementMenu;
+import me.mykindos.betterpvp.core.client.achievements.display.AchievementScopeMenu;
 import me.mykindos.betterpvp.core.client.achievements.repository.AchievementManager;
 import me.mykindos.betterpvp.core.client.stats.RealmManager;
 import me.mykindos.betterpvp.core.command.Command;
@@ -36,7 +36,7 @@ public class AchievementsCommand extends Command implements IConsoleCommand {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        new AchievementMenu(client, achievementManager, realmManager).show(player);
+        new AchievementScopeMenu(client, achievementManager, realmManager, null).show(player);
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/display/AchievementMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/display/AchievementMenu.java
@@ -33,8 +33,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @CustomLog
 @Getter
@@ -67,8 +69,8 @@ public class AchievementMenu extends AbstractPagedGui<Item> implements IAbstract
                 "# x x x x x x x #",
                 "# x x x x x x x #",
                 "# # # < - > # # #")
-                .addIngredient('x',Markers.CONTENT_LIST_SLOT_HORIZONTAL)
-                .addIngredient('#',Menu.BACKGROUND_ITEM)
+                .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+                .addIngredient('#', Menu.BACKGROUND_ITEM)
                 .addIngredient('<', new PageBackwardButton())
                 .addIngredient('-', new StatBackButton(previous))
                 .addIngredient('>', new PageForwardButton())
@@ -92,33 +94,31 @@ public class AchievementMenu extends AbstractPagedGui<Item> implements IAbstract
         this.previous = previous;
 
         this.type = type;
-        this.period = period;
+        this.period = type == StatFilterType.ALL ? null : period;
 
-        seasonButton.setRefresh(() ->
-                seasonButton.onChangeSeason().thenApply(status -> {
-                    if (status.equals(Boolean.FALSE)) return Boolean.FALSE;
-                    setContent(getItems());
-                    return Boolean.TRUE;
-                })
-        );
+        if (type == StatFilterType.ALL) {
+            // Global achievements are not season/realm scoped — hide both controls.
+            setItem(7, 0, Menu.BACKGROUND_GUI_ITEM);
+            setItem(8, 0, Menu.BACKGROUND_GUI_ITEM);
+        } else {
+            // Seasonal: remove the "All" season option and hide the realm filter entirely.
+            seasonButton.getContexts().removeIf(ctx -> ctx.getStatFilterType() == StatFilterType.ALL);
+            setItem(8, 0, Menu.BACKGROUND_GUI_ITEM);
 
-        realmButton.setRefresh(() ->
-                realmButton.onChangeSeason().thenApply(status -> {
-                    if (status.equals(Boolean.FALSE)) return Boolean.FALSE;
-                    setContent(getItems());
-                    return Boolean.TRUE;
-                })
-        );
-
-
+            seasonButton.setRefresh(() ->
+                    seasonButton.onChangeSeason().thenApply(status -> {
+                        if (status.equals(Boolean.FALSE)) return Boolean.FALSE;
+                        setContent(getItems());
+                        return Boolean.TRUE;
+                    })
+            );
+        }
 
         setContent(getItems());
     }
 
     private List<Item> getItems() {
         Collection<IAchievementCategory> childCategories;
-        //reset the achievement category if it is no longer valid
-        //get the category buttons
         if (achievementCategory != null) {
             childCategories = achievementCategory.getChildren();
         } else {
@@ -127,8 +127,11 @@ public class AchievementMenu extends AbstractPagedGui<Item> implements IAbstract
                     .toList();
         }
 
-        //add the categories
+        final Set<NamespacedKey> validCategoryTree = getValidCategoryTree();
+
+        //add the categories (only those with at least one matching achievement in their tree)
         final List<Item> items = new ArrayList<>(childCategories.stream()
+                .filter(child -> validCategoryTree.contains(child.getNamespacedKey()))
                 .map(child -> (Item) new AchievementCategoryButton(child, type, period, client, achievementManager, realmManager, this))
                 .toList());
 
@@ -155,13 +158,41 @@ public class AchievementMenu extends AbstractPagedGui<Item> implements IAbstract
         return items;
     }
 
+    private Set<NamespacedKey> getValidCategoryTree() {
+        final Set<NamespacedKey> validCategories = new HashSet<>();
+        achievementManager.getAchievementCategoryManager().getObjects().values()
+                .forEach(category -> markValidCategoryTree(category, validCategories));
+        return validCategories;
+    }
+
+    private boolean markValidCategoryTree(@NotNull IAchievementCategory category, @NotNull Set<NamespacedKey> validCategories) {
+        final NamespacedKey categoryKey = category.getNamespacedKey();
+        final boolean hasDirectAchievements = achievementManager.getObjects().values().stream()
+                .anyMatch(achievement -> type.equals(achievement.getAchievementFilterType())
+                        && Objects.equals(achievement.getAchievementCategory(), categoryKey));
+
+        boolean hasValidChild = false;
+        for (IAchievementCategory child : category.getChildren()) {
+            if (markValidCategoryTree(child, validCategories)) {
+                hasValidChild = true;
+            }
+        }
+
+        if (hasDirectAchievements || hasValidChild) {
+            validCategories.add(categoryKey);
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * @return The title of this menu.
      */
 
     @Override
     public @NotNull Component getTitle() {
-        return Component.text("Achievements");
+        return Component.text(type == StatFilterType.ALL ? "Achievements - Global" : "Achievements - Seasonal");
     }
 
     @Override
@@ -187,6 +218,4 @@ public class AchievementMenu extends AbstractPagedGui<Item> implements IAbstract
         this.pages = pages;
         update();
     }
-
 }
-

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/display/AchievementScopeMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/achievements/display/AchievementScopeMenu.java
@@ -1,0 +1,89 @@
+package me.mykindos.betterpvp.core.client.achievements.display;
+
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.achievements.repository.AchievementManager;
+import me.mykindos.betterpvp.core.client.stats.RealmManager;
+import me.mykindos.betterpvp.core.client.stats.StatFilterType;
+import me.mykindos.betterpvp.core.inventory.gui.AbstractGui;
+import me.mykindos.betterpvp.core.inventory.gui.structure.Structure;
+import me.mykindos.betterpvp.core.inventory.item.ItemProvider;
+import me.mykindos.betterpvp.core.inventory.item.impl.AbstractItem;
+import me.mykindos.betterpvp.core.menu.Menu;
+import me.mykindos.betterpvp.core.menu.Windowed;
+import me.mykindos.betterpvp.core.menu.button.BackButton;
+import me.mykindos.betterpvp.core.utilities.model.item.ClickActions;
+import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AchievementScopeMenu extends AbstractGui implements Windowed {
+
+    private final Client client;
+    private final AchievementManager achievementManager;
+    private final RealmManager realmManager;
+    @Nullable
+    private final Windowed previous;
+
+    public AchievementScopeMenu(@NotNull Client client, @NotNull AchievementManager achievementManager, @NotNull RealmManager realmManager, @Nullable Windowed previous) {
+        super(9, 3);
+        this.client = client;
+        this.achievementManager = achievementManager;
+        this.realmManager = realmManager;
+        this.previous = previous;
+
+        applyStructure(new Structure(
+                "# # # # # # # # #",
+                "# # G # # # S # #",
+                "# # # # B # # # #")
+                .addIngredient('#', Menu.BACKGROUND_ITEM)
+                .addIngredient('G', new GlobalAchievementsButton())
+                .addIngredient('S', new SeasonalAchievementsButton())
+                .addIngredient('B', new BackButton(previous)));
+    }
+
+    @Override
+    public @NotNull Component getTitle() {
+        return Component.text("Achievement Scope");
+    }
+
+    private class GlobalAchievementsButton extends AbstractItem {
+        @Override
+        public ItemProvider getItemProvider() {
+            return ItemView.builder()
+                    .material(Material.NETHER_STAR)
+                    .displayName(Component.text("Global Achievements", NamedTextColor.YELLOW))
+                    .lore(Component.text("Across all seasons", NamedTextColor.GRAY))
+                    .action(ClickActions.ALL, Component.text("Open Global Achievements"))
+                    .build();
+        }
+
+        @Override
+        public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
+            new AchievementMenu(client, null, StatFilterType.ALL, null, achievementManager, realmManager, AchievementScopeMenu.this).show(player);
+        }
+    }
+
+    private class SeasonalAchievementsButton extends AbstractItem {
+        @Override
+        public ItemProvider getItemProvider() {
+            return ItemView.builder()
+                    .material(Material.CLOCK)
+                    .displayName(Component.text("Seasonal Achievements", NamedTextColor.YELLOW))
+                    .lore(Component.text("Current season only", NamedTextColor.GRAY))
+                    .action(ClickActions.ALL, Component.text("Open Seasonal Achievements"))
+                    .build();
+        }
+
+        @Override
+        public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
+            new AchievementMenu(client, null, StatFilterType.SEASON, Core.getCurrentRealm().getSeason(), achievementManager, realmManager, AchievementScopeMenu.this).show(player);
+        }
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/profile/menu/ProfileMenu.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/profile/menu/ProfileMenu.java
@@ -2,7 +2,7 @@ package me.mykindos.betterpvp.core.client.profile.menu;
 
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.achievements.IAchievement;
-import me.mykindos.betterpvp.core.client.achievements.display.AchievementMenu;
+import me.mykindos.betterpvp.core.client.achievements.display.AchievementScopeMenu;
 import me.mykindos.betterpvp.core.client.achievements.repository.AchievementCompletion;
 import me.mykindos.betterpvp.core.client.achievements.repository.AchievementManager;
 import me.mykindos.betterpvp.core.client.stats.RealmManager;
@@ -109,7 +109,7 @@ public class ProfileMenu extends AbstractGui implements Windowed {
 
         @Override
         public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
-            new AchievementMenu(client, null, StatFilterType.ALL, null, achievementManager, realmManager, ProfileMenu.this).show(player);
+            new AchievementScopeMenu(client, achievementManager, realmManager, ProfileMenu.this).show(player);
         }
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/display/general/QualifiedStatListButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/display/general/QualifiedStatListButton.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.client.stats.display.general;
 
+import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.stats.StatContainer;
 import me.mykindos.betterpvp.core.client.stats.StatFilterType;
 import me.mykindos.betterpvp.core.client.stats.display.IAbstractStatMenu;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+@CustomLog
 public class QualifiedStatListButton extends ControlItem<IAbstractStatMenu> {
     private final List<IStat> stats;
     private final int numPerItem;
@@ -54,8 +56,20 @@ public class QualifiedStatListButton extends ControlItem<IAbstractStatMenu> {
         List<Component> description = stats.stream()
                 .skip(startIndex)
                 .limit(endIndex - startIndex)
-                .map(stat -> UtilMessage.deserialize("<gold>%s</gold>: <yellow>%s</yellow>",
-                        stat.getQualifiedName(), stat.formattedStatValue(statContainer, statFilterType, period))
+                .map(stat -> {
+                    final String formattedValue = stat.formattedStatValue(statContainer, statFilterType, period);
+                    if (formattedValue.isBlank()) {
+                        log.error("Stat {} returned blank formatted value (raw value {}) for client {} with filter type {} and period {}",
+                                stat.getQualifiedName(),
+                                stat.getStat(statContainer, statFilterType, period),
+                                gui.getClient().getName(),
+                                statFilterType,
+                                period)
+                                .submit();
+                    }
+                    return UtilMessage.deserialize("<gold>%s</gold>: <yellow>%s</yellow>",
+                            stat.getQualifiedName(), formattedValue);
+                }
                 )
                 .toList();
         return ItemView.builder()

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
@@ -138,7 +138,7 @@ public class DamageModifierStat implements IBuildableStat {
 
     @Override
     public @NotNull StatValueType getStatValueType() {
-        return StatValueType.DOUBLE;
+        return StatValueType.LONG;
     }
 
     @Override
@@ -161,10 +161,20 @@ public class DamageModifierStat implements IBuildableStat {
     @Override
     public String getSimpleName() {
         StringBuilder stringBuilder = new StringBuilder()
+                .append("Damage Modifier")
+                .append(" ")
                 .append(UtilFormat.cleanString(relation.name()));
         if (name != null) {
             stringBuilder.append(" ")
                     .append(UtilFormat.cleanString(name));
+        }
+        if (damageOperator != null) {
+            stringBuilder.append(" ")
+                    .append(UtilFormat.cleanString(damageOperator.name()));
+        }
+        if (damageOperand != null) {
+            stringBuilder.append(" ")
+                    .append(UtilFormat.cleanString(String.valueOf(damageOperand)));
         }
         return stringBuilder.toString();
     }
@@ -187,7 +197,10 @@ public class DamageModifierStat implements IBuildableStat {
 
     @Override
     public @NotNull IStat getGenericStat() {
-        return DamageModifierStat.builder().relation(relation).build();
+        return DamageModifierStat.builder()
+                .relation(relation)
+                .name(name)
+                .build();
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
@@ -13,7 +13,7 @@ import me.mykindos.betterpvp.core.client.stats.impl.IBuildableStat;
 import me.mykindos.betterpvp.core.client.stats.impl.IStat;
 import me.mykindos.betterpvp.core.client.stats.impl.utility.Relation;
 import me.mykindos.betterpvp.core.client.stats.impl.utility.StatValueType;
-import me.mykindos.betterpvp.core.client.stats.impl.utility.Type;
+import me.mykindos.betterpvp.core.combat.cause.DamageCause;
 import me.mykindos.betterpvp.core.combat.cause.DamageCauseRegistry;
 import me.mykindos.betterpvp.core.combat.modifiers.DamageOperator;
 import me.mykindos.betterpvp.core.combat.modifiers.ModifierType;
@@ -32,23 +32,31 @@ import java.util.Objects;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 public class DamageModifierStat implements IBuildableStat {
-    public static final String STAT_TYPE = "DAMAGE";
+    public static final String STAT_TYPE = "DAMAGE_MODIFIER";
     private static final DamageCauseRegistry damageCauseRegistry = JavaPlugin.getPlugin(Core.class).getInjector().getInstance(DamageCauseRegistry.class);
 
-    public static DamageStat fromData(String statType, JSONObject data) {
-        DamageStat.DamageStatBuilder builder = builder();
+    public static DamageModifierStat fromData(String statType, JSONObject data) {
+        DamageModifierStat.DamageModifierStatBuilder builder = builder();
         Preconditions.checkArgument(statType.equals(STAT_TYPE));
         builder.relation(Relation.valueOf(data.getString("relation")));
-        builder.type(Type.valueOf(data.getString("type")));
-        builder.damageCause(damageCauseRegistry.get(data.getString("damageCause")));
+        builder.name(data.optString("name", null));
+        if (data.has("damageOperator")) {
+            builder.damageOperator(DamageOperator.valueOf(data.getString("damageOperator")));
+        }
+        if (data.has("modifierType")) {
+            builder.modifierType(ModifierType.valueOf(data.getString("modifierType")));
+        }
+        if (data.has("damageOperand")) {
+            builder.damageOperand(data.getDouble("damageOperand"));
+        }
+        if (data.has("damageCause")) {
+            builder.damageCause(damageCauseRegistry.get(data.getString("damageCause")));
+        }
         return builder.build();
     }
 
-
     @NotNull
     private Relation relation;
-    @NotNull
-    private Type type;
     /**
      * The name of the Modifier
      */
@@ -69,26 +77,65 @@ public class DamageModifierStat implements IBuildableStat {
      */
     @Nullable
     private Double damageOperand;
+    /**
+     * The damage cause
+     */
+    @Nullable
+    private DamageCause damageCause;
 
+    private boolean filterSpecificModifierUsage(Map.Entry<IStat, Long> entry) {
+        DamageModifierStat other = (DamageModifierStat) entry.getKey();
+        if (!relation.equals(other.relation)) return false;
+        if (name != null && !Objects.equals(name, other.name)) return false;
+        if (damageOperator != null && damageOperator != other.damageOperator) return false;
+        if (modifierType != null && modifierType != other.modifierType) return false;
+        return damageCause == null || Objects.equals(damageCause, other.damageCause);
+    }
 
-    private boolean filterDamageCause(Map.Entry<IStat, Long> entry) {
-        DamageStat other = (DamageStat) entry.getKey();
-        return relation.equals(other.relation) && type.equals(other.type);
+    private boolean filterByModifierTypeOnly(Map.Entry<IStat, Long> entry) {
+        DamageModifierStat other = (DamageModifierStat) entry.getKey();
+        if (!relation.equals(other.relation)) return false;
+        if (modifierType != other.modifierType) return false;
+        return damageCause == null || Objects.equals(damageCause, other.damageCause);
+    }
+
+    private boolean filterByOperatorAndModifierType(Map.Entry<IStat, Long> entry) {
+        DamageModifierStat other = (DamageModifierStat) entry.getKey();
+        if (!relation.equals(other.relation)) return false;
+        if (damageOperator != other.damageOperator) return false;
+        if (modifierType != other.modifierType) return false;
+        return damageCause == null || Objects.equals(damageCause, other.damageCause);
+    }
+
+    private boolean filterByOperatorOnly(Map.Entry<IStat, Long> entry) {
+        DamageModifierStat other = (DamageModifierStat) entry.getKey();
+        if (!relation.equals(other.relation)) return false;
+        if (damageOperator != other.damageOperator) return false;
+        return damageCause == null || Objects.equals(damageCause, other.damageCause);
     }
 
     @Override
     public Long getStat(StatContainer statContainer, StatFilterType type, @Nullable Period period) {
-        if (damageCause == null) {
-            return getFilteredStat(statContainer, type, period, this::filterDamageCause);
+        // modifierType + damageOperator + null name/operand -> count that operator/type combination
+        if (modifierType != null && damageOperator != null && name == null && damageOperand == null) {
+            return getFilteredStat(statContainer, type, period, this::filterByOperatorAndModifierType);
         }
+        // modifierType only -> count by modifier type
+        if (modifierType != null && damageOperator == null && name == null && damageOperand == null) {
+            return getFilteredStat(statContainer, type, period, this::filterByModifierTypeOnly);
+        }
+        // damageOperator only -> count by operator
+        if (damageOperator != null && modifierType == null && name == null && damageOperand == null) {
+            return getFilteredStat(statContainer, type, period, this::filterByOperatorOnly);
+        }
+        // damageOperand null -> count uses for the provided modifier details
+        if (damageOperand == null) {
+            return getFilteredStat(statContainer, type, period, this::filterSpecificModifierUsage);
+        }
+
         return statContainer.getProperty(type, period, this);
     }
 
-    /**
-     * What type of stat this is, a LONG (default), DOUBLE, OR DURATION
-     *
-     * @return the type of stat
-     */
     @Override
     public @NotNull StatValueType getStatValueType() {
         return StatValueType.DOUBLE;
@@ -99,88 +146,59 @@ public class DamageModifierStat implements IBuildableStat {
         return STAT_TYPE;
     }
 
-    /**
-     * Get the jsonb data in string format for this object
-     *
-     * @return
-     */
     @Override
     public @Nullable JSONObject getJsonData() {
-        return new JSONObject()
-                .putOnce("relation", relation.name())
-                .putOnce("type", type.name())
-                .putOnce("damageCause", Objects.requireNonNull(damageCause).getName());
+        JSONObject obj = new JSONObject()
+                .putOnce("relation", relation.name());
+        if (name != null) obj.putOnce("name", name);
+        if (damageOperator != null) obj.putOnce("damageOperator", damageOperator.name());
+        if (modifierType != null) obj.putOnce("modifierType", modifierType.name());
+        if (damageOperand != null) obj.putOnce("damageOperand", damageOperand);
+        if (damageCause != null) obj.putOnce("damageCause", damageCause.getName());
+        return obj;
     }
 
-    /**
-     * Get the simple name of this stat, without qualifications (if present)
-     * <p>
-     * i.e. Time Played, Flags Captured
-     *
-     * @return the simple name
-     */
     @Override
     public String getSimpleName() {
         StringBuilder stringBuilder = new StringBuilder()
-                .append(UtilFormat.cleanString(relation.name()))
-                .append(" ")
-                .append(UtilFormat.cleanString(type.name()));
-        if (damageCause != null) {
+                .append(UtilFormat.cleanString(relation.name()));
+        if (name != null) {
             stringBuilder.append(" ")
-                    .append(UtilFormat.cleanString(damageCause.getName()));
+                    .append(UtilFormat.cleanString(name));
         }
-
         return stringBuilder.toString();
     }
 
-    /**
-     * Whether this stat is directly savable to the database
-     *
-     * @return {@code true} if it is, {@code false} otherwise
-     */
     @Override
     public boolean isSavable() {
-        return damageCause != null;
+        return name != null && damageOperator != null && modifierType != null && damageOperand != null && damageCause != null;
     }
 
-    /**
-     * Whether this stat contains this statName
-     *
-     * @param statName
-     * @return
-     */
-
-    /**
-     * Whether this stat contains this otherSTat
-     *
-     * @param otherStat
-     * @return
-     */
     @Override
     public boolean containsStat(IStat otherStat) {
-        if (!(otherStat instanceof DamageStat other)) return false;
-        if ((relation != other.relation) || (type != other.type)) return false;
-        return (damageCause != null && damageCause.equals(other.damageCause));
+        if (!(otherStat instanceof DamageModifierStat other)) return false;
+        if (relation != other.relation) return false;
+        if (name != null && !Objects.equals(name, other.name)) return false;
+        if (damageOperator != null && damageOperator != other.damageOperator) return false;
+        if (modifierType != null && modifierType != other.modifierType) return false;
+        if (damageOperand != null && !Objects.equals(damageOperand, other.damageOperand)) return false;
+        return damageCause == null || Objects.equals(damageCause, other.damageCause);
     }
 
-    /**
-     * <p>Get the generic stat that includes this stat.</p>
-     * <p>{@link IStat#containsStat(IStat)} of the generic should be {@code true} for this stat</p>
-     *
-     * @return the generic stat
-     */
     @Override
     public @NotNull IStat getGenericStat() {
-        return DamageStat.builder().relation(relation).type(type).build();
+        return DamageModifierStat.builder().relation(relation).build();
     }
 
     @Override
     public @NotNull IBuildableStat copyFromStatData(@NotNull String statType, JSONObject data) {
-        DamageStat other = fromData(statType, data);
+        DamageModifierStat other = fromData(statType, data);
         this.relation = other.relation;
-        this.type = other.type;
+        this.name = other.name;
+        this.damageOperator = other.damageOperator;
+        this.modifierType = other.modifierType;
+        this.damageOperand = other.damageOperand;
         this.damageCause = other.damageCause;
         return this;
     }
-
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageModifierStat.java
@@ -1,0 +1,186 @@
+package me.mykindos.betterpvp.core.client.stats.impl.core;
+
+import com.google.common.base.Preconditions;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.client.stats.StatContainer;
+import me.mykindos.betterpvp.core.client.stats.StatFilterType;
+import me.mykindos.betterpvp.core.client.stats.impl.IBuildableStat;
+import me.mykindos.betterpvp.core.client.stats.impl.IStat;
+import me.mykindos.betterpvp.core.client.stats.impl.utility.Relation;
+import me.mykindos.betterpvp.core.client.stats.impl.utility.StatValueType;
+import me.mykindos.betterpvp.core.client.stats.impl.utility.Type;
+import me.mykindos.betterpvp.core.combat.cause.DamageCauseRegistry;
+import me.mykindos.betterpvp.core.combat.modifiers.DamageOperator;
+import me.mykindos.betterpvp.core.combat.modifiers.ModifierType;
+import me.mykindos.betterpvp.core.server.Period;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Builder
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+public class DamageModifierStat implements IBuildableStat {
+    public static final String STAT_TYPE = "DAMAGE";
+    private static final DamageCauseRegistry damageCauseRegistry = JavaPlugin.getPlugin(Core.class).getInjector().getInstance(DamageCauseRegistry.class);
+
+    public static DamageStat fromData(String statType, JSONObject data) {
+        DamageStat.DamageStatBuilder builder = builder();
+        Preconditions.checkArgument(statType.equals(STAT_TYPE));
+        builder.relation(Relation.valueOf(data.getString("relation")));
+        builder.type(Type.valueOf(data.getString("type")));
+        builder.damageCause(damageCauseRegistry.get(data.getString("damageCause")));
+        return builder.build();
+    }
+
+
+    @NotNull
+    private Relation relation;
+    @NotNull
+    private Type type;
+    /**
+     * The name of the Modifier
+     */
+    @Nullable
+    private String name;
+    /**
+     * The damage operator
+     */
+    @Nullable
+    private DamageOperator damageOperator;
+    /**
+     * The modifier type
+     */
+    @Nullable
+    private ModifierType modifierType;
+    /**
+     * the damage operand
+     */
+    @Nullable
+    private Double damageOperand;
+
+
+    private boolean filterDamageCause(Map.Entry<IStat, Long> entry) {
+        DamageStat other = (DamageStat) entry.getKey();
+        return relation.equals(other.relation) && type.equals(other.type);
+    }
+
+    @Override
+    public Long getStat(StatContainer statContainer, StatFilterType type, @Nullable Period period) {
+        if (damageCause == null) {
+            return getFilteredStat(statContainer, type, period, this::filterDamageCause);
+        }
+        return statContainer.getProperty(type, period, this);
+    }
+
+    /**
+     * What type of stat this is, a LONG (default), DOUBLE, OR DURATION
+     *
+     * @return the type of stat
+     */
+    @Override
+    public @NotNull StatValueType getStatValueType() {
+        return StatValueType.DOUBLE;
+    }
+
+    @Override
+    public @NotNull String getStatType() {
+        return STAT_TYPE;
+    }
+
+    /**
+     * Get the jsonb data in string format for this object
+     *
+     * @return
+     */
+    @Override
+    public @Nullable JSONObject getJsonData() {
+        return new JSONObject()
+                .putOnce("relation", relation.name())
+                .putOnce("type", type.name())
+                .putOnce("damageCause", Objects.requireNonNull(damageCause).getName());
+    }
+
+    /**
+     * Get the simple name of this stat, without qualifications (if present)
+     * <p>
+     * i.e. Time Played, Flags Captured
+     *
+     * @return the simple name
+     */
+    @Override
+    public String getSimpleName() {
+        StringBuilder stringBuilder = new StringBuilder()
+                .append(UtilFormat.cleanString(relation.name()))
+                .append(" ")
+                .append(UtilFormat.cleanString(type.name()));
+        if (damageCause != null) {
+            stringBuilder.append(" ")
+                    .append(UtilFormat.cleanString(damageCause.getName()));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Whether this stat is directly savable to the database
+     *
+     * @return {@code true} if it is, {@code false} otherwise
+     */
+    @Override
+    public boolean isSavable() {
+        return damageCause != null;
+    }
+
+    /**
+     * Whether this stat contains this statName
+     *
+     * @param statName
+     * @return
+     */
+
+    /**
+     * Whether this stat contains this otherSTat
+     *
+     * @param otherStat
+     * @return
+     */
+    @Override
+    public boolean containsStat(IStat otherStat) {
+        if (!(otherStat instanceof DamageStat other)) return false;
+        if ((relation != other.relation) || (type != other.type)) return false;
+        return (damageCause != null && damageCause.equals(other.damageCause));
+    }
+
+    /**
+     * <p>Get the generic stat that includes this stat.</p>
+     * <p>{@link IStat#containsStat(IStat)} of the generic should be {@code true} for this stat</p>
+     *
+     * @return the generic stat
+     */
+    @Override
+    public @NotNull IStat getGenericStat() {
+        return DamageStat.builder().relation(relation).type(type).build();
+    }
+
+    @Override
+    public @NotNull IBuildableStat copyFromStatData(@NotNull String statType, JSONObject data) {
+        DamageStat other = fromData(statType, data);
+        this.relation = other.relation;
+        this.type = other.type;
+        this.damageCause = other.damageCause;
+        return this;
+    }
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageStat.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/stats/impl/core/DamageStat.java
@@ -72,6 +72,7 @@ public class DamageStat implements IBuildableStat {
      */
     @Override
     public @NotNull StatValueType getStatValueType() {
+        if (type.equals(Type.COUNT)) return StatValueType.LONG;
         return StatValueType.DOUBLE;
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatStatisticsListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatStatisticsListener.java
@@ -3,6 +3,7 @@ package me.mykindos.betterpvp.core.combat.listeners;
 import com.google.inject.Inject;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.client.stats.impl.core.DamageModifierStat;
 import me.mykindos.betterpvp.core.client.stats.impl.core.DamageStat;
 import me.mykindos.betterpvp.core.client.stats.impl.utility.Relation;
 import me.mykindos.betterpvp.core.client.stats.impl.utility.Type;
@@ -66,6 +67,18 @@ public class CombatStatisticsListener implements Listener {
 
         clientManager.incrementStat(damagee, builder.type(Type.COUNT).build(), 1);
         clientManager.incrementStat(damagee, builder.type(Type.AMOUNT).build(), event.getDamage());
+
+        event.getModifiers().values().forEach(modifier -> {
+            final DamageModifierStat damageModifierStat = DamageModifierStat.builder()
+                    .relation(Relation.RECEIVED)
+                    .name(modifier.getName())
+                    .damageOperator(modifier.getDamageOperator())
+                    .modifierType(modifier.getType())
+                    .damageOperand(modifier.getDamageOperand())
+                    .damageCause(event.getCause())
+                    .build();
+            clientManager.incrementStat(damagee, damageModifierStat, 1L);
+        });
     }
     
     /**
@@ -82,6 +95,20 @@ public class CombatStatisticsListener implements Listener {
 
         clientManager.incrementStat(damager, builder.type(Type.COUNT).build(), 1);
         clientManager.incrementStat(damager, builder.type(Type.AMOUNT).build(), event.getDamage());
+
+        event.getModifiers().values().forEach(modifier -> {
+            final DamageModifierStat damageModifierStat = DamageModifierStat.builder()
+                    .relation(Relation.DEALT)
+                    .name(modifier.getName())
+                    .damageOperator(modifier.getDamageOperator())
+                    .modifierType(modifier.getType())
+                    .damageOperand(modifier.getDamageOperand())
+                    .damageCause(event.getCause())
+                    .build();
+
+            clientManager.incrementStat(damager, damageModifierStat, 1L);
+        });
+
     }
     
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatStatisticsListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/CombatStatisticsListener.java
@@ -65,7 +65,7 @@ public class CombatStatisticsListener implements Listener {
                 .relation(Relation.RECEIVED)
                 .damageCause(event.getCause());
 
-        clientManager.incrementStat(damagee, builder.type(Type.COUNT).build(), 1);
+        clientManager.incrementStat(damagee, builder.type(Type.COUNT).build(), 1L);
         clientManager.incrementStat(damagee, builder.type(Type.AMOUNT).build(), event.getDamage());
 
         event.getModifiers().values().forEach(modifier -> {
@@ -93,7 +93,7 @@ public class CombatStatisticsListener implements Listener {
                 .relation(Relation.DEALT)
                 .damageCause(event.getCause());
 
-        clientManager.incrementStat(damager, builder.type(Type.COUNT).build(), 1);
+        clientManager.incrementStat(damager, builder.type(Type.COUNT).build(), 1L);
         clientManager.incrementStat(damager, builder.type(Type.AMOUNT).build(), event.getDamage());
 
         event.getModifiers().values().forEach(modifier -> {

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/DamageModifier.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/DamageModifier.java
@@ -41,4 +41,7 @@ public interface DamageModifier {
      * @return the modifier type
      */
     ModifierType getType();
+
+    DamageOperator getDamageOperator();
+    double getDamageOperand();
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/DamageModifier.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/DamageModifier.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.combat.modifiers;
 
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Interface for all damage modifiers that can affect damage values
@@ -42,6 +43,7 @@ public interface DamageModifier {
      */
     ModifierType getType();
 
+    @NotNull
     DamageOperator getDamageOperator();
     double getDamageOperand();
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/impl/GenericModifier.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/modifiers/impl/GenericModifier.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.core.combat.modifiers.impl;
 
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.With;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.combat.modifiers.DamageModifier;
@@ -18,13 +19,15 @@ public class GenericModifier implements DamageModifier {
     private final String reason;
     @With
     private ModifierType type = ModifierType.GENERIC;
-    private final DamageOperator operator;
-    private final double operand;
+    @Getter
+    private final DamageOperator damageOperator;
+    @Getter
+    private final double damageOperand;
 
-    public GenericModifier(String reason, DamageOperator operator, double operand) {
+    public GenericModifier(String reason, DamageOperator damageOperator, double damageOperand) {
         this.reason = reason;
-        this.operator = operator;
-        this.operand = operand;
+        this.damageOperator = damageOperator;
+        this.damageOperand = damageOperand;
     }
 
     @Override
@@ -44,7 +47,7 @@ public class GenericModifier implements DamageModifier {
     
     @Override
     public ModifierResult apply(DamageEvent event) {
-        return new ModifierResult(operand, operator, reason);
+        return new ModifierResult(damageOperand, damageOperator, reason);
     }
     
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/interaction/combat/InteractionDamageModifier.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/interaction/combat/InteractionDamageModifier.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.core.interaction.combat;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.With;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.combat.modifiers.DamageModifier;
@@ -18,34 +19,36 @@ import me.mykindos.betterpvp.core.interaction.Interaction;
 public class InteractionDamageModifier implements DamageModifier {
     
     protected final Interaction interaction;
-    protected final DamageOperator operator;
+    @Getter
+    protected final DamageOperator damageOperator;
     @With
     protected ModifierType modifierType = ModifierType.ABILITY;
-    protected final double operand;
+    @Getter
+    protected final double damageOperand;
     protected final int priority;
     
     /**
      * Creates an item interaction damage modifier
      * @param interaction the item interaction this modifier is for
-     * @param operator the damage operator
-     * @param operand the damage operand
+     * @param damageOperator the damage operator
+     * @param damageOperand the damage operand
      * @param priority the priority of this modifier
      */
-    public InteractionDamageModifier(Interaction interaction, DamageOperator operator, double operand, int priority) {
+    public InteractionDamageModifier(Interaction interaction, DamageOperator damageOperator, double damageOperand, int priority) {
         this.interaction = interaction;
-        this.operator = operator;
+        this.damageOperator = damageOperator;
         this.priority = priority;
-        this.operand = operand;
+        this.damageOperand = damageOperand;
     }
     
     /**
      * Creates a item interaction damage modifier with default priority
      * @param interaction the item interaction this modifier is for
-    * @param operator the damage operator
-    * @param operand the damage operand
+    * @param damageOperator the damage operator
+    * @param damageOperand the damage operand
      */
-    public InteractionDamageModifier(Interaction interaction, DamageOperator operator, double operand) {
-        this(interaction, operator, operand, 300);
+    public InteractionDamageModifier(Interaction interaction, DamageOperator damageOperator, double damageOperand) {
+        this(interaction, damageOperator, damageOperand, 300);
     }
     
     @Override
@@ -76,7 +79,7 @@ public class InteractionDamageModifier implements DamageModifier {
     
     @Override
     public ModifierResult apply(DamageEvent event) {
-        return new ModifierResult(operand, operator, interaction.getName());
+        return new ModifierResult(damageOperand, damageOperator, interaction.getName());
     }
     
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilTime.java
@@ -116,6 +116,9 @@ public class UtilTime {
     }
 
     public static String humanReadableFormat(Duration duration) {
+        if (duration.isZero()) {
+            return "0 seconds";
+        }
         long days = duration.toDays();
         duration = duration.minus(days, ChronoUnit.DAYS);
         long hours = duration.toHours();
@@ -126,19 +129,23 @@ public class UtilTime {
 
         StringBuilder result = new StringBuilder();
         if (days > 0) {
-            result.append(days).append(" days ");
+            result.append(days).append(days == 1 ? " day " : " days ");
         }
         if (hours > 0) {
-            result.append(hours).append(" hours ");
+            result.append(hours).append(hours == 1 ? " hour " : " hours ");
         }
         if (minutes > 0) {
-            result.append(minutes).append(" minutes ");
+            result.append(minutes).append(minutes == 1 ? " minute " : " minutes ");
         }
         if (seconds > 0) {
-            result.append(seconds).append(" seconds");
+            result.append(seconds).append(seconds == 1 ? " second " : " seconds ");
         }
 
-        return result.toString().trim();
+        String resString = result.toString().trim();
+        if (resString.isBlank()) {
+            return "under 1 second";
+        }
+        return result.toString();
     }
 
     public static String getTime(double d, int decPoint) {


### PR DESCRIPTION
Add damage modifier stats, now tracks dealt and received damage modifiers by name and value (and type for future composite). Fix stats with less than a second showing a blank line. Update how achievements are shown to be much clearer, user now chooses to look at global or seasonal achievements.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
