### PR TITLE
Fix circular dependency

### DIFF
--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/FishingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/FishingHandler.java
@@ -3,12 +3,10 @@ package me.mykindos.betterpvp.progression.profession.fishing;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import io.papermc.paper.datacomponent.DataComponentTypes;
 import lombok.CustomLog;
 import lombok.Getter;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.item.ItemFactory;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
 import me.mykindos.betterpvp.core.loot.LootTable;
@@ -16,9 +14,6 @@ import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
-import me.mykindos.betterpvp.core.utilities.UtilMath;
-import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.ProfessionHandler;
@@ -29,19 +24,11 @@ import me.mykindos.betterpvp.progression.profession.fishing.leaderboards.Fishing
 import me.mykindos.betterpvp.progression.profession.fishing.leaderboards.FishingWeightLeaderboard;
 import me.mykindos.betterpvp.progression.profession.fishing.repository.FishingRepository;
 import me.mykindos.betterpvp.progression.profession.skill.ProfessionNodeManager;
-import me.mykindos.betterpvp.progression.profession.skill.fishing.attributes.fishingdoubletreasurechance.FishingDoubleTreasureChanceAttribute;
-import me.mykindos.betterpvp.progression.profession.skill.fishing.attributes.fishingtreasurechance.FishingTreasureChanceAttribute;
 import me.mykindos.betterpvp.progression.profile.ProfessionData;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
 
 @Singleton
 @CustomLog
