### PR TITLE
Fix Workbench quick craft result mismatch

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/workbench/QuickCraftingButton.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/workbench/QuickCraftingButton.java
@@ -126,18 +126,17 @@ public class QuickCraftingButton extends ControlItem<Gui> {
 
             player.getInventory().setStorageContents(contents);
 
-            // Place the ingredients for the recipe in the matrix
+            // Place the ingredients for the recipe in the matrix.
+            // Using setItem(reason, ...) fires the post-update handler so the
+            // result slot refreshes; the handler debounces to a single lookup.
+            final PlayerUpdateReason reason = new PlayerUpdateReason(player, event);
             for (Map.Entry<Integer, RecipeIngredient> entry : recipe.getIngredients().entrySet()) {
                 final Integer matrixSlot = entry.getKey();
                 final RecipeIngredient ingredient = entry.getValue();
                 final ItemInstance itemInstance = workbenchGui.itemFactory.create(ingredient.getBaseItem());
                 itemInstance.getItemStack().setAmount(ingredient.getAmount());
-                craftingMatrix.setItemSilently(matrixSlot, itemInstance.getItemStack());
+                craftingMatrix.setItem(reason, matrixSlot, itemInstance.getItemStack());
             }
-
-            // Call the update
-            final PlayerUpdateReason reason = new PlayerUpdateReason(player, event);
-            craftingMatrix.setItemAmount(reason, 0, craftingMatrix.getItemAmount(0));
         }
 
         // Set the current tab to the crafter, independent of where we are


### PR DESCRIPTION
## Describe your changes
A partially empty crafting recipe would cause quick crafts to fail on the result `ItemStack` change, leaving the result slot unchanged but mutating the matrix. This means that swapping from a working recipe (that is currently previewing the result) to a broken one would swap the matrices but not the results, allowing to craft one with the other's ingredients.
- Fixed this issue by not manually triggering the result update on the zero-th slot, but rather on every slot changed. This won't cause recipe recalculation every time a slot is changed for the quick craft, as (later on) we added an pending queue for cases like these with batch updates, to prevent a high calculation count.

Example problem: (Fixed)
[https://medal.tv/games/minecraft/clips/mG98lXa4rFeNC68kn?invite=cr-MSx2ODgsNjgyMTI0MjE](https://medal.tv/games/minecraft/clips/mG98lXa4rFeNC68kn?invite=cr-MSx2ODgsNjgyMTI0MjE
)
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
