### PR TITLE
Constrain Hub server matching to before the hyphen

### DIFF
--- a/hub/src/main/java/me/mykindos/betterpvp/hub/feature/menu/ServerTypeMenu.java
+++ b/hub/src/main/java/me/mykindos/betterpvp/hub/feature/menu/ServerTypeMenu.java
@@ -34,7 +34,7 @@ public class ServerTypeMenu extends AbstractGui implements Windowed {
         // Filter to servers matching this type's name prefix, sorted alphabetically
         final Map<String, Integer> counts = networkService.getServerPlayerCounts();
         final List<String> servers = counts.keySet().stream()
-                .filter(name -> name.startsWith(serverType.getServerNamePrefix()))
+                .filter(name -> name.split("-")[0].equalsIgnoreCase(serverType.getServerNamePrefix()))
                 .sorted()
                 .toList();
 


### PR DESCRIPTION
## Describe your changes
- Constrain Hub server matching to before the hyphen to prevent `ClansTest-1` from showing up in server selector

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
