### PR TITLE
Fix being unable to craft torches

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Torch.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Torch.java
@@ -1,0 +1,62 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.FallbackItem;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.model.VanillaItem;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+
+@Singleton
+@ItemKey("core:torch")
+@FallbackItem(value = Material.TORCH, keepRecipes = true)
+@CustomLog
+public class Torch extends VanillaItem {
+
+    private transient boolean registered;
+
+    @Inject
+    private Torch() {
+        super("Torch", Material.TORCH, ItemRarity.COMMON);
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry, ItemFactory itemFactory) {
+        if (registered) return;
+        registered = true;
+
+        //the default minecraft:torch recipe uses coal, we need to register the charcoal recipe to match https://minecraft.wiki/w/Torch#Crafting_ingredient
+
+        final BaseItem charcoal = itemFactory.getFallbackItem(Material.CHARCOAL);
+        final BaseItem stick = itemFactory.getFallbackItem(Material.STICK);
+
+        final RecipeIngredient charcoalIngredient = new RecipeIngredient(charcoal, 1);
+        final RecipeIngredient stickIngredient = new RecipeIngredient(stick, 1);
+
+        final String[] pattern = new String[] {
+                "C",
+                "S",
+        };
+
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(
+                this,
+                instance -> instance.getItemStack().setAmount(4),
+                pattern,
+                itemFactory
+                )
+                .setIngredient('S', stickIngredient);
+        final ShapedCraftingRecipe charcoalRecipe = builder.setIngredient('C', charcoalIngredient).build();
+
+
+        registry.registerRecipe(new NamespacedKey("core", "torch_charcoal"), charcoalRecipe);
+    }
+
+}


### PR DESCRIPTION
Register torch as its own item to register a charcoal variant, as Minecraft:torch only has coal (probably some bug here on our end, as in vanilla both coal and charcoal work).

This also changes the order of registration, allowing coal to be used. Charcoal is still blocked because of #2029, which Rey said he was going to look at (or if he doesn't I can take a crack at it).

Fixes #2027


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
