### PR TITLE
Fix regular bows being used in water and on other classes

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/roles/listeners/RoleListener.java
@@ -17,9 +17,7 @@ import me.mykindos.betterpvp.core.combat.CombatFeaturesService;
 import me.mykindos.betterpvp.core.combat.death.events.CustomDeathMessageEvent;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.components.champions.Role;
-import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
@@ -35,7 +33,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityRemoveEvent;
-import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -49,7 +46,6 @@ import java.util.function.Function;
 @BPvPListener
 public class RoleListener implements Listener {
 
-    private final ItemFactory itemFactory;
     private final RoleManager roleManager;
     private final ClientManager clientManager;
     private final BuildManager buildManager;
@@ -57,9 +53,8 @@ public class RoleListener implements Listener {
     private final CombatFeaturesService combatFeaturesService;
 
     @Inject
-    public RoleListener(ItemFactory itemFactory, RoleManager roleManager, ClientManager clientManager, BuildManager buildManager,
+    public RoleListener(RoleManager roleManager, ClientManager clientManager, BuildManager buildManager,
                         RoleSoundProvider soundProvider, CombatFeaturesService combatFeaturesService) {
-        this.itemFactory = itemFactory;
         this.roleManager = roleManager;
         this.clientManager = clientManager;
         this.buildManager = buildManager;
@@ -127,26 +122,6 @@ public class RoleListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void damageSound(DamageEvent pre) {
         pre.setSoundProvider(soundProvider);
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onShootBow(EntityShootBowEvent event) {
-        if (event.getBow() != null && itemFactory.isCustomItem(event.getBow())) {
-            return; // custom bow
-        }
-
-        final LivingEntity livingEntity = event.getEntity();
-        if (UtilBlock.isInLiquid(livingEntity)) {
-            UtilMessage.message(livingEntity, "Bow", "You cannot shoot a bow in liquid.");
-            event.setCancelled(true);
-            return;
-        }
-
-        final Role role = roleManager.getRole(livingEntity).orElse(null);
-        if (role != Role.ASSASSIN && role != Role.RANGER) {
-            UtilMessage.message(livingEntity, "Bow", "You can't shoot a bow without Assassin or Ranger equipped.");
-            event.setCancelled(true);
-        }
     }
 
     @EventHandler(priority = EventPriority.NORMAL)

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/item/Bow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/item/Bow.java
@@ -1,0 +1,67 @@
+package me.mykindos.betterpvp.champions.item;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.EqualsAndHashCode;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.roles.RoleManager;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.item.FallbackItem;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.model.WeaponItem;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.Reloadable;
+import org.bukkit.Material;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Optional;
+
+@Singleton
+@ItemKey("core:bow")
+@BPvPListener
+@FallbackItem(value = Material.BOW, keepRecipes = true)
+public class Bow extends WeaponItem implements Listener, Reloadable {
+
+    @EqualsAndHashCode.Exclude
+    private final ItemFactory itemFactory;
+
+    @EqualsAndHashCode.Exclude
+    private final RoleManager roleManager;
+
+    @Inject
+    private Bow(Champions champions, ItemFactory itemFactory, RoleManager roleManager) {
+        super(champions, "Bow", ItemStack.of(Material.BOW), ItemRarity.COMMON);
+        this.itemFactory = itemFactory;
+        this.roleManager = roleManager;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onShootBow(EntityShootBowEvent event) {
+        if (event.getBow() == null) return;
+        Optional<ItemInstance> itemInstanceOptional = itemFactory.fromItemStack(event.getBow());
+        if (itemInstanceOptional.isPresent() && itemInstanceOptional.get().getBaseItem() != this) return;
+
+        final LivingEntity livingEntity = event.getEntity();
+        if (UtilBlock.isInLiquid(livingEntity)) {
+            UtilMessage.message(livingEntity, "Bow", "You cannot shoot this bow in liquid.");
+            event.setCancelled(true);
+            return;
+        }
+
+        final Role role = roleManager.getRole(livingEntity).orElse(null);
+        if (role != Role.ASSASSIN && role != Role.RANGER) {
+            UtilMessage.message(livingEntity, "Bow", "You can't shoot this bow without Assassin or Ranger equipped.");
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1992

Since bows were a custom item (registered in core), any bow was allowed to be used anywhere. Added a bow to champions and moved that specific logic to that bow.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
