### PR TITLE
Clickable /mining /fishing /woodcutting, Profession Menu auto scroll to bottom

### DIFF
--- a/progression/src/main/java/me/mykindos/betterpvp/progression/listener/ProgressionListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/listener/ProgressionListener.java
@@ -16,6 +16,8 @@ import me.mykindos.betterpvp.progression.profile.ProfessionData;
 import me.mykindos.betterpvp.progression.profile.ProfessionProfileManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Sound;
@@ -95,8 +97,16 @@ public class ProgressionListener implements Listener {
         final int level = event.getLevel();
         final int previous = event.getPreviousLevel();
 
+        final Component spendSkillPointsComponent = Component.text("Type ")
+                .append(Component.text("/" + tree.toLowerCase(), NamedTextColor.YELLOW)
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.runCommand("/" + tree.toLowerCase()))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to spend your skill points!", NamedTextColor.GRAY)))
+                )
+                .append(Component.text(" to spend your skill points!", NamedTextColor.GRAY));
+
         UtilMessage.simpleMessage(player, tree, "You have leveled up to <green>%d <gray>in <green>%s<gray>!", level, tree);
-        UtilMessage.simpleMessage(player, tree, "Type <yellow>%s<gray> to spend your skill points!", "/" + tree.toLowerCase());
+        UtilMessage.simpleMessage(player, tree, spendSkillPointsComponent);
 
             Function<Gamer, Component> title = gmr -> Component.text(tree + " Level Up!", NamedTextColor.GREEN, TextDecoration.BOLD);
             Function<Gamer, Component> subtitle = gmr -> Component.text("Level " + previous + " \u279C " + level, NamedTextColor.DARK_GREEN);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/menu/ProfessionMenu.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/menu/ProfessionMenu.java
@@ -29,6 +29,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class ProfessionMenu extends AbstractScrollGui<Item> implements Windowed {
 
@@ -66,8 +69,34 @@ public abstract class ProfessionMenu extends AbstractScrollGui<Item> implements 
         // Initialize the content with an empty list
         setContent(loadSkillTree());
 
+        // Scroll to the deepest unlocked node so new nodes are easy to find
+        setCurrentLine(getInitialScrollLine());
+
         // Add scroll handler to update content when scrolled
         addScrollHandler((oldLine, newLine) -> updateContent());
+    }
+
+    private int getInitialScrollLine() {
+        SkillTreeLayout layout = professionHandler.getSkillTree();
+        if (layout == null) return 0;
+
+        Set<String> unlockedNodeNames = professionData.getBuild().getNodes().entrySet().stream()
+                .filter(e -> e.getValue() > 0)
+                .map(e -> e.getKey().getName())
+                .collect(Collectors.toSet());
+
+        if (unlockedNodeNames.isEmpty()) return 0;
+
+        int deepestRow = 0;
+        for (Map.Entry<Integer, SkillTreeCell> entry : layout.cells().entrySet()) {
+            if (entry.getValue() instanceof SkillTreeCell.Skill(String skillId)) {
+                if (unlockedNodeNames.contains(skillId)) {
+                    int row = entry.getKey() / 9;
+                    deepestRow = Math.max(deepestRow, row);
+                }
+            }
+        }
+        return deepestRow;
     }
 
     private List<Item> loadSkillTree() {


### PR DESCRIPTION
Can now click the "type /mining" to run the command.

All profession menus now scroll to the bottom

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
