### PR TITLE
Fix setprotection and protection feedback. Fix frozen feedback. Allow vanish damage

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/commands/SetProtectionCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/client/gamer/commands/SetProtectionCommand.java
@@ -46,7 +46,7 @@ public class SetProtectionCommand extends Command {
             return;
         }
 
-        clientManager.search().offline(args[0]).thenAcceptAsync(clientOptional -> {
+        clientManager.search().offline(args[0]).thenAccept(clientOptional -> {
             if (clientOptional.isEmpty()) {
                 UtilMessage.message(player, "Protection", UtilMessage.deserialize("<yellow>%s</yellow> is not a valid Player.", args[0]));
                 return;

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/EffectManager.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.effects;
 
 import com.google.inject.Singleton;
+import lombok.CustomLog;
 import me.mykindos.betterpvp.core.effects.events.EffectExpireEvent;
 import me.mykindos.betterpvp.core.effects.events.EffectReceiveEvent;
 import me.mykindos.betterpvp.core.framework.manager.Manager;
@@ -25,6 +26,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Singleton
+@CustomLog
 public class EffectManager extends Manager<String, ConcurrentHashMap<String, List<Effect>>> {
 
     // Thread-safe cache for effect type names
@@ -271,14 +273,17 @@ public class EffectManager extends Manager<String, ConcurrentHashMap<String, Lis
             List<Effect> effectList = effects.get(type.getName());
             if (effectList == null) return;
             effectList.removeIf(effect -> {
+                try {
+                    if (effect.getEffectType() instanceof VanillaEffectType vanillaEffectType) {
+                        vanillaEffectType.onExpire(target, effect, notify);
+                    }
 
-                if (effect.getEffectType() instanceof VanillaEffectType vanillaEffectType) {
-                    vanillaEffectType.onExpire(target, effect, notify);
+                    UtilServer.callEvent(new EffectExpireEvent(target, effect, notify));
+                    return true;
+                } catch (Exception e) {
+                    log.error("Error while removing effect {} from {}: ", effect.getEffectType().getName(), target.getName(), e).submit();
+                    return false;
                 }
-
-                UtilServer.callEvent(new EffectExpireEvent(target, effect, notify));
-                return true;
-
             });
         });
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/EffectListener.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.client.Client;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
-import me.mykindos.betterpvp.core.combat.events.EntityCanHurtEntityEvent;
 import me.mykindos.betterpvp.core.effects.Effect;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
@@ -18,7 +17,6 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -179,17 +177,6 @@ public class EffectListener implements Listener {
         effectsOptional.ifPresent(effects -> {
             effects.values().forEach(effectList -> effectList.forEach(effect -> effect.getEffectType().onReceive(event.getPlayer(), effect)));
         });
-    }
-
-    @EventHandler
-    public void onCanHurt(EntityCanHurtEntityEvent event) {
-        if (!event.isAllowed()) return;
-
-        if (effectManager.hasEffect(event.getDamagee(), EffectTypes.PROTECTION)
-                || effectManager.hasEffect(event.getDamagee(), EffectTypes.VANISH)
-                || effectManager.hasEffect(event.getDamagee(), EffectTypes.FROZEN)) {
-            event.setResult(Event.Result.DENY);
-        }
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/FrozenListener.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.core.effects.listeners.effects;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.combat.events.EntityCanHurtEntityEvent;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
@@ -95,6 +96,24 @@ public class FrozenListener implements Listener {
             }
         }
     }
+
+    @EventHandler
+    public void onCanHurt(EntityCanHurtEntityEvent event) {
+        if (event.getDamagee() instanceof LivingEntity damagee) {
+            if (effectManager.hasEffect(damagee, EffectTypes.FROZEN)) {
+                UtilMessage.message(event.getDamager(), "Frozen", "<yellow>%s</yellow> is frozen and cannot receive damage!", damagee.getName());
+                event.setResult(Event.Result.DENY);
+            }
+        }
+
+        if (event.getDamager() instanceof LivingEntity damager) {
+            if (effectManager.hasEffect(damager, EffectTypes.FROZEN)) {
+                UtilMessage.message(damager, "Frozen", "You cannot damage anything while you are Frozen!");
+                event.setResult(Event.Result.DENY);
+            }
+        }
+    }
+
 
 
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/ProtectionListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/ProtectionListener.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.combat.events.CustomEntityVelocityEvent;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import me.mykindos.betterpvp.core.combat.events.EntityCanHurtEntityEvent;
 import me.mykindos.betterpvp.core.combat.throwables.events.ThrowableHitEntityEvent;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
@@ -17,6 +18,7 @@ import me.mykindos.betterpvp.core.utilities.events.FetchNearbyEntityEvent;
 import net.minecraft.world.entity.projectile.FishingHook;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -64,13 +66,11 @@ public class ProtectionListener implements Listener {
 
     @EventHandler
     public void onFetchNearbyEntity(FetchNearbyEntityEvent<?> event) {
-        if (!(event.getSource() instanceof Player player)) return;
+        if (!(event.getSource() instanceof Player)) return;
 
         event.getEntities().removeIf(ent -> {
-            if(ent instanceof Player target) {
-                if (effectManager.hasEffect(target, EffectTypes.PROTECTION)) {
-                    return true;
-                }
+            if (ent instanceof Player target) {
+                return effectManager.hasEffect(target, EffectTypes.PROTECTION);
             }
             return false;
         });
@@ -91,6 +91,23 @@ public class ProtectionListener implements Listener {
         event.getItems().forEach(item -> {
             UtilItem.reserveItem(item, event.getPlayer(), reserveTime);
         });
+    }
+
+    @EventHandler
+    public void onEntityHurtEvent(EntityCanHurtEntityEvent event) {
+        if (event.getDamagee() instanceof Player damagee &&
+                event.getDamager() instanceof Player damager) {
+            if (effectManager.hasEffect(damagee, EffectTypes.PROTECTION)) {
+                UtilMessage.message(damager, "Protected", "This is a new player and is protected from damage!");
+                event.setResult(Event.Result.DENY);
+            }
+
+            if (effectManager.hasEffect(damager, EffectTypes.PROTECTION)) {
+                UtilMessage.message(damager, "Protected", "You cannot damage other players while you have protection!");
+                EffectTypes.disableProtectionReminder(damager);
+                event.setResult(Event.Result.DENY);
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)


### PR DESCRIPTION
Fixes #1950


Fix setprotection calling on an async thread and silently failing. Fix changes to how damage event processing causes feedback messages to not be sent for protection and frozen. Allow vanish damage (do not deny by default)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