@@ -55,35 +42,27 @@ public class FishingHandler extends ProfessionHandler implements Reloadable {
     private final FishingRepository fishingRepository;
     private final LeaderboardManager leaderboardManager;
     private final ItemFactory itemFactory;
-    private final FishingTreasureChanceAttribute treasureChanceAttribute;
-    private final FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
     private final LootTableRegistry lootTableRegistry;
     private final LootSessionController sessionController;
 
     private LootTable lootTable;
-    private LootTable treasureLootTable;
 
     @Inject
     protected FishingHandler(Progression progression, ItemFactory itemFactory, ClientManager clientManager,
                              ProfessionProfileManager professionProfileManager, Provider<ProfessionNodeManager> nodeManager,
                              FishingRepository fishingRepository, LeaderboardManager leaderboardManager,
-                             LootTableRegistry lootTableRegistry, LootSessionController sessionController,
-                             FishingTreasureChanceAttribute treasureChanceAttribute,
-                             FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute) {
+                             LootTableRegistry lootTableRegistry, LootSessionController sessionController) {
         super(progression, clientManager, professionProfileManager, nodeManager, "Fishing");
         this.fishingRepository = fishingRepository;
         this.leaderboardManager = leaderboardManager;
         this.itemFactory = itemFactory;
         this.lootTableRegistry = lootTableRegistry;
         this.sessionController = sessionController;
-        this.treasureChanceAttribute = treasureChanceAttribute;
-        this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
     }
 
     @Override
     public void reload() {
         this.lootTable = lootTableRegistry.loadLootTable("fishing");
-        this.treasureLootTable = lootTableRegistry.loadLootTable("fishing_treasure_chance");
     }
 
     public void addFish(Player player, Fish fish) {
@@ -145,66 +124,6 @@ public class FishingHandler extends ProfessionHandler implements Reloadable {
         final LootSession session = sessionController.resolve(player, lootTable, () -> LootSession.newSession(lootTable, player));
         final LootContext context = new LootContext(session, location, "Fishing");
         return this.lootTable.generateLoot(context);
-    }
-
-    public void attemptTreasureDrop(Player player, Location location) {
-        double treasureChance = treasureChanceAttribute.getChance(player);
-        if (treasureChance <= 0 || UtilMath.randDouble(0, 100) >= treasureChance) {
-            return;
-        }
-
-        LootBundle firstBundle = getRandomTreasureLoot(player, location);
-        for (Loot<?, ?> loot : firstBundle) {
-            awardTreasure(player, location, loot, firstBundle.getContext(), false);
-        }
-
-        // Roll a second bundle independently rather than doubling amounts on the first.
-        if (UtilMath.randDouble(0, 100) < doubleTreasureChanceAttribute.getChance(player)) {
-            LootBundle secondBundle = getRandomTreasureLoot(player, location);
-            for (Loot<?, ?> loot : secondBundle) {
-                awardTreasure(player, location, loot, secondBundle.getContext(), true);
-            }
-        }
-    }
-
-    private @NotNull LootBundle getRandomTreasureLoot(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Fishing");
-        return this.treasureLootTable.generateLoot(context);
-    }
-
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context, boolean doubled) {
-        final Object award = loot.award(context);
-        if (award instanceof Item item) {
-            sendTreasureMessage(player, location, item.getItemStack(), doubled);
-        } else if (award instanceof ItemStack itemStack) {
-            sendTreasureMessage(player, location, itemStack, doubled);
-        }
-    }
-
-    private void sendTreasureMessage(Player player, Location location, ItemStack itemStack, boolean doubled) {
-        final Component name;
-        if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
-            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
-        } else {
-            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
-                    Component.translatable(itemStack.getType().translationKey()));
-        }
-
-        TextComponent message = Component.text("You found ")
-                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
-                .append(Component.text(" "))
-                .append(name);
-
-        if (doubled) {
-            message = message.append(Component.text(" (doubled!)"));
-        }
-
-        UtilMessage.message(player, getName(), message);
-
-        log.info("{} found {}x {} from fishing treasure{}", player.getName(), itemStack.getAmount(),
-                        itemStack.getType().name().toLowerCase(), doubled ? " (doubled)" : "")
-                .addClientContext(player).addLocationContext(location).submit();
     }
 
     @Override

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/event/PlayerFishingDoubleTreasureDropEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/event/PlayerFishingDoubleTreasureDropEvent.java
@@ -1,0 +1,21 @@
+package me.mykindos.betterpvp.progression.profession.fishing.event;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@Getter
+public class PlayerFishingDoubleTreasureDropEvent extends CustomCancellableEvent {
+
+    private final Player player;
+    private final Location location;
+    private final LootBundle bundle;
+
+    public PlayerFishingDoubleTreasureDropEvent(Player player, Location location, LootBundle bundle) {
+        this.player = player;
+        this.location = location;
+        this.bundle = bundle;
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/event/PlayerFishingTreasureDropEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/event/PlayerFishingTreasureDropEvent.java
@@ -1,0 +1,21 @@
+package me.mykindos.betterpvp.progression.profession.fishing.event;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@Getter
+public class PlayerFishingTreasureDropEvent extends CustomCancellableEvent {
+
+    private final Player player;
+    private final Location location;
+    private final LootBundle bundle;
+
+    public PlayerFishingTreasureDropEvent(Player player, Location location, LootBundle bundle) {
+        this.player = player;
+        this.location = location;
+        this.bundle = bundle;
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
@@ -281,8 +281,6 @@ public class FishingListener implements Listener {
 
         }
 
-        fishingHandler.attemptTreasureDrop(player, hook.getLocation());
-
         player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 5f, 0F);
         UtilServer.callEvent(new PlayerStopFishingEvent(player, bundle, PlayerStopFishingEvent.FishingResult.CATCH));
     }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
@@ -17,7 +17,6 @@ public interface IProfessionAttribute {
     }
 
     static double computeValue(Player player, String profession, IProfessionAttribute attribute, ProfessionProfileManager profileManager) {
-        System.out.println(System.identityHashCode(profileManager));
         return profileManager.getObject(player.getUniqueId().toString())
                 .map(profile -> profile.getProfessionDataMap().get(profession))
                 .map(data -> data.getBuild().getNodes().entrySet().stream()

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
@@ -23,7 +23,7 @@ public interface IProfessionAttribute {
                         .filter(e -> e.getKey() instanceof ProfessionAttributeNode && e.getValue() > 0)
                         .mapToDouble(e -> computeNodeContribution((ProfessionAttributeNode) e.getKey(), e.getValue(), attribute))
                         .sum())
-                .orElse(0.0);
+                .orElseThrow();
     }
 
     private static double computeNodeContribution(ProfessionAttributeNode node, int level, IProfessionAttribute attribute) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/IProfessionAttribute.java
@@ -17,6 +17,7 @@ public interface IProfessionAttribute {
     }
 
     static double computeValue(Player player, String profession, IProfessionAttribute attribute, ProfessionProfileManager profileManager) {
+        System.out.println(System.identityHashCode(profileManager));
         return profileManager.getObject(player.getUniqueId().toString())
                 .map(profile -> profile.getProfessionDataMap().get(profession))
                 .map(data -> data.getBuild().getNodes().entrySet().stream()

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
@@ -1,0 +1,116 @@
+package me.mykindos.betterpvp.progression.profession.skill.fishing.attributes.fishingdoubletreasurechance;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootTable;
+import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.session.LootSession;
+import me.mykindos.betterpvp.core.loot.session.LootSessionController;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.Reloadable;
+import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingDoubleTreasureDropEvent;
+import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingTreasureDropEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+@BPvPListener
+@Singleton
+@CustomLog
+public class DoubleTreasureChanceListener implements Listener, Reloadable {
+
+    private final FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
+    private final LootTableRegistry lootTableRegistry;
+    private final LootSessionController sessionController;
+
+    private LootTable treasureLootTable;
+
+    @Inject
+    public DoubleTreasureChanceListener(FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute,
+                                        LootTableRegistry lootTableRegistry,
+                                        LootSessionController sessionController) {
+        this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
+        this.lootTableRegistry = lootTableRegistry;
+        this.sessionController = sessionController;
+    }
+
+    @Override
+    public void reload() {
+        this.treasureLootTable = lootTableRegistry.loadLootTable("fishing_treasure_chance");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTreasureDrop(PlayerFishingTreasureDropEvent event) {
+        final Player player = event.getPlayer();
+        final Location location = event.getLocation();
+
+        double chance = doubleTreasureChanceAttribute.getChance(player);
+        if (chance <= 0 || UtilMath.randDouble(0, 1) >= chance) {
+            return;
+        }
+
+        LootBundle bundle = rollTreasure(player, location);
+        PlayerFishingDoubleTreasureDropEvent doubleEvent = UtilServer.callEvent(new PlayerFishingDoubleTreasureDropEvent(player, location, bundle));
+        if (doubleEvent.isCancelled()) {
+            return;
+        }
+
+        for (Loot<?, ?> loot : bundle) {
+            awardTreasure(player, location, loot, bundle.getContext());
+        }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, "Fishing");
+        return treasureLootTable.generateLoot(context);
+    }
+
+    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
+        final Object award = loot.award(context);
+        if (award instanceof Item item) {
+            sendMessage(player, location, item.getItemStack());
+        } else if (award instanceof ItemStack itemStack) {
+            sendMessage(player, location, itemStack);
+        }
+    }
+
+    private void sendMessage(Player player, Location location, ItemStack itemStack) {
+        final Component name;
+        if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
+            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
+        } else {
+            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
+                    Component.translatable(itemStack.getType().translationKey()));
+        }
+
+        TextComponent message = Component.text("You found ")
+                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
+                .append(Component.text(" "))
+                .append(name)
+                .append(Component.text(" (doubled!)"));
+
+        UtilMessage.message(player, "Fishing", message);
+
+        log.info("{} found {}x {} from fishing treasure (doubled)", player.getName(), itemStack.getAmount(),
+                        itemStack.getType().name().toLowerCase())
+                .addClientContext(player).addLocationContext(location).submit();
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingtreasurechance/TreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingtreasurechance/TreasureChanceListener.java
@@ -1,0 +1,115 @@
+package me.mykindos.betterpvp.progression.profession.skill.fishing.attributes.fishingtreasurechance;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootTable;
+import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.session.LootSession;
+import me.mykindos.betterpvp.core.loot.session.LootSessionController;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.Reloadable;
+import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerCaughtFishEvent;
+import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingTreasureDropEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+@BPvPListener
+@Singleton
+@CustomLog
+public class TreasureChanceListener implements Listener, Reloadable {
+
+    private final FishingTreasureChanceAttribute treasureChanceAttribute;
+    private final LootTableRegistry lootTableRegistry;
+    private final LootSessionController sessionController;
+
+    private LootTable treasureLootTable;
+
+    @Inject
+    public TreasureChanceListener(FishingTreasureChanceAttribute treasureChanceAttribute,
+                                  LootTableRegistry lootTableRegistry,
+                                  LootSessionController sessionController) {
+        this.treasureChanceAttribute = treasureChanceAttribute;
+        this.lootTableRegistry = lootTableRegistry;
+        this.sessionController = sessionController;
+    }
+
+    @Override
+    public void reload() {
+        this.treasureLootTable = lootTableRegistry.loadLootTable("fishing_treasure_chance");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onCaughtFish(PlayerCaughtFishEvent event) {
+        final Player player = event.getPlayer();
+        final Location location = event.getHook().getLocation();
+
+        double chance = treasureChanceAttribute.getChance(player);
+        if (chance <= 0 || UtilMath.randDouble(0, 1) >= chance) {
+            return;
+        }
+
+        LootBundle bundle = rollTreasure(player, location);
+        PlayerFishingTreasureDropEvent treasureEvent = UtilServer.callEvent(new PlayerFishingTreasureDropEvent(player, location, bundle));
+        if (treasureEvent.isCancelled()) {
+            return;
+        }
+
+        for (Loot<?, ?> loot : bundle) {
+            awardTreasure(player, location, loot, bundle.getContext());
+        }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, "Fishing");
+        return treasureLootTable.generateLoot(context);
+    }
+
+    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
+        final Object award = loot.award(context);
+        if (award instanceof Item item) {
+            sendMessage(player, location, item.getItemStack());
+        } else if (award instanceof ItemStack itemStack) {
+            sendMessage(player, location, itemStack);
+        }
+    }
+
+    private void sendMessage(Player player, Location location, ItemStack itemStack) {
+        final Component name;
+        if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
+            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
+        } else {
+            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
+                    Component.translatable(itemStack.getType().translationKey()));
+        }
+
+        TextComponent message = Component.text("You found ")
+                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
+                .append(Component.text(" "))
+                .append(name);
+
+        UtilMessage.message(player, "Fishing", message);
+
+        log.info("{} found {}x {} from fishing treasure", player.getName(), itemStack.getAmount(),
+                        itemStack.getType().name().toLowerCase())
+                .addClientContext(player).addLocationContext(location).submit();
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
@@ -1,0 +1,129 @@
+package me.mykindos.betterpvp.progression.profession.skill.woodcutting.attributes.doubletreasurechance;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootTable;
+import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.session.LootSession;
+import me.mykindos.betterpvp.core.loot.session.LootSessionController;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.Reloadable;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingDoubleTreasureDropEvent;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Objects;
+
+@BPvPListener
+@Singleton
+@CustomLog
+public class WoodcuttingDoubleTreasureChanceListener implements Listener, Reloadable {
+
+    private final WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
+    private final LootTableRegistry lootTableRegistry;
+    private final LootSessionController sessionController;
+    private final ItemFactory itemFactory;
+
+    private LootTable treasureLootTable;
+
+    @Inject
+    public WoodcuttingDoubleTreasureChanceListener(WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute,
+                                                   LootTableRegistry lootTableRegistry,
+                                                   LootSessionController sessionController,
+                                                   ItemFactory itemFactory) {
+        this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
+        this.lootTableRegistry = lootTableRegistry;
+        this.sessionController = sessionController;
+        this.itemFactory = itemFactory;
+    }
+
+    @Override
+    public void reload() {
+        this.treasureLootTable = lootTableRegistry.loadLootTable("woodcutting_treasure_chance");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTreasureDrop(PlayerWoodcuttingTreasureDropEvent event) {
+        final Player player = event.getPlayer();
+        final Location location = event.getLocation();
+
+        double chance = doubleTreasureChanceAttribute.getChance(player);
+        if (chance <= 0 || UtilMath.randDouble(0, 1) >= chance) {
+            return;
+        }
+
+        LootBundle bundle = rollTreasure(player, location);
+        PlayerWoodcuttingDoubleTreasureDropEvent doubleEvent = UtilServer.callEvent(new PlayerWoodcuttingDoubleTreasureDropEvent(player, location, bundle));
+        if (doubleEvent.isCancelled()) {
+            return;
+        }
+
+        for (Loot<?, ?> loot : bundle) {
+            awardTreasure(player, location, loot, bundle.getContext());
+        }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, "Woodcutting");
+        return treasureLootTable.generateLoot(context);
+    }
+
+    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
+        final Object award = loot.award(context);
+        if (award instanceof Item item) {
+            sendMessage(player, location, item.getItemStack());
+        } else if (award instanceof ItemStack itemStack) {
+            ItemStack finalItemStack = itemFactory.convertItemStack(itemStack).orElse(itemStack);
+            UtilItem.insert(player, finalItemStack);
+            sendMessage(player, location, finalItemStack);
+        } else if (award instanceof List<?> itemStacks) {
+            for (Object awardedItem : itemStacks) {
+                if (!(awardedItem instanceof ItemStack itemStack)) continue;
+                sendMessage(player, location, itemStack);
+            }
+        }
+    }
+
+    private void sendMessage(Player player, Location location, ItemStack itemStack) {
+        final Component name;
+        if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
+            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
+        } else {
+            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
+                    Component.translatable(itemStack.getType().translationKey()));
+        }
+
+        TextComponent message = Component.text("You found ")
+                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
+                .append(Component.text(" "))
+                .append(name)
+                .append(Component.text(" (doubled!)"));
+
+        UtilMessage.message(player, "Woodcutting", message);
+
+        log.info("{} found {}x {} from woodcutting treasure (doubled)", player.getName(), itemStack.getAmount(),
+                        itemStack.getType().name().toLowerCase())
+                .addClientContext(player).addLocationContext(location).submit();
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
@@ -1,0 +1,128 @@
+package me.mykindos.betterpvp.progression.profession.skill.woodcutting.attributes.treasurechance;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootTable;
+import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.session.LootSession;
+import me.mykindos.betterpvp.core.loot.session.LootSessionController;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
+import me.mykindos.betterpvp.core.utilities.UtilMath;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.Reloadable;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
+import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Objects;
+
+@BPvPListener
+@Singleton
+@CustomLog
+public class WoodcuttingTreasureChanceListener implements Listener, Reloadable {
+
+    private final WoodcuttingTreasureChanceAttribute treasureChanceAttribute;
+    private final LootTableRegistry lootTableRegistry;
+    private final LootSessionController sessionController;
+    private final ItemFactory itemFactory;
+
+    private LootTable treasureLootTable;
+
+    @Inject
+    public WoodcuttingTreasureChanceListener(WoodcuttingTreasureChanceAttribute treasureChanceAttribute,
+                                             LootTableRegistry lootTableRegistry,
+                                             LootSessionController sessionController,
+                                             ItemFactory itemFactory) {
+        this.treasureChanceAttribute = treasureChanceAttribute;
+        this.lootTableRegistry = lootTableRegistry;
+        this.sessionController = sessionController;
+        this.itemFactory = itemFactory;
+    }
+
+    @Override
+    public void reload() {
+        this.treasureLootTable = lootTableRegistry.loadLootTable("woodcutting_treasure_chance");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onChopLog(PlayerChopLogEvent event) {
+        final Player player = event.getPlayer();
+        final Location location = event.getChoppedLogBlock().getLocation();
+
+        double chance = treasureChanceAttribute.getChance(player);
+        if (chance <= 0 || UtilMath.randDouble(0, 1) >= chance) {
+            return;
+        }
+
+        LootBundle bundle = rollTreasure(player, location);
+        PlayerWoodcuttingTreasureDropEvent treasureEvent = UtilServer.callEvent(new PlayerWoodcuttingTreasureDropEvent(player, location, bundle));
+        if (treasureEvent.isCancelled()) {
+            return;
+        }
+
+        for (Loot<?, ?> loot : bundle) {
+            awardTreasure(player, location, loot, bundle.getContext());
+        }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, "Woodcutting");
+        return treasureLootTable.generateLoot(context);
+    }
+
+    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
+        final Object award = loot.award(context);
+        if (award instanceof Item item) {
+            sendMessage(player, location, item.getItemStack());
+        } else if (award instanceof ItemStack itemStack) {
+            ItemStack finalItemStack = itemFactory.convertItemStack(itemStack).orElse(itemStack);
+            UtilItem.insert(player, finalItemStack);
+            sendMessage(player, location, finalItemStack);
+        } else if (award instanceof List<?> itemStacks) {
+            for (Object awardedItem : itemStacks) {
+                if (!(awardedItem instanceof ItemStack itemStack)) continue;
+                sendMessage(player, location, itemStack);
+            }
+        }
+    }
+
+    private void sendMessage(Player player, Location location, ItemStack itemStack) {
+        final Component name;
+        if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
+            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
+        } else {
+            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
+                    Component.translatable(itemStack.getType().translationKey()));
+        }
+
+        TextComponent message = Component.text("You found ")
+                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
+                .append(Component.text(" "))
+                .append(name);
+
+        UtilMessage.message(player, "Woodcutting", message);
+
+        log.info("{} found {}x {} from woodcutting treasure", player.getName(), itemStack.getAmount(),
+                        itemStack.getType().name().toLowerCase())
+                .addClientContext(player).addLocationContext(location).submit();
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -3,7 +3,6 @@ package me.mykindos.betterpvp.progression.profession.woodcutting;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import io.papermc.paper.datacomponent.DataComponentTypes;
 import lombok.CustomLog;
 import lombok.Getter;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
@@ -11,7 +10,6 @@ import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.framework.blocktag.BlockTagManager;
 import me.mykindos.betterpvp.core.item.ItemFactory;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
 import me.mykindos.betterpvp.core.loot.LootTable;
@@ -20,38 +18,26 @@ import me.mykindos.betterpvp.core.loot.item.DroppedItemLoot;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
-import me.mykindos.betterpvp.core.utilities.UtilMath;
-import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.Progression;
 import me.mykindos.betterpvp.progression.profession.ProfessionHandler;
 import me.mykindos.betterpvp.progression.profession.skill.ProfessionNodeManager;
-import me.mykindos.betterpvp.progression.profession.skill.woodcutting.attributes.doubletreasurechance.WoodcuttingDoubleTreasureChanceAttribute;
-import me.mykindos.betterpvp.progression.profession.skill.woodcutting.attributes.treasurechance.WoodcuttingTreasureChanceAttribute;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
 import me.mykindos.betterpvp.progression.profession.woodcutting.leaderboards.TotalLogsChoppedLeaderboard;
 import me.mykindos.betterpvp.progression.profession.woodcutting.repository.WoodcuttingRepository;
 import me.mykindos.betterpvp.progression.profile.ProfessionData;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.DoubleUnaryOperator;
 
 
@@ -69,8 +55,6 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
     private final BlockTagManager blockTagManager;
     private final EffectManager effectManager;
     private final ItemFactory itemFactory;
-    private final WoodcuttingTreasureChanceAttribute treasureChanceAttribute;
-    private final WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
 
     /**
      * Maps the log type (key) to its base experience value for chopping it (value)
@@ -81,16 +65,13 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
     private final LootSessionController sessionController;
     private final Map<String, LootTable> logLootTables = new HashMap<>();
     private LootTable lootTable;
-    private LootTable treasureLootTable;
 
     @Inject
     public WoodcuttingHandler(Progression progression, ClientManager clientManager, ProfessionProfileManager professionProfileManager,
                               Provider<ProfessionNodeManager> nodeManager,
                               WoodcuttingRepository woodcuttingRepository, LeaderboardManager leaderboardManager,
                               BlockTagManager blockTagManager, EffectManager effectManager, ItemFactory itemFactory,
-                              LootTableRegistry lootTableRegistry, LootSessionController sessionController,
-                              WoodcuttingTreasureChanceAttribute treasureChanceAttribute,
-                              WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute) {
+                              LootTableRegistry lootTableRegistry, LootSessionController sessionController) {
         super(progression, clientManager, professionProfileManager, nodeManager, "Woodcutting");
         this.woodcuttingRepository = woodcuttingRepository;
         this.leaderboardManager = leaderboardManager;
@@ -99,8 +80,6 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
         this.itemFactory = itemFactory;
         this.lootTableRegistry = lootTableRegistry;
         this.sessionController = sessionController;
-        this.treasureChanceAttribute = treasureChanceAttribute;
-        this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
     }
 
     /**
@@ -120,7 +99,6 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
         this.logLootTables.put("CRIMSON_STEM", lootTableRegistry.loadLootTable("woodcutting_crimson_stem"));
         this.logLootTables.put("WARPED_STEM", lootTableRegistry.loadLootTable("woodcutting_warped_stem"));
         this.lootTable = lootTableRegistry.loadLootTable("woodcutting");
-        this.treasureLootTable = lootTableRegistry.loadLootTable("woodcutting_treasure_chance");
     }
 
     /**
@@ -200,8 +178,6 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
                 totalLogsChoppedLeaderboard.attemptAnnounce(player, result);
             });
         });
-
-        attemptTreasureDrop(player, block.getLocation());
     }
 
     @Override
@@ -220,85 +196,10 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
                 .forEach(lootType -> {
                     DroppedItemLoot droppedItemLoot = (DroppedItemLoot) lootType;
                     Item item = droppedItemLoot.award(lootContext);
-                    Bukkit.broadcastMessage("Awarding " + item.getItemStack().getType().name());
                     if (isProtected) {
                         UtilItem.reserveItem(item, player, 10);
                     }
                 });
-    }
-
-    private void attemptTreasureDrop(Player player, Location location) {
-        double treasureChance = treasureChanceAttribute.getChance(player);
-        if (treasureChance <= 0 || UtilMath.randDouble(0, 100) >= treasureChance) {
-            return;
-        }
-
-        boolean doubleTreasure = UtilMath.randDouble(0, 100) < doubleTreasureChanceAttribute.getChance(player);
-        LootBundle bundle = getRandomTreasureLoot(player, location);
-        for (Loot<?, ?> loot : bundle) {
-            awardTreasure(player, location, loot, bundle.getContext(), doubleTreasure);
-        }
-    }
-
-    private @NotNull LootBundle getRandomTreasureLoot(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Woodcutting");
-        return this.treasureLootTable.generateLoot(context);
-    }
-
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context, boolean doubleTreasure) {
-        final Object award = loot.award(context);
-        if (award instanceof Item item) {
-            ItemStack itemStack = item.getItemStack();
-            if (doubleTreasure) {
-                itemStack.setAmount(itemStack.getAmount() * 2);
-                item.setItemStack(itemStack);
-            }
-            sendTreasureMessage(player, location, itemStack, doubleTreasure);
-        } else if (award instanceof ItemStack itemStack) {
-            if (doubleTreasure) {
-                itemStack.setAmount(itemStack.getAmount() * 2);
-            }
-            ItemStack finalItemStack = itemFactory.convertItemStack(itemStack).orElse(itemStack);
-            UtilItem.insert(player, finalItemStack);
-            sendTreasureMessage(player, location, finalItemStack, doubleTreasure);
-        } else if (award instanceof List<?> itemStacks) {
-            for (Object awardedItem : itemStacks) {
-                if (!(awardedItem instanceof ItemStack itemStack)) continue;
-                ItemStack displayItemStack = itemStack;
-                if (doubleTreasure) {
-                    ItemStack extraTreasure = itemStack.clone();
-                    UtilItem.insert(player, extraTreasure);
-                    displayItemStack = itemStack.clone();
-                    displayItemStack.setAmount(itemStack.getAmount() + extraTreasure.getAmount());
-                }
-                sendTreasureMessage(player, location, displayItemStack, doubleTreasure);
-            }
-        }
-    }
-
-    private void sendTreasureMessage(Player player, Location location, ItemStack itemStack, boolean doubleTreasure) {
-        final Component name;
-        if (itemStack.getItemMeta().hasDisplayName()) {
-            name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
-        } else {
-            name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
-                    Component.translatable(itemStack.getType().translationKey()));
-        }
-
-        TextComponent message = Component.text("You found ")
-                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
-                .append(Component.text(" "))
-                .append(name);
-
-        if (doubleTreasure) {
-            message = message.append(Component.text(" and doubled your treasure"));
-        }
-
-        UtilMessage.message(player, getName(), message);
-
-        log.info("{} found {}x {} from woodcutting treasure.", player.getName(), itemStack.getAmount(), itemStack.getType().name().toLowerCase())
-                .addClientContext(player).addLocationContext(location).submit();
     }
 
     /**

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerWoodcuttingDoubleTreasureDropEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerWoodcuttingDoubleTreasureDropEvent.java
@@ -1,0 +1,21 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.event;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@Getter
+public class PlayerWoodcuttingDoubleTreasureDropEvent extends CustomCancellableEvent {
+
+    private final Player player;
+    private final Location location;
+    private final LootBundle bundle;
+
+    public PlayerWoodcuttingDoubleTreasureDropEvent(Player player, Location location, LootBundle bundle) {
+        this.player = player;
+        this.location = location;
+        this.bundle = bundle;
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerWoodcuttingTreasureDropEvent.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/event/PlayerWoodcuttingTreasureDropEvent.java
@@ -1,0 +1,21 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.event;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomCancellableEvent;
+import me.mykindos.betterpvp.core.loot.LootBundle;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@Getter
+public class PlayerWoodcuttingTreasureDropEvent extends CustomCancellableEvent {
+
+    private final Player player;
+    private final Location location;
+    private final LootBundle bundle;
+
+    public PlayerWoodcuttingTreasureDropEvent(Player player, Location location, LootBundle bundle) {
+        this.player = player;
+        this.location = location;
+        this.bundle = bundle;
+    }
+}


### PR DESCRIPTION
## Describe your changes
- Fix woodcutting treasure/double treasure chance attribute
- Fix fishing treasure/double treasure chance attribute
- These bugs originated from a circular dependency that caused two instances of `ProfessionProfileManager`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
