### PR TITLE
Fix ice prison suffocation not respecting damage delay

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/IcePrison.java
@@ -114,7 +114,7 @@ public class IcePrison extends Skill implements InteractSkill, CooldownSkill, Li
 
     public void despawn(Player player) {
         final List<RestoreBlock> blocks = blockHandler.getRestoreBlocks(player, getName());
-        final Collection<Player> receivers = player.getWorld().getNearbyPlayers(blocks.get(0).getBlock().getLocation(), 60);
+        final Collection<Player> receivers = player.getWorld().getNearbyPlayers(blocks.getFirst().getBlock().getLocation(), 60);
         for (RestoreBlock block : blocks) {
             final Location loc = block.getBlock().getLocation();
             loc.getWorld().playSound(loc, Sound.BLOCK_GLASS_STEP, 0.4f, 1.8f);

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/cause/VanillaDamageCause.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/cause/VanillaDamageCause.java
@@ -58,8 +58,11 @@ public class VanillaDamageCause implements DamageCause {
     @Override
     public long getDefaultDelay() {
         return switch (vanillaCause) {
-            case ENTITY_ATTACK, CUSTOM, LAVA, SUFFOCATION, FIRE, FIRE_TICK -> DEFAULT_DELAY;
-            case VOID, THORNS, WORLD_BORDER, CONTACT -> 500L;
+            case ENTITY_ATTACK, CUSTOM -> DEFAULT_DELAY;
+            case SUFFOCATION, FIRE, LAVA, VOID, THORNS, WORLD_BORDER, CONTACT, CAMPFIRE -> 500L;
+            //every 25 ticks
+            case POISON -> (long) ((25d/20) * 1000L);
+            case FREEZE -> 2000L;
             default -> 1000L;
         };
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/delay/DamageDelayManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/delay/DamageDelayManager.java
@@ -13,7 +13,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
-
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -126,26 +125,47 @@ public class DamageDelayManager {
     }
     
     /**
-     * Processes damage delay for an event
+     * Pre-event phase: checks whether the damage is currently gated by an active delay.
+     * Must be called BEFORE the DamageEvent is fired, using the damager as it stands at
+     * that point (may still be null for skill-applied environmental damage).
+     *
      * @param event the damage event
-     * @return true if the damage should proceed, false if it should be blocked by delay
+     * @return true if the damage should proceed to the event call, false if blocked by delay
      */
-    public boolean processDamageDelay(DamageEvent event) {
-        // Check if damage can proceed
-        final boolean canDealDamage = canDealDamage(event.getDamager(), event.getDamagee(), event.getCause());
-        if (!canDealDamage) {
-            return false;
+    public boolean processPreEventDelay(DamageEvent event) {
+        return canDealDamage(event.getDamager(), event.getDamagee(), event.getCause());
+    }
+
+    /**
+     * Post-event phase: sets default delays, applies effect modifiers, and re-checks the
+     * delay with the <em>resolved</em> damager (which may have been set by a listener during
+     * the event call, e.g. Ice Prison assigning the caster as damager).
+     * <p>
+     * If the damager changed during the event the resolved damager key is also checked so
+     * that an existing delay registered under that key correctly blocks the hit.
+     *
+     * @param event       the damage event (damager may now differ from {@code preDamager})
+     * @param preDamager  the damager that was present before the event was fired
+     * @return true if the damage should proceed to finalisation, false if blocked
+     */
+    public boolean processPostEventDelay(DamageEvent event, @Nullable Entity preDamager) {
+        // If the damager was resolved/changed during the event, check the new key too.
+        Entity resolvedDamager = event.getDamager();
+        if (resolvedDamager != preDamager) {
+            if (!canDealDamage(resolvedDamager, event.getDamagee(), event.getCause())) {
+                return false;
+            }
         }
 
         // Set default delays if not already set
         setDefaultDelays(event);
 
-        // Apply effect modifiers
+        // Apply effect modifiers now that the real damager is known
         applyEffectModifiers(event);
 
         return true;
     }
-    
+
     /**
      * Gets the remaining delay for a specific damage combination
      * @param damager the damager (can be null)

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/DamageEventProcessor.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/listeners/DamageEventProcessor.java
@@ -103,8 +103,8 @@ public class DamageEventProcessor implements Listener {
             return false; // Entity is invulnerable
         }
 
-        // Check if we can proceed with damage due to damage delays
-        if (!delayManager.processDamageDelay(damageEvent)) return false;
+        // Pre-event delay check (uses the damager as known before any listener can change it)
+        if (!delayManager.processPreEventDelay(damageEvent)) return false;
 
         // Check if they can be hurt
         if (damageEvent.isDamageeLiving() && damageEvent.getDamager() instanceof LivingEntity livingDamager) {
@@ -124,12 +124,21 @@ public class DamageEventProcessor implements Listener {
             return false; // The adapter has cancelled the event
         }
 
+        // Snapshot the damager before firing the event — listeners may resolve it to a real
+        // entity (e.g. Ice Prison assigning the caster as damager during the event call).
+        final LivingEntity preDamager = damageEvent.getDamager();
+
         // Fire our custom event
         UtilServer.callEvent(damageEvent);
 
         if (damageEvent.isCancelled()) {
             return false;
         }
+
+        // Post-event delay phase: re-check with the resolved damager and apply modifiers.
+        // This catches the case where a listener promoted the damager from null → player,
+        // meaning the previously stored delay key (player, damagee, cause) now applies.
+        if (!delayManager.processPostEventDelay(damageEvent, preDamager)) return false;
 
         // Call the finalizer
         finalizer.finalizeEvent(damageEvent, adapter);


### PR DESCRIPTION
Fixes #1974

Fix ice prison suffocation not following damage delay because damage delay was checked before the event was run, but damage delay applied afterward with the changed damager (delay is stored under NULL, but added under damager). Now checks before and after event run.

Updated default damage delay for Vanilla Damage causes to match vanilla minecraft

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
