### PR TITLE
Fix anti heal and update UtilEntity#health

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/AntiHealListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/AntiHealListener.java
@@ -13,11 +13,26 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
+
+import java.util.Set;
+
+import static org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.CUSTOM;
+import static org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.MAGIC;
+import static org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.MAGIC_REGEN;
+import static org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.REGEN;
+import static org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.SATIATED;
 
 @BPvPListener
 @Singleton
 public class AntiHealListener implements Listener {
+
+    private static final Set<EntityRegainHealthEvent.RegainReason> healReasons = Set.of(
+            SATIATED,
+            MAGIC,
+            MAGIC_REGEN,
+            CUSTOM,
+            REGEN
+    );
 
     private final EffectManager effectManager;
 
@@ -30,9 +45,7 @@ public class AntiHealListener implements Listener {
     public void onEntityRegainHealth(EntityRegainHealthEvent event) {
         if (!(event.getEntity() instanceof LivingEntity ent)) return;
         effectManager.getEffect(ent, EffectTypes.ANTI_HEAL).ifPresent(effect -> {
-            if (event.getRegainReason() == EntityRegainHealthEvent.RegainReason.SATIATED
-                    || event.getRegainReason() == EntityRegainHealthEvent.RegainReason.REGEN
-                    || event.getRegainReason() == EntityRegainHealthEvent.RegainReason.MAGIC_REGEN) {
+            if (healReasons.contains(event.getRegainReason())) {
                 if ((event.getEntity() instanceof Player player)) {
                     player.playSound(player.getLocation(), Sound.BLOCK_GLASS_BREAK, 0.5f, 2.0f);
                 }
@@ -48,10 +61,5 @@ public class AntiHealListener implements Listener {
             event.getTarget().getWorld().playSound(event.getTarget().getLocation(), Sound.BLOCK_GLASS_BREAK, 2.0f, 2.0f );
             UtilMessage.message(event.getTarget(), "Anti Heal", "You can no longer regenerate health!");
         }
-    }
-
-    @EventHandler
-    public void removeEffectOnDeath(PlayerDeathEvent event) {
-        effectManager.removeEffect(event.getEntity(), EffectTypes.REGENERATION);
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/positive/RegenerationEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/positive/RegenerationEffect.java
@@ -11,6 +11,7 @@ import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffectType;
 
@@ -72,7 +73,7 @@ public class RegenerationEffect extends VanillaEffectType {
         Long lastHealTime = lastHeal.computeIfAbsent(livingEntity, k -> 0L);
         if (lastHealTime - System.currentTimeMillis() <= 0) {
             final double maxHealth = healthService.getMaxHealth(livingEntity);
-            double actualHeal = UtilEntity.health(livingEntity, maxHealth * 0.05);
+            double actualHeal = UtilEntity.health(livingEntity, maxHealth * 0.05, EntityRegainHealthEvent.RegainReason.MAGIC_REGEN);
 
 
             if (actualHeal > 0) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilEntity.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -338,12 +339,19 @@ public class UtilEntity {
     }
 
     /**
+     *
+     */
+    public static double health(LivingEntity ent, double mod) {
+        return health(ent, mod, EntityRegainHealthEvent.RegainReason.CUSTOM);
+    }
+
+    /**
      * Returns the amount of healing actually done
      * @param ent
      * @param mod
      * @return
      */
-    public static double health(LivingEntity ent, double mod) {
+    public static double health(LivingEntity ent, double mod, EntityRegainHealthEvent.RegainReason reason) {
         if (ent.isDead()) {
             return 0;
         }
@@ -352,14 +360,14 @@ public class UtilEntity {
         double healing = mod;
         if (health < 0.0D) {
             healing = 0 - entityHealth;
-            health = 0.0D;
-
+            ent.setHealth(0);
+            return healing;
         }
         if (health > UtilPlayer.getMaxHealth(ent)) {
             healing = UtilPlayer.getMaxHealth(ent) - entityHealth;
-            health = UtilPlayer.getMaxHealth(ent);
         }
-        ent.setHealth(health);
+        //living entity guards against overheal and calculates max health the same way we do
+        ent.heal(healing);
         return healing;
     }
 


### PR DESCRIPTION
Fix anti heal not always working because not all healing went through EntityRegenerateHealthEvent
Update UtilEntity#health to use LivingEntity#health (which triggers EntityRegnerateHealthEvent). Unsure why it didn't already, all the guards we do exist there and it gets max health the same way

Fixes #1991

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
