### PR TITLE
fix IMMUNE preventing self-applied negative effects

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/ImmuneListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/ImmuneListener.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.core.effects.listeners.effects;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.effects.Effect;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
@@ -10,6 +11,8 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+
+import java.util.Objects;
 
 @Singleton
 @BPvPListener
@@ -24,11 +27,13 @@ public class ImmuneListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onImmuneToNegativity(EffectReceiveEvent event) {
-        EffectType type = event.getEffect().getEffectType();
-        if (type.isNegative()) {
-            if (effectManager.hasEffect(event.getTarget(), EffectTypes.IMMUNE)) {
-                event.setCancelled(true);
-            }
+        final EffectType type = event.getEffect().getEffectType();
+        if (!type.isNegative()) return;
+        final Effect effect = event.getEffect();
+        //self applied negative effects should be applied
+        if (Objects.equals(effect.getApplier().get(), event.getTarget())) return;
+        if (effectManager.hasEffect(event.getTarget(), EffectTypes.IMMUNE)) {
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
Fixes #1976

IMMUNE no longer blocks self-applied negative effects

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
