### PR TITLE
Invert legacy registration

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/item/adapter/BukkitMaterialAdapter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/adapter/BukkitMaterialAdapter.java
@@ -43,7 +43,7 @@ public class BukkitMaterialAdapter {
         Arrays.stream(Material.values())
                 .filter(Material::isItem)
                 .filter(material -> !excludedMaterials.contains(material))
-                .filter(Material::isLegacy)
+                .filter(material -> !material.isLegacy())
                 .parallel()
                 .forEach(material -> {
                     final VanillaItem item = new VanillaItem(material, ItemRarity.COMMON);


### PR DESCRIPTION
## Describe your changes
Invert legacy state check for bukkit materials. Fixes an issue where not all items were registered for viewing in `/items`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
