### PR TITLE
Add loot table expressions

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/Loot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/Loot.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.loot;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import me.mykindos.betterpvp.core.utilities.model.item.ItemView;
 
@@ -15,6 +16,7 @@ import java.util.function.Predicate;
  *           As some rewards have an in-world type representation.
  */
 @Data
+@AllArgsConstructor
 public abstract class Loot<T, R> {
 
     /**
@@ -24,8 +26,10 @@ public abstract class Loot<T, R> {
 
     /**
      * The condition for this loot. If the condition is not met, the loot will not be awarded.
+     * <p>
+     * Mutable to allow deserializers to attach expression-based conditions after construction.
      */
-    private final Predicate<LootContext> condition;
+    private Predicate<LootContext> condition;
 
     /**
      * The reward for this loot.

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootConditions.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootConditions.java
@@ -1,0 +1,30 @@
+package me.mykindos.betterpvp.core.loot;
+
+import me.mykindos.betterpvp.core.loot.expression.ExpressionEngine;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Factories for {@link Loot#getCondition()} predicates.
+ */
+public final class LootConditions {
+
+    private LootConditions() {
+    }
+
+    /**
+     * A predicate that always returns {@code true}.
+     */
+    public static Predicate<LootContext> always() {
+        return ctx -> true;
+    }
+
+    /**
+     * A predicate that evaluates {@code expression} as a boolean against the context.
+     * Returns {@code false} if the expression fails to evaluate.
+     */
+    public static Predicate<LootContext> expression(String expression) {
+        return ctx -> ExpressionEngine.evalBoolean(expression, ctx, Map.of(), false);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootContext.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootContext.java
@@ -5,8 +5,11 @@ import lombok.Value;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Defines the context for which a loot table is being evaluated.
@@ -31,12 +34,39 @@ public class LootContext {
 
     @NotNull String source;
 
+    /**
+     * Caller-supplied named values made available to expression-based roll counts, weights
+     * and conditions. Values may be numbers, booleans or strings.
+     */
+    @NotNull Map<String, Object> inputs;
+
     public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull String source) {
+        this(session, location, source, Map.of());
+    }
+
+    public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull String source, @NotNull Map<String, Object> inputs) {
         Preconditions.checkArgument(!source.isEmpty(), "Source cannot be empty");
         this.location = location;
         this.session = session;
         this.source = source;
         this.time = Instant.now();
+        this.inputs = Map.copyOf(inputs);
     }
 
+    /**
+     * Returns a copy of this context with the given input added.
+     */
+    public @NotNull LootContext withInput(@NotNull String key, @Nullable Object value) {
+        final Map<String, Object> merged = new HashMap<>(this.inputs);
+        if (value == null) merged.remove(key);
+        else merged.put(key, value);
+        return new LootContext(session, location, source, merged);
+    }
+
+    /**
+     * Returns the named input value, or {@code null} if absent.
+     */
+    public @Nullable Object getInput(@NotNull String key) {
+        return inputs.get(key);
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootTable.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootTable.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Value;
+import me.mykindos.betterpvp.core.loot.expression.ExpressionEngine;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,12 +53,10 @@ public class LootTable {
     @NotNull List<@NotNull Loot<?, ?>> guaranteedLoot = new ArrayList<>();
 
     /**
-     * The weighted loot entries. These entries will be generated based on their weight.
-     * <p>
-     * Higher weights will result in a higher chance of being generated.
+     * The weighted loot entries.
      */
     @Builder.Default
-    @NotNull Multimap<@NotNull Integer, @NotNull Loot<?, ?>> weightedLoot = ArrayListMultimap.create();
+    @NotNull List<@NotNull WeightedEntry> weightedEntries = new ArrayList<>();
 
     /**
      * The pity rules for this loot table. See {@link PityRule}.
@@ -83,72 +82,42 @@ public class LootTable {
 
     /**
      * Generates a loot bundle based on this loot table.
-     * <p>
-     *     Two types of loot are generated:
-     *     <ul>
-     *         <li>Guaranteed loot: that is always generated regardless of the roll count.</li>
-     *         <li>Weighted loot: that is generated based on their weight.</li>
-     *     </ul>
-     * </p>
-     * <br>
-     * <p>
-     *     The steps to generate loot are the following:
-     *     <ol>
-     *         <li>Generate guaranteed loot.</li>
-     *         <li>Call the {@link #rollCountFunction} to get the number of loot entries to generate.</li>
-     *         <li>Make an aggregate list of weighted loot entries based on their weight.</li>
-     *         <li>Sum the weights of all weighted loot entries.</li>
-     *         <li>Generate a random number between 0 and the sum of all weighted loot entry weights.</li>
-     *         <li>Iterate over the aggregate list and pick the first entry whose weight is greater than the random number.</li>
-     *         <li>Add the picked entry to the generated loot bundle.</li>
-     *         <li>Repeat steps 5-7 until the roll count has been reached.</li>
-     *     </ol>
-     * </p>
      *
      * @param context The context in which the loot is being generated.
-     *
      * @return The generated loot bundle, not guaranteed to be populated with any entries.
      */
     public @NotNull LootBundle generateLoot(@NotNull LootContext context) {
         // 1. Guaranteed loot
-        final List<Loot<? ,?>> loot = new ArrayList<>(guaranteedLoot);
+        final List<Loot<?, ?>> loot = new ArrayList<>(guaranteedLoot);
         loot.removeIf(l -> !l.getCondition().test(context));
 
         // 2. Roll count
         int rolls = rollCountFunction.apply(context);
         if (rolls <= 0) {
-            final LootBundle bundle = new LootBundle(context, awardStrategy, loot);
-            context.getSession().getProgress().history.add(bundle);
-            return bundle;
+            return finalizeBundle(context, loot);
         }
 
-        // 3. Flatten weighted loot into entries with base weight
-        List<Loot<? ,?>> candidates = new ArrayList<>();
-        List<Integer> baseWeights = new ArrayList<>();
-        for (var entry : weightedLoot.entries()) {
-            int weight = entry.getKey();
-            Loot<? ,?> l = entry.getValue();
-            if (weight <= 0) continue;
-            candidates.add(l);
-            baseWeights.add(weight);
-        }
-
+        // 3. Snapshot candidates
+        final List<WeightedEntry> candidates = new ArrayList<>(weightedEntries);
         if (candidates.isEmpty()) {
-            final LootBundle bundle = new LootBundle(context,awardStrategy, loot);
-            context.getSession().getProgress().history.add(bundle);
-            return bundle;
+            return finalizeBundle(context, loot);
         }
 
         // 4. Perform rolls
         for (int i = 0; i < rolls; i++) {
-            // copy base -> effective, then apply distribution for this moment-in-bundle
-            final List<Integer> effectiveWeights = new ArrayList<>(baseWeights);
-            applyWeightDistribution(candidates, effectiveWeights, context.getSession().getProgress(), loot);
+            final LootContext rollContext = context.withInput(ExpressionEngine.VAR_ROLL_INDEX, i)
+                    .withInput(ExpressionEngine.VAR_BUNDLE_SIZE, loot.size());
 
-            // total must be from effective weights
+            // base weights for this roll, then distribution adjustments
+            final List<Integer> effectiveWeights = new ArrayList<>(candidates.size());
+            for (WeightedEntry entry : candidates) {
+                effectiveWeights.add(Math.max(0, entry.getWeight().applyAsInt(rollContext)));
+            }
+            applyWeightDistribution(candidates, effectiveWeights, rollContext.getSession().getProgress(), loot);
+
             int totalWeight = 0;
             for (int j = 0; j < candidates.size(); j++) {
-                if (candidates.get(j).getCondition().test(context)) {
+                if (candidates.get(j).getLoot().getCondition().test(rollContext)) {
                     totalWeight += effectiveWeights.get(j);
                 }
             }
@@ -157,10 +126,10 @@ public class LootTable {
             int r = ThreadLocalRandom.current().nextInt(totalWeight);
             int cumulative = 0;
             for (int j = 0; j < candidates.size(); j++) {
-                final Loot<?, ?> candidate = candidates.get(j);
+                final WeightedEntry entry = candidates.get(j);
+                final Loot<?, ?> candidate = entry.getLoot();
 
-                // do not count weight for candidates that fail the condition
-                if (!candidate.getCondition().test(context)) continue;
+                if (!candidate.getCondition().test(rollContext)) continue;
 
                 cumulative += effectiveWeights.get(j);
                 if (r < cumulative) {
@@ -170,7 +139,6 @@ public class LootTable {
                             .orElse(this.replacementStrategy);
                     if (strategy == ReplacementStrategy.WITHOUT_REPLACEMENT) {
                         candidates.remove(j);
-                        baseWeights.remove(j); // <-- remove from base, not effective
                     }
                     break;
                 }
@@ -178,12 +146,16 @@ public class LootTable {
             if (candidates.isEmpty()) break;
         }
 
-        final LootBundle bundle = new LootBundle(context,awardStrategy, loot);
+        return finalizeBundle(context, loot);
+    }
+
+    private LootBundle finalizeBundle(LootContext context, List<Loot<?, ?>> loot) {
+        final LootBundle bundle = new LootBundle(context, awardStrategy, loot);
         context.getSession().getProgress().history.add(bundle);
         return bundle;
     }
 
-    private void applyWeightDistribution(List<Loot<? ,?>> candidates, List<Integer> weights,
+    private void applyWeightDistribution(List<WeightedEntry> candidates, List<Integer> weights,
                                          @Nullable LootProgress progress, List<Loot<?, ?>> awardedInThisBundle) {
         switch (weightDistributionStrategy) {
             case STATIC -> {
@@ -192,7 +164,7 @@ public class LootTable {
             case PITY -> {
                 if (progress == null) return;
                 for (int i = 0; i < candidates.size(); i++) {
-                    Loot<? ,?> candidate = candidates.get(i);
+                    Loot<?, ?> candidate = candidates.get(i).getLoot();
 
                     // suppress pity if this bundle already contains this loot
                     if (awardedInThisBundle.contains(candidate)) continue;
@@ -214,7 +186,6 @@ public class LootTable {
             case PROGRESSIVE -> {
                 if (progress == null || weights.isEmpty()) return;
 
-                // mean of active weights (>=0)
                 long sum = 0;
                 int n = 0;
                 for (int w : weights) { if (w > 0) { sum += w; n++; } }
@@ -229,12 +200,12 @@ public class LootTable {
                     int w = weights.get(j);
                     if (w <= 0) continue;
 
-                    double delta = avg - w;                  // move toward mean
-                    double shift = delta * factor;           // base shift
+                    double delta = avg - w;
+                    double shift = delta * factor;
                     if (scaleVar) {
                         double spread = Math.abs(delta);
                         double scale = (avg == 0.0) ? 1.0 : (spread / avg);
-                        shift *= scale;                      // variance scaling
+                        shift *= scale;
                     }
                     if (maxShift > 0) {
                         if (shift >  maxShift) shift =  maxShift;
@@ -248,20 +219,32 @@ public class LootTable {
         }
     }
 
+    /**
+     * Returns a snapshot of the weighted entries keyed by {@link WeightedEntry#getDefaultWeight()}.
+     * Intended for menu previews and persistence; runtime rolls use {@link #weightedEntries} directly.
+     */
     public @NotNull Multimap<@NotNull Integer, @NotNull Loot<?, ?>> getWeightedLoot() {
-        return ArrayListMultimap.create(weightedLoot);
+        final Multimap<Integer, Loot<?, ?>> out = ArrayListMultimap.create();
+        for (WeightedEntry entry : weightedEntries) {
+            out.put(entry.getDefaultWeight(), entry.getLoot());
+        }
+        return out;
     }
 
+    /**
+     * Returns the static drop-chance preview based on {@link WeightedEntry#getDefaultWeight()}.
+     * Expression-driven weights are represented by their default value here.
+     */
     public Map<Loot<?, ?>, Float> getChances() {
-        int sumWeights = this.weightedLoot.keys().stream().mapToInt(Integer::intValue).sum();
+        int sumWeights = 0;
+        for (WeightedEntry entry : weightedEntries) sumWeights += entry.getDefaultWeight();
         final Map<Loot<?, ?>, Float> chances = new HashMap<>();
         for (Loot<?, ?> loot : this.guaranteedLoot) {
             chances.put(loot, 1.0f);
         }
-
-        for (Map.Entry<@NotNull Integer, @NotNull Loot<?, ?>> entry : this.weightedLoot.entries()) {
-            float chance = (float) entry.getKey() / sumWeights;
-            chances.put(entry.getValue(), chance);
+        if (sumWeights <= 0) return chances;
+        for (WeightedEntry entry : weightedEntries) {
+            chances.put(entry.getLoot(), (float) entry.getDefaultWeight() / sumWeights);
         }
         return chances;
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/RollCountFunction.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/RollCountFunction.java
@@ -1,5 +1,8 @@
 package me.mykindos.betterpvp.core.loot;
 
+import me.mykindos.betterpvp.core.loot.expression.ExpressionEngine;
+
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
@@ -73,6 +76,22 @@ public interface RollCountFunction extends Function<LootContext, Integer> {
         return context -> {
             // Use ThreadLocalRandom for thread-safe random number generation
             return ThreadLocalRandom.current().nextInt(minRolls, maxRolls + 1);
+        };
+    }
+
+    /**
+     * Creates a roll count function that evaluates {@code expression} against the context's
+     * inputs. The result is coerced to a non-negative integer; {@code fallback} is used if
+     * the expression fails to evaluate.
+     *
+     * @param expression a JEXL expression returning a numeric value, e.g.
+     *                   {@code "clamp(4 - slayer_standing, 1, 3)"}
+     * @param fallback the value to return on evaluation failure
+     */
+    static RollCountFunction expression(String expression, int fallback) {
+        return context -> {
+            double v = ExpressionEngine.evalDouble(expression, context, Map.of(), fallback);
+            return Math.max(0, (int) Math.round(v));
         };
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/WeightFunction.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/WeightFunction.java
@@ -1,0 +1,33 @@
+package me.mykindos.betterpvp.core.loot;
+
+import me.mykindos.betterpvp.core.loot.expression.ExpressionEngine;
+
+import java.util.Map;
+import java.util.function.ToIntFunction;
+
+/**
+ * Computes the weight of a {@link WeightedEntry} for a given {@link LootContext}.
+ * <p>
+ * Weight is evaluated per roll. Non-positive results disable the entry for that roll.
+ */
+@FunctionalInterface
+public interface WeightFunction extends ToIntFunction<LootContext> {
+
+    /**
+     * A weight function that always returns {@code weight}.
+     */
+    static WeightFunction constant(int weight) {
+        return ctx -> weight;
+    }
+
+    /**
+     * A weight function that evaluates {@code expression} as a number. {@code fallback}
+     * is used when evaluation fails.
+     */
+    static WeightFunction expression(String expression, int fallback) {
+        return ctx -> {
+            double v = ExpressionEngine.evalDouble(expression, ctx, Map.of(), fallback);
+            return (int) Math.max(0, Math.round(v));
+        };
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/WeightedEntry.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/WeightedEntry.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.loot;
+
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A weighted loot entry. {@code defaultWeight} is the static value used for menu previews
+ * and {@link LootTable#getChances()}; {@code weight} is the function used during rolls.
+ */
+@Value
+public class WeightedEntry {
+
+    @NotNull Loot<?, ?> loot;
+    @NotNull WeightFunction weight;
+    int defaultWeight;
+
+    public static WeightedEntry of(@NotNull Loot<?, ?> loot, int weight) {
+        return new WeightedEntry(loot, WeightFunction.constant(weight), weight);
+    }
+
+    public static WeightedEntry of(@NotNull Loot<?, ?> loot, @NotNull WeightFunction weight, int defaultWeight) {
+        return new WeightedEntry(loot, weight, defaultWeight);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngine.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngine.java
@@ -1,0 +1,137 @@
+package me.mykindos.betterpvp.core.loot.expression;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.loot.LootContext;
+import org.apache.commons.jexl3.JexlBuilder;
+import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.JexlExpression;
+import org.apache.commons.jexl3.JexlFeatures;
+import org.apache.commons.jexl3.MapContext;
+import org.apache.commons.jexl3.introspection.JexlPermissions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Sandboxed expression evaluator backed by Apache Commons JEXL.
+ * <p>
+ * Expressions are restricted: no scripts, no loops, no {@code new}, no method calls on objects,
+ * no assignments. The default namespace exposes {@link LootFunctions}. Variables come from a
+ * {@link LootContext}'s inputs merged with optional per-call extras. Reserved names
+ * (e.g. {@code roll_index}, {@code bundle_size}, {@code history_size}, {@code source}) are
+ * supplied by the loot system at evaluation time.
+ */
+@CustomLog
+public final class ExpressionEngine {
+
+    public static final String VAR_ROLL_INDEX = "roll_index";
+    public static final String VAR_BUNDLE_SIZE = "bundle_size";
+    public static final String VAR_HISTORY_SIZE = "history_size";
+    public static final String VAR_SOURCE = "source";
+
+    private static final int MAX_EXPRESSION_LENGTH = 512;
+    /** Namespace prefix for built-in helper functions; call as {@code fn:clamp(...)}. */
+    public static final String FN_NAMESPACE = "fn";
+    private static final Map<String, Object> NAMESPACES = Map.of(FN_NAMESPACE, new LootFunctions());
+
+    private static final JexlEngine ENGINE = new JexlBuilder()
+            .features(new JexlFeatures()
+                    .script(false)
+                    .loops(false)
+                    .lambda(false)
+                    .newInstance(false)
+                    .sideEffectGlobal(false)
+                    .sideEffect(false)
+                    .annotation(false)
+                    .pragma(false))
+            .permissions(JexlPermissions.RESTRICTED.compose("me.mykindos.betterpvp.core.loot.expression.*"))
+            .namespaces(NAMESPACES)
+            .silent(true)
+            .strict(false)
+            .safe(true)
+            .cache(0) // we cache externally
+            .create();
+
+    private static final Cache<String, JexlExpression> CACHE = Caffeine.newBuilder()
+            .maximumSize(512)
+            .build();
+
+    private ExpressionEngine() {
+    }
+
+    /**
+     * Evaluates {@code expr} against {@code context}'s inputs plus {@code extras}.
+     *
+     * @return the result, or {@code null} if the expression failed to parse or evaluate.
+     */
+    public static @Nullable Object eval(@NotNull String expr, @NotNull LootContext context, @NotNull Map<String, Object> extras) {
+        final JexlExpression compiled = compile(expr);
+        if (compiled == null) return null;
+
+        final MapContext jc = new MapContext();
+        for (Map.Entry<String, Object> e : context.getInputs().entrySet()) {
+            jc.set(e.getKey(), e.getValue());
+        }
+        for (Map.Entry<String, Object> e : extras.entrySet()) {
+            jc.set(e.getKey(), e.getValue());
+        }
+        jc.set(VAR_SOURCE, context.getSource());
+        jc.set(VAR_HISTORY_SIZE, context.getSession().getProgress().getHistory().size());
+
+        try {
+            return compiled.evaluate(jc);
+        } catch (Exception ex) {
+            log.warn("Failed to evaluate loot expression '{}': {}", expr, ex.getMessage(), ex).submit();
+            return null;
+        }
+    }
+
+    /**
+     * Evaluates {@code expr} as a number. Returns {@code fallback} if evaluation fails
+     * or the result is not numeric.
+     */
+    public static double evalDouble(@NotNull String expr, @NotNull LootContext context, @NotNull Map<String, Object> extras, double fallback) {
+        final Object r = eval(expr, context, extras);
+        if (r instanceof Number n) return n.doubleValue();
+        if (r instanceof Boolean b) return b ? 1.0 : 0.0;
+        return fallback;
+    }
+
+    /**
+     * Evaluates {@code expr} as a boolean. {@code null}/non-boolean numeric results follow
+     * the rule "non-zero is true". Returns {@code fallback} when evaluation fails entirely.
+     */
+    public static boolean evalBoolean(@NotNull String expr, @NotNull LootContext context, @NotNull Map<String, Object> extras, boolean fallback) {
+        final Object r = eval(expr, context, extras);
+        if (r instanceof Boolean b) return b;
+        if (r instanceof Number n) return n.doubleValue() != 0.0;
+        if (r instanceof String s) return !s.isEmpty();
+        return fallback;
+    }
+
+    private static @Nullable JexlExpression compile(@NotNull String expr) {
+        if (expr.length() > MAX_EXPRESSION_LENGTH) {
+            log.warn("Loot expression exceeds {} chars, rejecting", MAX_EXPRESSION_LENGTH).submit();
+            return null;
+        }
+        return CACHE.get(expr, key -> {
+            try {
+                return ENGINE.createExpression(key);
+            } catch (Exception ex) {
+                log.warn("Failed to compile loot expression '{}': {}", key, ex.getMessage()).submit();
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Convenience overload with no extras.
+     */
+    public static @Nullable Object eval(@NotNull String expr, @NotNull LootContext context) {
+        return eval(expr, context, Collections.emptyMap());
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/LootFunctions.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/LootFunctions.java
@@ -1,0 +1,49 @@
+package me.mykindos.betterpvp.core.loot.expression;
+
+/**
+ * Functions exposed to loot expressions in the default namespace.
+ * <p>
+ * Methods are invoked from expressions as bare names, e.g. {@code clamp(x, 1, 5)}.
+ */
+public final class LootFunctions {
+
+    /** Returns {@code v} clamped between {@code lo} and {@code hi}. */
+    public double clamp(double v, double lo, double hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+
+    /** Returns the smaller of {@code a} and {@code b}. */
+    public double min(double a, double b) {
+        return Math.min(a, b);
+    }
+
+    /** Returns the larger of {@code a} and {@code b}. */
+    public double max(double a, double b) {
+        return Math.max(a, b);
+    }
+
+    /** Returns {@code a} rounded to the nearest integer (as a long). */
+    public long round(double a) {
+        return Math.round(a);
+    }
+
+    /** Returns the floor of {@code a}. */
+    public double floor(double a) {
+        return Math.floor(a);
+    }
+
+    /** Returns the ceiling of {@code a}. */
+    public double ceil(double a) {
+        return Math.ceil(a);
+    }
+
+    /** Returns the absolute value of {@code a}. */
+    public double abs(double a) {
+        return Math.abs(a);
+    }
+
+    /** Returns the length of {@code s}, or 0 if null. */
+    public int len(String s) {
+        return s == null ? 0 : s.length();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/serialization/LootTableDeserializer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/serialization/LootTableDeserializer.java
@@ -1,8 +1,6 @@
 package me.mykindos.betterpvp.core.loot.serialization;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -12,12 +10,15 @@ import com.google.gson.JsonParseException;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootConditions;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.PityRule;
 import me.mykindos.betterpvp.core.loot.ProgressiveWeightConfig;
 import me.mykindos.betterpvp.core.loot.ReplacementStrategy;
 import me.mykindos.betterpvp.core.loot.RollCountFunction;
 import me.mykindos.betterpvp.core.loot.WeightDistributionStrategy;
+import me.mykindos.betterpvp.core.loot.WeightFunction;
+import me.mykindos.betterpvp.core.loot.WeightedEntry;
 import me.mykindos.betterpvp.core.loot.chest.BigLootChest;
 import me.mykindos.betterpvp.core.loot.chest.LootChest;
 import me.mykindos.betterpvp.core.loot.chest.SmallLootChest;
@@ -74,19 +75,19 @@ public class LootTableDeserializer implements JsonDeserializer<LootTable> {
         // Parse entries
         JsonArray entriesArray = obj.getAsJsonArray("entries");
         Map<String, Loot<?, ?>> lootById = new HashMap<>();
-        Multimap<Integer, Loot<?, ?>> weightedLoot = ArrayListMultimap.create();
+        List<WeightedEntry> weightedEntries = new ArrayList<>();
 
         for (JsonElement entryElement : entriesArray) {
             JsonObject entryObj = entryElement.getAsJsonObject();
             String entryId = entryObj.get("id").getAsString();
-            int weight = entryObj.get("weight").getAsInt();
             Optional<Loot<?, ?>> loot = parseLootEntry(entryObj);
             if (loot.isEmpty()) {
                 continue;
             }
 
+            applyCondition(entryObj, loot.get());
             lootById.put(entryId, loot.get());
-            weightedLoot.put(weight, loot.get());
+            weightedEntries.add(parseWeightedEntry(entryObj, loot.get()));
         }
 
         // Parse guaranteed entries
@@ -99,6 +100,7 @@ public class LootTableDeserializer implements JsonDeserializer<LootTable> {
                 if (loot.isEmpty()) {
                     continue;
                 }
+                applyCondition(guaranteedObj, loot.get());
                 guaranteedLoot.add(loot.get());
             }
         }
@@ -130,7 +132,7 @@ public class LootTableDeserializer implements JsonDeserializer<LootTable> {
                 .awardStrategy(awardStrategy)
                 .replacementStrategy(replacementStrategy)
                 .rollCountFunction(rollCountFunction)
-                .weightedLoot(weightedLoot)
+                .weightedEntries(weightedEntries)
                 .guaranteedLoot(guaranteedLoot)
                 .pityRules(pityRules)
                 .weightDistributionStrategy(weightDistributionStrategy)
@@ -199,8 +201,52 @@ public class LootTableDeserializer implements JsonDeserializer<LootTable> {
                 int maxRolls = rollStrategyObj.get("maxRolls").getAsInt();
                 yield RollCountFunction.progressive(baseRolls, incrementPerProgress, maxRolls);
             }
+            case "EXPRESSION" -> {
+                String expr = rollStrategyObj.get("expression").getAsString();
+                int fallback = rollStrategyObj.has("fallback") ? rollStrategyObj.get("fallback").getAsInt() : 0;
+                yield RollCountFunction.expression(expr, fallback);
+            }
             default -> throw new JsonParseException("Unknown roll strategy type: " + type);
         };
+    }
+
+    /**
+     * Parses an entry's weight, which may be a plain integer or an object of the form
+     * {@code {"type":"EXPRESSION","expression":"...","fallback":N}}.
+     */
+    private @NotNull WeightedEntry parseWeightedEntry(@NotNull JsonObject entryObj, @NotNull Loot<?, ?> loot) {
+        JsonElement weightEl = entryObj.get("weight");
+        if (weightEl == null) {
+            return WeightedEntry.of(loot, 0);
+        }
+        if (weightEl.isJsonPrimitive()) {
+            return WeightedEntry.of(loot, weightEl.getAsInt());
+        }
+        if (weightEl.isJsonObject()) {
+            JsonObject weightObj = weightEl.getAsJsonObject();
+            String type = weightObj.get("type").getAsString();
+            return switch (type) {
+                case "CONSTANT" -> WeightedEntry.of(loot, weightObj.get("value").getAsInt());
+                case "EXPRESSION" -> {
+                    String expr = weightObj.get("expression").getAsString();
+                    int fallback = weightObj.has("fallback") ? weightObj.get("fallback").getAsInt() : 0;
+                    int preview = weightObj.has("preview") ? weightObj.get("preview").getAsInt() : fallback;
+                    yield WeightedEntry.of(loot, WeightFunction.expression(expr, fallback), preview);
+                }
+                default -> throw new JsonParseException("Unknown weight type: " + type);
+            };
+        }
+        throw new JsonParseException("Invalid weight value");
+    }
+
+    /**
+     * Applies a JEXL {@code condition} expression from {@code entryObj} to the loot, if present.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void applyCondition(@NotNull JsonObject entryObj, @NotNull Loot<?, ?> loot) {
+        if (!entryObj.has("condition")) return;
+        String expr = entryObj.get("condition").getAsString();
+        ((Loot) loot).setCondition(LootConditions.expression(expr));
     }
 
     private Optional<Loot<?, ?>> parseLootEntry(@NotNull JsonObject entryObj) {

--- a/core/src/test/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngineTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngineTest.java
@@ -1,0 +1,85 @@
+package me.mykindos.betterpvp.core.loot.expression;
+
+import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootProgress;
+import me.mykindos.betterpvp.core.loot.session.LootSession;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class ExpressionEngineTest {
+
+    private LootContext context;
+
+    @BeforeEach
+    void setUp() {
+        final World world = Mockito.mock(World.class);
+        final Location location = new Location(world, 0, 0, 0);
+        final LootSession session = Mockito.mock(LootSession.class);
+        when(session.getProgress()).thenReturn(new LootProgress());
+        context = new LootContext(session, location, "test", Map.of(
+                "slayer_standing", 1,
+                "dungeon_score", 75,
+                "tier", "boss",
+                "is_first", true
+        ));
+    }
+
+    @Test
+    void evaluatesArithmetic() {
+        assertEquals(3.0, ExpressionEngine.evalDouble("1 + 2", context, Map.of(), 0));
+    }
+
+    @Test
+    void readsContextInputs() {
+        assertEquals(3.0, ExpressionEngine.evalDouble("fn:clamp(4 - slayer_standing, 1, 3)", context, Map.of(), 0));
+    }
+
+    @Test
+    void supportsStringComparisons() {
+        assertTrue(ExpressionEngine.evalBoolean("tier == 'boss'", context, Map.of(), false));
+        assertFalse(ExpressionEngine.evalBoolean("tier == 'trash'", context, Map.of(), true));
+    }
+
+    @Test
+    void supportsBooleanInputs() {
+        assertTrue(ExpressionEngine.evalBoolean("is_first && dungeon_score > 50", context, Map.of(), false));
+    }
+
+    @Test
+    void missingVariableEvaluatesToZero() {
+        // strict(false) treats missing vars as null; arithmetic on null returns 0
+        assertEquals(0.0, ExpressionEngine.evalDouble("not_a_var * 2", context, Map.of(), 42));
+    }
+
+    @Test
+    void unparseableExpressionReturnsFallback() {
+        assertEquals(42.0, ExpressionEngine.evalDouble("@@@ syntax error", context, Map.of(), 42));
+    }
+
+    @Test
+    void extrasOverrideInputs() {
+        double v = ExpressionEngine.evalDouble("slayer_standing", context, Map.of("slayer_standing", 99), 0);
+        assertEquals(99.0, v);
+    }
+
+    @Test
+    void rejectsMethodCallsAndNew() {
+        // method calls on classes are blocked by sandbox
+        assertNull(ExpressionEngine.eval("''.getClass().getName()", context));
+        assertNull(ExpressionEngine.eval("new('java.lang.String', 'x')", context));
+    }
+
+    @Test
+    void rejectsOverlongExpression() {
+        String huge = "1+".repeat(300) + "1";
+        assertEquals(7.0, ExpressionEngine.evalDouble(huge, context, Map.of(), 7));
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -116,6 +116,7 @@ dependencyResolutionManagement {
             library("prettytime", "org.ocpsoft.prettytime", "prettytime").version("5.0.4.Final")
             library("zip4j", "net.lingala.zip4j", "zip4j").version("2.11.5")
             library("json", "org.json", "json").version("20250107")
+            library("jexl3", "org.apache.commons", "commons-jexl3").version("3.4.0")
 
             // Library - Mapper
             library("mapper", "com.github.BetterPvP", "Mapper").version("1.0.9")
@@ -174,7 +175,8 @@ dependencyResolutionManagement {
                     "reflections",
                     "okhttp",
                     "zip4j",
-                    "json"))
+                    "json",
+                    "jexl3"))
             bundle("data", listOf("flyway-core", "flyway-mysql", "flyway-postgres"))
             bundle("mixins", listOf("mixin"))
         }


### PR DESCRIPTION
## Describe your changes
- Already deployed in the loot table editor [loot.betterpvp.net](loot.betterpvp.net)
- Adds support for arithmetic / logical expressions in 
  - Loot weight
  - Loot conditionals (logical)
  - Roll counts
- Uses JEXL for parsing.
  - Includes unit test for verification
  - Worth noting that function calls must be prepended with `fn:`
   ```java
   fn:clamp(4 - slayer_standing, 1, 3)
   ```
- Allows passing of variables (called `inputs`) to support custom values in expression evaluation
  - `strings` (conditional `tier == 'boss'`)
  - `number` (roll count `standing + 1`)
  - `boolean` (conditional `in_clan == true`)
  - Variables are passed into `LootContext` (not a session) as such:
    ```java
    final LootContext context = new LootContext(session, player.getLocation(), getName())
        .withInput("slayer_standing", standing); // 1, 2, 3
    ```
  - Default variables are included
    - `roll_index`: roll index of the current bundle instance (clamped by roll count)
    - `bundle_size`: total size of bundle
    - `history_size`: amount of bundles in the current session (normally zero for non-persisting sessions; used for pity)
    - `source`: the source of this `LootContext` (i.e.: `fishing`, `boss`, etc)
    
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
