### PR TITLE
Add Battle Fatigue system

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigue.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigue.java
@@ -1,0 +1,75 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Per-player battle fatigue state. Pure domain object: it holds the score and a
+ * bounded death history and knows how to prune itself, but contains no Bukkit
+ * scheduling, no messaging, and no scoring policy. Decay and gain are driven
+ * externally by {@link BattleFatigueManager}.
+ */
+@Getter
+public class BattleFatigue {
+
+    /** Hard ceiling so a streak can't run away past what the tiers expect. */
+    public static final double MAX_SCORE = 100.0;
+
+    /** How many recent deaths the factors are allowed to reason about. */
+    private static final int MAX_HISTORY = 12;
+
+    private final Deque<DeathRecord> recentDeaths = new ArrayDeque<>();
+
+    @Setter
+    private double score;
+
+    /** Cached tier; recomputed by the manager whenever the score changes. */
+    @Setter
+    private FatigueTier tier = FatigueTier.FRESH;
+
+    /** True while the player is trapped in the void-world respawn hold. */
+    @Setter
+    private boolean respawnHold;
+
+    public void addScore(double delta) {
+        this.score = Math.max(0.0, Math.min(MAX_SCORE, this.score + delta));
+    }
+
+    /**
+     * Record a death, evicting the oldest entry once the history is full.
+     */
+    public void recordDeath(DeathRecord record) {
+        recentDeaths.addLast(record);
+        while (recentDeaths.size() > MAX_HISTORY) {
+            recentDeaths.removeFirst();
+        }
+    }
+
+    /**
+     * Drop death records older than {@code windowMillis} so frequency/locality
+     * factors only ever see the relevant window.
+     */
+    public void pruneOlderThan(long windowMillis) {
+        final long cutoff = System.currentTimeMillis() - windowMillis;
+        recentDeaths.removeIf(record -> record.timestamp() < cutoff);
+    }
+
+    /**
+     * @return an unmodifiable view of the death history, oldest first.
+     */
+    public List<DeathRecord> getDeathHistory() {
+        return List.copyOf(recentDeaths);
+    }
+
+    /**
+     * @return true when the player has fully recovered and the entry can be evicted.
+     */
+    public boolean isIdle() {
+        return score <= 0.0 && recentDeaths.isEmpty() && !respawnHold;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueListener.java
@@ -1,0 +1,90 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.Clan;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.core.combat.damagelog.DamageLog;
+import me.mykindos.betterpvp.core.combat.damagelog.DamageLogManager;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Adapter only: turns a Bukkit {@link PlayerDeathEvent} into a {@link DeathContext},
+ * hands it to the scoring layer, and triggers the hold if the resolved tier
+ * demands it. No scoring, punishment, or presentation logic lives here.
+ */
+@Singleton
+@BPvPListener
+public class BattleFatigueListener implements Listener {
+
+    private final ClanManager clanManager;
+    private final DamageLogManager damageLogManager;
+    private final BattleFatigueManager fatigueManager;
+    private final RespawnHoldService respawnHoldService;
+
+    @Inject
+    public BattleFatigueListener(ClanManager clanManager,
+                                 DamageLogManager damageLogManager,
+                                 BattleFatigueManager fatigueManager,
+                                 RespawnHoldService respawnHoldService) {
+        this.clanManager = clanManager;
+        this.damageLogManager = damageLogManager;
+        this.fatigueManager = fatigueManager;
+        this.respawnHoldService = respawnHoldService;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDeath(PlayerDeathEvent event) {
+        final Player player = event.getPlayer();
+        final DeathContext context = new DeathContext(
+                player.getUniqueId(),
+                resolveKiller(player),
+                player.getLocation(),
+                System.currentTimeMillis(),
+                distanceFromSafety(player));
+
+        final FatigueTier tier = fatigueManager.recordDeath(player, context);
+        if (tier.requiresHold()) {
+            respawnHoldService.beginHold(player, tier);
+        }
+    }
+
+    private UUID resolveKiller(Player killed) {
+        final DamageLog lastDamage = damageLogManager.getLastDamager(killed);
+        if (lastDamage != null && lastDamage.getDamager() instanceof Player killer) {
+            return killer.getUniqueId();
+        }
+        return null;
+    }
+
+    /**
+     * Distance from the death spot to the player's own clan core — a cheap proxy
+     * for "how far from home did you recklessly roam". {@code -1} when it can't
+     * be measured (no clan, no core, or a different world).
+     */
+    private double distanceFromSafety(Player player) {
+        final Optional<Clan> clanOptional = clanManager.getClanByPlayer(player);
+        if (clanOptional.isEmpty()) {
+            return -1;
+        }
+        final Clan clan = clanOptional.get();
+        if (clan.getCore() == null || clan.getCore().getPosition() == null) {
+            return -1;
+        }
+        final Location core = clan.getCore().getPosition();
+        final Location death = player.getLocation();
+        if (core.getWorld() == null || !core.getWorld().equals(death.getWorld())) {
+            return -1;
+        }
+        return core.distance(death);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
@@ -43,7 +43,7 @@ public class BattleFatigueManager extends Manager<String, BattleFatigue> impleme
     private long deathHistoryWindowSeconds;
 
     @Inject
-    @Config(path = "clans.fatigue.threshold.worn", defaultValue = "35.0")
+    @Config(path = "clans.fatigue.threshold.worn", defaultValue = "30.0")
     private double thresholdWorn;
 
     @Inject
@@ -56,7 +56,7 @@ public class BattleFatigueManager extends Manager<String, BattleFatigue> impleme
 
     // --- combine() formula tunables (global to the algorithm, not per-factor) -------
     @Inject
-    @Config(path = "clans.fatigue.combine.baseGain", defaultValue = "2.0")
+    @Config(path = "clans.fatigue.combine.baseGain", defaultValue = "10.0")
     private double baseGain;
 
     /** A signal at/above this counts as an "active axis" for synergy. */
@@ -71,7 +71,7 @@ public class BattleFatigueManager extends Manager<String, BattleFatigue> impleme
 
     /** Hard cap on a single death's gain, so one death can't skip a whole tier. */
     @Inject
-    @Config(path = "clans.fatigue.combine.maxGainPerDeath", defaultValue = "28.0")
+    @Config(path = "clans.fatigue.combine.maxGainPerDeath", defaultValue = "50.0")
     private double maxGainPerDeath;
 
     @Inject

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
@@ -1,0 +1,196 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.clans.clans.fatigue.events.PlayerFatigueGainEvent;
+import me.mykindos.betterpvp.clans.clans.fatigue.events.PlayerFatigueTierChangeEvent;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.FatigueFactor;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.framework.manager.Manager;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Owns battle-fatigue scoring: it sums the registered {@link FatigueFactor}
+ * strategies into a single recklessness gain, applies passive time decay, and
+ * resolves the {@link FatigueTier}. It fires events on change and knows nothing
+ * about slowness, titles, or the void world — those concerns live elsewhere.
+ * <p>
+ * State is session-only: entries live in the in-memory map and are evicted once
+ * a player has fully recovered or logged off.
+ */
+@Singleton
+@BPvPListener
+@CustomLog
+public class BattleFatigueManager extends Manager<String, BattleFatigue> implements Listener {
+
+    private final Set<FatigueFactor> factors;
+
+    @Inject
+    @Config(path = "clans.fatigue.decayPerSecond", defaultValue = "0.8")
+    private double decayPerSecond;
+
+    @Inject
+    @Config(path = "clans.fatigue.deathHistoryWindowSeconds", defaultValue = "60")
+    private long deathHistoryWindowSeconds;
+
+    @Inject
+    @Config(path = "clans.fatigue.threshold.worn", defaultValue = "35.0")
+    private double thresholdWorn;
+
+    @Inject
+    @Config(path = "clans.fatigue.threshold.weary", defaultValue = "65.0")
+    private double thresholdWeary;
+
+    @Inject
+    @Config(path = "clans.fatigue.threshold.exhausted", defaultValue = "90.0")
+    private double thresholdExhausted;
+
+    // --- combine() formula tunables (global to the algorithm, not per-factor) -------
+    @Inject
+    @Config(path = "clans.fatigue.combine.baseGain", defaultValue = "2.0")
+    private double baseGain;
+
+    /** A signal at/above this counts as an "active axis" for synergy. */
+    @Inject
+    @Config(path = "clans.fatigue.combine.synergy.activationThreshold", defaultValue = "0.35")
+    private double synergyActivationThreshold;
+
+    /** Each active axis beyond the first multiplies the weighted sum by this much more. */
+    @Inject
+    @Config(path = "clans.fatigue.combine.synergy.perExtraAxis", defaultValue = "0.55")
+    private double synergyPerExtraAxis;
+
+    /** Hard cap on a single death's gain, so one death can't skip a whole tier. */
+    @Inject
+    @Config(path = "clans.fatigue.combine.maxGainPerDeath", defaultValue = "28.0")
+    private double maxGainPerDeath;
+
+    @Inject
+    public BattleFatigueManager(Set<FatigueFactor> factors) {
+        this.factors = factors;
+    }
+
+    public BattleFatigue getOrCreate(UUID uuid) {
+        return objects.computeIfAbsent(uuid.toString(), key -> new BattleFatigue());
+    }
+
+    public FatigueTier getTier(UUID uuid) {
+        return getObject(uuid).map(BattleFatigue::getTier).orElse(FatigueTier.FRESH);
+    }
+
+    /**
+     * Process a death: evaluate every factor, fold them into a gain, update the
+     * score and tier, and fire the appropriate event. Returns the resolved tier
+     * so the caller (the listener) can decide whether to trigger the hold.
+     */
+    public FatigueTier recordDeath(Player player, DeathContext context) {
+        final BattleFatigue state = getOrCreate(player.getUniqueId());
+        state.pruneOlderThan(deathHistoryWindowSeconds * 1000L);
+
+        final double previousScore = state.getScore();
+        final FatigueTier previousTier = state.getTier();
+
+        final double gain = computeGain(state, context);
+        state.addScore(gain);
+        state.recordDeath(context.toRecord());
+
+        final FatigueTier newTier = resolveTier(state.getScore());
+        state.setTier(newTier);
+
+        Bukkit.broadcastMessage("Score for " + player.getName() + ": " + state.getScore());
+
+        if (newTier != previousTier) {
+            UtilServer.callEvent(new PlayerFatigueTierChangeEvent(player, previousTier, newTier));
+        } else {
+            UtilServer.callEvent(new PlayerFatigueGainEvent(player, previousScore, state.getScore()));
+        }
+        return newTier;
+    }
+
+    /**
+     * Fold every registered factor into a single gain. Fully generic: it asks
+     * each {@link FatigueFactor} for its normalized signal and its weight and
+     * never names or special-cases a concrete factor. Adding a factor changes
+     * nothing here.
+     * <p>
+     * The bad-vs-reckless line is the <b>synergy multiplier</b>: a merely-bad
+     * player spikes ONE axis and gets no multiplier (passive decay erases it);
+     * a reckless player lights up several axes at once and the multiplier makes
+     * it bite. {@code baseGain} is a per-death floor; the result is capped so a
+     * single death can't leap a whole tier. Score is further clamped to
+     * {@code [0, 100]} by {@link BattleFatigue#addScore}.
+     *
+     * @param state   the victim's current fatigue state (history pre-this-death)
+     * @param context the death snapshot
+     * @return points to add to the fatigue score
+     */
+    private double computeGain(BattleFatigue state, DeathContext context) {
+        double weightedSum = 0.0;
+        int activeAxes = 0;
+
+        for (FatigueFactor factor : factors) {
+            // Defensive clamp: honor the [0,1] contract even if a factor misbehaves.
+            final double signal = Math.max(0.0, Math.min(1.0, factor.evaluate(state, context)));
+            weightedSum += factor.getWeight() * signal;
+            if (signal >= synergyActivationThreshold) {
+                activeAxes++;
+            }
+        }
+
+        final double synergyMultiplier = 1.0 + synergyPerExtraAxis * Math.max(0, activeAxes - 1);
+        final double gain = baseGain + weightedSum * synergyMultiplier;
+        return Math.min(gain, maxGainPerDeath);
+    }
+
+    private FatigueTier resolveTier(double score) {
+        if (score >= thresholdExhausted) {
+            return FatigueTier.EXHAUSTED;
+        }
+        if (score >= thresholdWeary) {
+            return FatigueTier.WEARY;
+        }
+        if (score >= thresholdWorn) {
+            return FatigueTier.WORN;
+        }
+        return FatigueTier.FRESH;
+    }
+
+    /**
+     * Passive recovery. Runs once a second, bleeding the score down and emitting
+     * a tier-change event if a player drops back into a calmer band.
+     */
+    @UpdateEvent(delay = 1000)
+    public void decay() {
+        objects.entrySet().removeIf(entry -> {
+            final BattleFatigue state = entry.getValue();
+            if (state.isRespawnHold()) {
+                return false; // never decay or evict while mid-hold
+            }
+
+            if (state.getScore() > 0.0) {
+                final FatigueTier before = state.getTier();
+                state.addScore(-decayPerSecond);
+                final FatigueTier after = resolveTier(state.getScore());
+                if (after != before) {
+                    state.setTier(after);
+                    final Player player = Bukkit.getPlayer(UUID.fromString(entry.getKey()));
+                    if (player != null) {
+                        UtilServer.callEvent(new PlayerFatigueTierChangeEvent(player, before, after));
+                    }
+                }
+            }
+
+            state.pruneOlderThan(deathHistoryWindowSeconds * 1000L);
+            return state.isIdle();
+        });
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueManager.java
@@ -106,8 +106,6 @@ public class BattleFatigueManager extends Manager<String, BattleFatigue> impleme
         final FatigueTier newTier = resolveTier(state.getScore());
         state.setTier(newTier);
 
-        Bukkit.broadcastMessage("Score for " + player.getName() + ": " + state.getScore());
-
         if (newTier != previousTier) {
             UtilServer.callEvent(new PlayerFatigueTierChangeEvent(player, previousTier, newTier));
         } else {

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueMessages.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/BattleFatigueMessages.java
@@ -1,0 +1,144 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.events.PlayerFatigueGainEvent;
+import me.mykindos.betterpvp.clans.clans.fatigue.events.PlayerFatigueTierChangeEvent;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.model.display.title.TitleComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * The voice of battle fatigue. The only layer that builds text. It listens to
+ * the scoring events and renders medieval flavor via <b>title</b> (the visceral
+ * moment) and <b>chat</b> (the durable record) — never the action bar.
+ * <p>
+ * Scoring code fires events and forgets; this class decides how it <i>feels</i>.
+ */
+@Singleton
+@BPvPListener
+public class BattleFatigueMessages implements Listener {
+
+    // Minor accumulation — a low growl, chat only.
+    private static final String[] MINOR = {
+            "Your limbs grow heavy from the ceaseless fray...",
+            "A dull ache settles into your bones.",
+            "Your breath comes harder than it once did.",
+            "The weight of battle presses upon your shoulders."
+    };
+
+    // Crossed into a worse tier — felt, with a title.
+    private static final String[] WORN = {
+            "Your body protests the endless slaughter.",
+            "Fatigue creeps into your sword-arm."
+    };
+    private static final String[] WEARY = {
+            "Your vision swims; the battlefield will not forgive this.",
+            "Every wound you have ignored now cries out at once."
+    };
+    private static final String[] EXHAUSTED = {
+            "Your body is spent. Death comes easy to the reckless.",
+            "You can barely lift your blade. Rest, or be broken."
+    };
+
+    // Recovered back down a tier — relief.
+    private static final String[] RECOVERED = {
+            "Strength seeps back into your bones.",
+            "Your breathing steadies. The ache fades.",
+            "The fog of exhaustion lifts a little."
+    };
+
+    private final ClientManager clientManager;
+
+    @Inject
+    public BattleFatigueMessages(ClientManager clientManager) {
+        this.clientManager = clientManager;
+    }
+
+    @EventHandler
+    public void onGain(PlayerFatigueGainEvent event) {
+        // Only nag when the gain was meaningful, so it doesn't spam every death.
+        if (event.getDelta() >= 3.0) {
+            flavor(event.getPlayer(), pick(MINOR));
+        }
+    }
+
+    @EventHandler
+    public void onTierChange(PlayerFatigueTierChangeEvent event) {
+        final Player player = event.getPlayer();
+        final FatigueTier tier = event.getNewTier();
+
+        if (!event.isEscalation()) {
+            if (event.getOldTier().requiresHold() && !tier.requiresHold()) {
+                flavor(player, pick(RECOVERED));
+            }
+            return;
+        }
+
+        final String line = switch (tier) {
+            case WORN -> pick(WORN);
+            case WEARY -> pick(WEARY);
+            case EXHAUSTED -> pick(EXHAUSTED);
+            default -> null;
+        };
+        if (line == null) {
+            return;
+        }
+
+        title(player,
+                Component.text(tier.getDisplayName(), tier.getColor(), TextDecoration.BOLD),
+                Component.text(line, NamedTextColor.GRAY, TextDecoration.ITALIC),
+                1.5);
+        flavor(player, line);
+    }
+
+    /** Shown by {@link RespawnHoldService} the instant the hold begins. */
+    public void onRespawnHoldStart(Player player, FatigueTier tier, double seconds) {
+        title(player,
+                Component.text("Broken", tier.getColor(), TextDecoration.BOLD),
+                Component.text("Your body refuses to rise...", NamedTextColor.GRAY, TextDecoration.ITALIC),
+                2.0);
+
+        final String format = String.format("Recklessness has its price. You will rise in %.0f seconds...", Math.ceil(seconds));
+        final TextComponent text = Component.text(format, NamedTextColor.RED, TextDecoration.ITALIC);
+        UtilMessage.message(player, Component.empty());
+        UtilMessage.message(player, text);
+        UtilMessage.message(player, Component.empty());
+    }
+
+    /** Shown by {@link RespawnHoldService} when the player is returned to the world. */
+    public void onRespawnHoldRelease(Player player, FatigueTier tier) {
+        final Gamer gamer = clientManager.search().online(player).getGamer();
+        gamer.getTitleQueue().add(1, TitleComponent.subtitle(0.3, 1.5, 0.5, false,
+                gmr -> Component.text("You stagger to your feet...", NamedTextColor.GRAY, TextDecoration.ITALIC)));
+        final TextComponent text = Component.text("Tread carefully. Your body remembers.", NamedTextColor.RED, TextDecoration.ITALIC);
+        UtilMessage.message(player, Component.empty());
+        UtilMessage.message(player, text);
+        UtilMessage.message(player, Component.empty());
+    }
+
+    private void title(Player player, Component title, Component subtitle, double seconds) {
+        final Gamer gamer = clientManager.search().online(player).getGamer();
+        gamer.getTitleQueue().add(1, new TitleComponent(0.3, seconds, 0.5, false,
+                gmr -> title, gmr -> subtitle));
+    }
+
+    private void flavor(Player player, String line) {
+        UtilMessage.message(player, Component.text(line, NamedTextColor.GRAY, TextDecoration.ITALIC));
+    }
+
+    private static String pick(String[] pool) {
+        return pool[ThreadLocalRandom.current().nextInt(pool.length)];
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/DeathContext.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/DeathContext.java
@@ -1,0 +1,31 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Immutable snapshot of a death, assembled by {@link me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigueListener}
+ * and handed to every {@link me.mykindos.betterpvp.clans.clans.fatigue.factor.FatigueFactor}.
+ * <p>
+ * Keeping this a pure value object (no Bukkit lookups inside factors) is what
+ * makes the scoring layer unit-testable without a running server.
+ *
+ * @param victim             the player who died
+ * @param killer             the killing player, or {@code null} for environmental / unknown deaths
+ * @param location           where the death occurred
+ * @param timestamp          epoch millis of the death
+ * @param distanceFromSafety blocks from the victim to the nearest safety (own/closest wilderness);
+ *                           {@code -1} if it could not be determined
+ */
+public record DeathContext(UUID victim,
+                           @Nullable UUID killer,
+                           Location location,
+                           long timestamp,
+                           double distanceFromSafety) {
+
+    public DeathRecord toRecord() {
+        return new DeathRecord(killer, location, timestamp);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/DeathRecord.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/DeathRecord.java
@@ -1,0 +1,17 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * An immutable record of a single death, retained in a bounded history on
+ * {@link BattleFatigue}. Factors read this history to derive recklessness.
+ *
+ * @param killer        the UUID of the killing player, or {@code null} for environmental deaths
+ * @param location      where the death occurred
+ * @param timestamp     epoch millis of the death
+ */
+public record DeathRecord(@Nullable UUID killer, Location location, long timestamp) {
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/FatigueHomeCastListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/FatigueHomeCastListener.java
@@ -1,0 +1,65 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.framework.delayedactions.events.ClanCoreTeleportEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * Lengthens the {@code /c home} (clan core teleport) cast for fatigued players.
+ * <p>
+ * It listens to {@link ClanCoreTeleportEvent} — a {@code PlayerDelayedActionEvent}
+ * with a mutable {@code delayInSeconds}.
+ * <p>
+ * <b>Priority is deliberately {@link EventPriority#HIGHEST}.</b> Other clan
+ * listeners <i>assign</i> an absolute base delay at {@code NORMAL}
+ * ({@code ClansMovementListener.onClanHomeTeleport}) or cancel the event
+ * ({@code PillageListener.onTeleportCore}). We must run <i>after</i> every such
+ * absolute setter so our {@code +=} stacks on top instead of being overwritten,
+ * yet still <i>before</i> the core {@code DelayedActionListener} which consumes
+ * the value at {@code MONITOR}. {@code HIGHEST} is the last mutation stage that
+ * satisfies both. {@code ignoreCancelled = true} cleanly excludes us when an
+ * upstream listener has already denied the teleport.
+ * <p>
+ * Zero coupling: {@code CoreTransportButton}/{@code TransportListener}/
+ * {@code ClansMovementListener} are never touched — the systems coordinate
+ * purely through this Bukkit event.
+ */
+@Singleton
+@BPvPListener
+public class FatigueHomeCastListener implements Listener {
+
+    private final BattleFatigueManager fatigueManager;
+
+    @Inject
+    @Config(path = "clans.fatigue.homeCast.extraSecondsPerTier", defaultValue = "8.0")
+    private double extraSecondsPerTier;
+
+    @Inject
+    public FatigueHomeCastListener(BattleFatigueManager fatigueManager) {
+        this.fatigueManager = fatigueManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onCoreTeleport(ClanCoreTeleportEvent event) {
+        final Player player = event.getPlayer();
+        final FatigueTier tier = fatigueManager.getTier(player.getUniqueId());
+        if (!tier.requiresHold()) {
+            return; // Rested/low fatigue — leave the normal cast untouched.
+        }
+
+        final double extra = extraSecondsPerTier * tier.ordinal();
+        event.setDelayInSeconds(event.getDelayInSeconds() + extra);
+
+        UtilMessage.message(player, "Battle Fatigue",
+                Component.text("Your weary body is slow to find its way home...", NamedTextColor.RED));
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/FatigueTier.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/FatigueTier.java
@@ -1,0 +1,37 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import lombok.Getter;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+
+/**
+ * Severity bands a player's battle fatigue can fall into.
+ * <p>
+ * Score thresholds live in config (resolved by {@link BattleFatigueManager});
+ * per-tier punishment magnitudes (hold duration, slowness) are owned by each
+ * punishment strategy. This enum only carries presentation metadata.
+ */
+@Getter
+public enum FatigueTier {
+
+    FRESH("Rested", NamedTextColor.GREEN),
+    WORN("Worn", NamedTextColor.YELLOW),
+    WEARY("Weary", NamedTextColor.GOLD),
+    EXHAUSTED("Exhausted", NamedTextColor.RED);
+
+    private final String displayName;
+    private final TextColor color;
+
+    FatigueTier(String displayName, TextColor color) {
+        this.displayName = displayName;
+        this.color = color;
+    }
+
+    /**
+     * @return whether this tier should trap the player in the respawn hold on death.
+     */
+    public boolean requiresHold() {
+        return ordinal() >= WORN.ordinal();
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/RespawnHoldService.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/RespawnHoldService.java
@@ -1,0 +1,302 @@
+package me.mykindos.betterpvp.clans.clans.fatigue;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import me.mykindos.betterpvp.core.utilities.model.display.title.TitleComponent;
+import me.mykindos.betterpvp.core.world.model.BPvPWorld;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Owns the void-world "you are recovering" hold. Mirrors the game module's
+ * {@code ParticipantRespawnHandler} pattern (deferred respawn + tick-up
+ * countdown with title/chat/vignette/heartbeat) but for clans, and adds a
+ * single authoritative failsafe so a player can never get stuck "respawning".
+ * <p>
+ * Immobilisation and invulnerability are free: {@code VoidWorldListener} already
+ * cancels movement and damage for non-ops in the void world.
+ */
+@Singleton
+@BPvPListener
+@CustomLog
+public class RespawnHoldService implements Listener {
+
+    /** Per-player active hold. */
+    private static final class HoldSession {
+        private FatigueTier tier;
+        private long endTime;
+        private BukkitTask task;
+        private boolean teleported; // true once we've placed them in the void
+        /** Where the player would have respawned if not for the hold (the true home). */
+        private Location returnLocation;
+    }
+
+    private final Clans plugin;
+    private final ClientManager clientManager;
+    private final BattleFatigueManager fatigueManager;
+    private final Set<FatiguePunishment> punishments;
+    private final BattleFatigueMessages messages;
+
+    private final Map<UUID, HoldSession> sessions = new ConcurrentHashMap<>();
+    private final World voidWorld;
+
+    @Inject
+    @Config(path = "clans.fatigue.hold.secondsPerTier", defaultValue = "7.0")
+    private double holdSecondsPerTier;
+
+    @Inject
+    public RespawnHoldService(Clans plugin,
+                              ClientManager clientManager,
+                              BattleFatigueManager fatigueManager,
+                              Set<FatiguePunishment> punishments,
+                              BattleFatigueMessages messages) {
+        this.plugin = plugin;
+        this.clientManager = clientManager;
+        this.fatigueManager = fatigueManager;
+        this.punishments = punishments;
+        this.messages = messages;
+        this.voidWorld = new BPvPWorld(BPvPWorld.VOID_WORLD_NAME).getWorld();
+    }
+
+    public boolean isHeld(Player player) {
+        return sessions.containsKey(player.getUniqueId());
+    }
+
+    /**
+     * Begin holding a player who just died at a hold-worthy tier. We force a
+     * respawn shortly after death (the game module's trick); {@link #onRespawn}
+     * then captures wherever the normal respawn listeners decided to send them
+     * and detours them through the void for the hold.
+     */
+    public void beginHold(Player player, FatigueTier tier) {
+        if (isHeld(player)) {
+            return;
+        }
+
+        final HoldSession session = new HoldSession();
+        session.tier = tier;
+        session.endTime = System.currentTimeMillis() + (long) (holdSecondsPerTier * tier.ordinal() * 1000L);
+        sessions.put(player.getUniqueId(), session);
+        fatigueManager.getOrCreate(player.getUniqueId()).setRespawnHold(true);
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (player.isOnline() && player.isDead()) {
+                    player.spigot().respawn();
+                }
+            }
+        }.runTaskLater(plugin, 3L);
+    }
+
+    /**
+     * Runs at {@code MONITOR}, after every other respawn listener
+     * (notably {@code VoidWorldListener} at {@code HIGHEST}) has had its say.
+     * We therefore read the <i>final</i> respawn location — the player's true
+     * home, whether that's a clan core, a bed, or world spawn — capture it for
+     * the release, and only then redirect this respawn into the void for the
+     * hold. We never reimplement or know the home logic; we just use its output.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onRespawn(PlayerRespawnEvent event) {
+        final Player player = event.getPlayer();
+        final HoldSession session = sessions.get(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        // Capture the real destination the normal listeners settled on, then
+        // detour into the void so the player materialises straight in the hold.
+        session.returnLocation = event.getRespawnLocation().clone();
+        event.setRespawnLocation(voidWorld.getSpawnLocation());
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline() || !sessions.containsKey(player.getUniqueId())) {
+                    return;
+                }
+                player.teleport(voidWorld.getSpawnLocation());
+                player.setGameMode(GameMode.ADVENTURE);
+                player.setInvulnerable(true);
+                startCountdown(player, session);
+            }
+        }.runTaskLater(plugin, 1L);
+    }
+
+    private void startCountdown(Player player, HoldSession session) {
+        session.teleported = true;
+        final Gamer gamer = clientManager.search().online(player).getGamer();
+        messages.onRespawnHoldStart(player, session.tier, remainingSeconds(session));
+
+        session.task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline() || !sessions.containsKey(player.getUniqueId())) {
+                    cancel();
+                    return;
+                }
+
+                final double remaining = remainingSeconds(session);
+                if (remaining <= 0.0) {
+                    cancel();
+                    release(player, session); // returns them to the captured home
+                    return;
+                }
+
+                // Live countdown title + escalating heartbeat (game-module feel).
+                gamer.getTitleQueue().add(10, TitleComponent.subtitle(0, 1.15, 0.0, false,
+                        gmr -> Component.text(String.format("Recovering... %.0f", Math.ceil(remaining)), NamedTextColor.RED)));
+                UtilPlayer.setWarningEffect(player, 1);
+                if (remaining <= 3.0) {
+                    new SoundEffect(Sound.ENTITY_WARDEN_HEARTBEAT, 0.9f, 1.4f).play(player);
+                } else {
+                    new SoundEffect(Sound.ENTITY_WARDEN_HEARTBEAT, 0.7f, 1f).play(player);
+                }
+            }
+        }.runTaskTimer(plugin, 1L, 20L);
+    }
+
+    private double remainingSeconds(HoldSession session) {
+        return Math.max(0.0, (session.endTime - System.currentTimeMillis()) / 1000.0);
+    }
+
+    /**
+     * The single authoritative cleanup path. Whether the timer finished, the
+     * player was teleported out, the task died, or the failsafe caught them —
+     * everything funnels through here exactly once.
+     */
+    private void release(Player player, HoldSession session, Location destination) {
+        if (sessions.remove(player.getUniqueId()) == null) {
+            return; // already released by another path
+        }
+        if (session.task != null) {
+            session.task.cancel();
+        }
+
+        fatigueManager.getOrCreate(player.getUniqueId()).setRespawnHold(false);
+
+        if (player.isOnline()) {
+            UtilPlayer.clearWarningEffect(player);
+            player.setInvulnerable(false);
+            player.setGameMode(GameMode.SURVIVAL);
+            if (destination != null) {
+                player.teleport(destination);
+            }
+
+            new SoundEffect(Sound.BLOCK_BEACON_POWER_SELECT, 1.4f, 0.7f).play(player.getLocation());
+
+            for (FatiguePunishment punishment : punishments) {
+                if (punishment.appliesTo(session.tier)) {
+                    punishment.apply(player, session.tier);
+                }
+            }
+            messages.onRespawnHoldRelease(player, session.tier);
+        }
+    }
+
+    /**
+     * Failsafe reconciler. Any held player who is offline, no longer in the void
+     * world, or whose countdown task has died is force-released so nobody can
+     * get stuck in the "respawning" state.
+     */
+    @UpdateEvent(delay = 1000)
+    public void reconcile() {
+        for (Map.Entry<UUID, HoldSession> entry : sessions.entrySet()) {
+            final UUID uuid = entry.getKey();
+            final HoldSession session = entry.getValue();
+            final Player player = plugin.getServer().getPlayer(uuid);
+
+            if (player == null || !player.isOnline()) {
+                // Offline: clear flag, drop the session (state is session-only).
+                fatigueManager.getOrCreate(uuid).setRespawnHold(false);
+                if (session.task != null) {
+                    session.task.cancel();
+                }
+                sessions.remove(uuid);
+                continue;
+            }
+
+            if (!session.teleported) {
+                continue; // still in the brief death→respawn window
+            }
+
+            final boolean inVoid = player.getWorld().getName().equals(BPvPWorld.VOID_WORLD_NAME);
+            final boolean taskDead = session.task == null || session.task.isCancelled();
+            if (!inVoid) {
+                // Yanked out by something else — finalise where they are now.
+                release(player, session, null);
+            } else if (taskDead) {
+                release(player, session);
+            }
+        }
+    }
+
+    /**
+     * Decoupled compatibility with {@code VoidWorldListener}: it tries to open
+     * the clan travel-hub menu for every non-op in the void every 500ms. While
+     * a player is in our hold, we veto any GUI open so the recovery title/chat
+     * is the only thing they see. Neither listener references the other — they
+     * coordinate purely through this Bukkit event.
+     */
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (event.getPlayer() instanceof Player player && isHeld(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        final HoldSession session = sessions.remove(event.getPlayer().getUniqueId());
+        if (session != null) {
+            if (session.task != null) {
+                session.task.cancel();
+            }
+            fatigueManager.getOrCreate(event.getPlayer().getUniqueId()).setRespawnHold(false);
+        }
+    }
+
+    /**
+     * Called by the countdown when it completes (and the failsafe). Returns the
+     * player to the home we captured at respawn. The fallback should never be
+     * needed — vanilla/bed/clan respawn is never the void — but guards against a
+     * lost capture so we can never strand anyone.
+     */
+    private void release(Player player, HoldSession session) {
+        Location destination = session.returnLocation;
+        if (destination == null || destination.getWorld() == null
+                || destination.getWorld().equals(voidWorld)) {
+            destination = plugin.getServer().getWorlds().get(0).getSpawnLocation();
+        }
+        release(player, session, destination);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/events/PlayerFatigueGainEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/events/PlayerFatigueGainEvent.java
@@ -1,0 +1,30 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+/**
+ * Fired on every fatigue gain that did <i>not</i> change the player's tier
+ * (a tier change fires {@link PlayerFatigueTierChangeEvent} instead). Drives the
+ * lighter "your body aches" chat flavor without coupling scoring to presentation.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class PlayerFatigueGainEvent extends CustomEvent {
+
+    private final Player player;
+    private final double previousScore;
+    private final double newScore;
+
+    public PlayerFatigueGainEvent(Player player, double previousScore, double newScore) {
+        this.player = player;
+        this.previousScore = previousScore;
+        this.newScore = newScore;
+    }
+
+    public double getDelta() {
+        return newScore - previousScore;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/events/PlayerFatigueTierChangeEvent.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/events/PlayerFatigueTierChangeEvent.java
@@ -1,0 +1,32 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import me.mykindos.betterpvp.clans.clans.fatigue.FatigueTier;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import org.bukkit.entity.Player;
+
+/**
+ * Fired when a player crosses from one {@link FatigueTier} to another, in either
+ * direction. The scoring layer fires this and is done; punishment and messaging
+ * listen independently, keeping those concerns fully decoupled.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class PlayerFatigueTierChangeEvent extends CustomEvent {
+
+    private final Player player;
+    private final FatigueTier oldTier;
+    private final FatigueTier newTier;
+
+    public PlayerFatigueTierChangeEvent(Player player, FatigueTier oldTier, FatigueTier newTier) {
+        this.player = player;
+        this.oldTier = oldTier;
+        this.newTier = newTier;
+    }
+
+    /** @return true when the player got worse (moved up a tier). */
+    public boolean isEscalation() {
+        return newTier.ordinal() > oldTier.ordinal();
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DeathFrequencyFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DeathFrequencyFactor.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathRecord;
+import me.mykindos.betterpvp.core.config.Config;
+
+/**
+ * Signals rapid re-queueing into death. Counts deaths in the short window
+ * leading up to this one; the magnitude rises super-linearly so the first death
+ * barely registers but a burst of them spikes hard.
+ */
+@Singleton
+public class DeathFrequencyFactor implements FatigueFactor {
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.frequency.windowSeconds", defaultValue = "120")
+    private int windowSeconds;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.frequency.saturationDeaths", defaultValue = "4")
+    private int saturationDeaths;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.frequency.weight", defaultValue = "15.0")
+    private double weight;
+
+    @Override
+    public String getName() {
+        return "frequency";
+    }
+
+    @Override
+    public double getWeight() {
+        return weight;
+    }
+
+    @Override
+    public double evaluate(BattleFatigue state, DeathContext context) {
+        final long cutoff = context.timestamp() - (windowSeconds * 1000L);
+
+        long recent = 0;
+        for (DeathRecord record : state.getDeathHistory()) {
+            if (record.timestamp() >= cutoff) {
+                recent++;
+            }
+        }
+
+        final double ratio = Math.min(1.0, (double) recent / Math.max(1, saturationDeaths));
+        // Super-linear: a single recent death is cheap, a cluster is punishing.
+        return ratio * ratio;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DeathLocalityFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DeathLocalityFactor.java
@@ -1,0 +1,57 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathRecord;
+import me.mykindos.betterpvp.core.config.Config;
+import org.bukkit.Location;
+
+/**
+ * Signals that the player keeps dying in the <i>same place</i> — i.e. sprinting
+ * straight back into the meat grinder. Counts how many recent deaths occurred
+ * within {@code radius} blocks of this one and saturates toward 1.0.
+ */
+@Singleton
+public class DeathLocalityFactor implements FatigueFactor {
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.locality.radius", defaultValue = "80.0")
+    private double radius;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.locality.saturationDeaths", defaultValue = "3")
+    private int saturationDeaths;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.locality.weight", defaultValue = "12.0")
+    private double weight;
+
+    @Override
+    public String getName() {
+        return "locality";
+    }
+
+    @Override
+    public double getWeight() {
+        return weight;
+    }
+
+    @Override
+    public double evaluate(BattleFatigue state, DeathContext context) {
+        final Location here = context.location();
+        final double radiusSq = radius * radius;
+
+        long nearby = 0;
+        for (DeathRecord record : state.getDeathHistory()) {
+            final Location past = record.location();
+            if (past.getWorld() != null && past.getWorld().equals(here.getWorld())
+                    && past.distanceSquared(here) <= radiusSq) {
+                nearby++;
+            }
+        }
+
+        return Math.min(1.0, (double) nearby / Math.max(1, saturationDeaths));
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DistanceFromSafetyFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/DistanceFromSafetyFactor.java
@@ -1,0 +1,51 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+import me.mykindos.betterpvp.core.config.Config;
+
+/**
+ * Signals dying close to your own base. Pure distance: maximum at the clan
+ * core, fading linearly to 0 at {@code homeRadiusBlocks} and beyond.
+ * <p>
+ * Death history is intentionally <b>not</b> considered here — the "repeated
+ * deaths" angle is owned by {@link DeathFrequencyFactor} and
+ * {@link DeathLocalityFactor}. This axis is purely positional, so the
+ * {@code combine()} synergy multiplier (not this factor) is what makes
+ * "near home" matter more when it coincides with rapid/clustered deaths.
+ */
+@Singleton
+public class DistanceFromSafetyFactor implements FatigueFactor {
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.distance.homeRadiusBlocks", defaultValue = "100.0")
+    private double homeRadiusBlocks;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.distance.weight", defaultValue = "12.0")
+    private double weight;
+
+    @Override
+    public String getName() {
+        return "distanceFromSafety";
+    }
+
+    @Override
+    public double getWeight() {
+        return weight;
+    }
+
+    @Override
+    public double evaluate(BattleFatigue state, DeathContext context) {
+        final double distance = context.distanceFromSafety();
+        if (distance < 0) {
+            return 0.0; // Unknown (no clan/core) — don't punish what we can't measure.
+        }
+
+        // Closer to home = stronger; zero once you're beyond the home radius.
+        final double proximity = 1.0 - Math.min(1.0, distance / Math.max(1.0, homeRadiusBlocks));
+        return Math.max(0.0, proximity);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/FatigueFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/FatigueFactor.java
@@ -1,0 +1,49 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+
+/**
+ * One pluggable, self-contained signal of recklessness.
+ * <p>
+ * A factor owns <b>everything</b> about itself: its identity ({@link #getName()}),
+ * how reckless a death is on its axis ({@link #evaluate}), and how much that
+ * axis should count ({@link #getWeight()}). The
+ * {@link me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigueManager}
+ * discovers implementations via a Guice {@code Multibinder} and combines them
+ * generically — it never names or special-cases a concrete factor. Adding a
+ * factor is therefore: write the class, add one binding line. No other file
+ * changes.
+ * <p>
+ * Implementations must be <b>pure</b>: derive everything from the supplied
+ * {@code state} and {@code context}, never query Bukkit. This keeps the scoring
+ * layer deterministic and unit-testable.
+ */
+public interface FatigueFactor {
+
+    /**
+     * @return a stable identifier (used for logging/debugging; the manager does
+     * not switch on it).
+     */
+    String getName();
+
+    /**
+     * How much this axis contributes relative to the others. The manager
+     * multiplies the normalized {@link #evaluate} output by this. Keep the
+     * backing value in a {@code @Config} on the implementation so weights stay
+     * tunable and co-located with the factor's logic.
+     *
+     * @return this factor's weight (typical range ~5–15; non-negative)
+     */
+    double getWeight();
+
+    /**
+     * Evaluate this factor for a death that has just occurred.
+     *
+     * @param state   the victim's fatigue state, with history <i>not yet</i> including this death
+     * @param context the death snapshot
+     * @return a normalized magnitude in {@code [0.0, 1.0]} — 0 means "no recklessness
+     * signal", 1 means "maximally reckless on this axis". The manager scales by weight.
+     */
+    double evaluate(BattleFatigue state, DeathContext context);
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/PlayerDeathFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/PlayerDeathFactor.java
@@ -1,0 +1,40 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+import me.mykindos.betterpvp.core.config.Config;
+
+import java.util.UUID;
+
+/**
+ * Signals that the player died against another player.
+ */
+@Singleton
+public class PlayerDeathFactor implements FatigueFactor {
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.playerDeath.weight", defaultValue = "30.0")
+    private double weight;
+
+    @Override
+    public String getName() {
+        return "playerDeath";
+    }
+
+    @Override
+    public double getWeight() {
+        return weight;
+    }
+
+    @Override
+    public double evaluate(BattleFatigue state, DeathContext context) {
+        final UUID killer = context.killer();
+        if (killer == null) {
+            return 0.0;
+        }
+
+        return 1.0;
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/RepeatKillerFactor.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/factor/RepeatKillerFactor.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.factor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.BattleFatigue;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathContext;
+import me.mykindos.betterpvp.clans.clans.fatigue.DeathRecord;
+import me.mykindos.betterpvp.core.config.Config;
+
+import java.util.UUID;
+
+/**
+ * Signals that the player keeps feeding the <i>same</i> opponent. Returns the
+ * fraction of recent deaths attributable to the current killer, so dying to one
+ * person over and over saturates toward 1.0 while a varied death log stays low.
+ */
+@Singleton
+public class RepeatKillerFactor implements FatigueFactor {
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.repeatKiller.saturationDeaths", defaultValue = "4")
+    private int saturationDeaths;
+
+    @Inject
+    @Config(path = "clans.fatigue.factor.repeatKiller.weight", defaultValue = "15.0")
+    private double weight;
+
+    @Override
+    public String getName() {
+        return "repeatKiller";
+    }
+
+    @Override
+    public double getWeight() {
+        return weight;
+    }
+
+    @Override
+    public double evaluate(BattleFatigue state, DeathContext context) {
+        final UUID killer = context.killer();
+        if (killer == null) {
+            return 0.0;
+        }
+
+        long sameKiller = 0;
+        for (DeathRecord record : state.getDeathHistory()) {
+            if (killer.equals(record.killer())) {
+                sameKiller++;
+            }
+        }
+
+        // Saturates at 1.0 once the player has fed this killer `saturationDeaths` times.
+        return Math.min(1.0, (double) sameKiller / Math.max(1, saturationDeaths));
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/FatiguePunishment.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/FatiguePunishment.java
@@ -1,0 +1,29 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.punishment;
+
+import me.mykindos.betterpvp.clans.clans.fatigue.FatigueTier;
+import org.bukkit.entity.Player;
+
+/**
+ * A consequence applied to a fatigued player <i>when they are released from the
+ * respawn hold</i> (or immediately on respawn if their tier requires no hold).
+ * <p>
+ * Discovered via a Guice {@code Multibinder}; {@code RespawnHoldService} runs
+ * every punishment whose {@link #appliesTo(FatigueTier)} accepts the player's
+ * tier. Adding a punishment is one binding line — no orchestration code changes.
+ */
+public interface FatiguePunishment {
+
+    /**
+     * @return whether this punishment should fire for the given tier.
+     */
+    boolean appliesTo(FatigueTier tier);
+
+    /**
+     * Apply the consequence. Called on the main thread, after the player has
+     * been returned to the world.
+     *
+     * @param player the recovering player
+     * @param tier   the tier that triggered the punishment (for scaling)
+     */
+    void apply(Player player, FatigueTier tier);
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/SlownessPunishment.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/SlownessPunishment.java
@@ -19,7 +19,7 @@ public class SlownessPunishment implements FatiguePunishment {
     private final EffectManager effectManager;
 
     @Inject
-    @Config(path = "clans.fatigue.slowness.secondsPerTier", defaultValue = "7.0")
+    @Config(path = "clans.fatigue.slowness.secondsPerTier", defaultValue = "0.0")
     private double secondsPerTier;
 
     @Inject

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/SlownessPunishment.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/fatigue/punishment/SlownessPunishment.java
@@ -1,0 +1,42 @@
+package me.mykindos.betterpvp.clans.clans.fatigue.punishment;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.clans.clans.fatigue.FatigueTier;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import org.bukkit.entity.Player;
+
+/**
+ * Lingering heavy-limbs slowness once the player is back on their feet. The
+ * level and duration scale with how exhausted they are, so a Worn player barely
+ * notices while an Exhausted one is visibly hobbled for a while.
+ */
+@Singleton
+public class SlownessPunishment implements FatiguePunishment {
+
+    private final EffectManager effectManager;
+
+    @Inject
+    @Config(path = "clans.fatigue.slowness.secondsPerTier", defaultValue = "7.0")
+    private double secondsPerTier;
+
+    @Inject
+    public SlownessPunishment(EffectManager effectManager) {
+        this.effectManager = effectManager;
+    }
+
+    @Override
+    public boolean appliesTo(FatigueTier tier) {
+        return tier.requiresHold();
+    }
+
+    @Override
+    public void apply(Player player, FatigueTier tier) {
+        // WORN -> I, WEARY -> II, EXHAUSTED -> III
+        final int level = Math.max(1, tier.ordinal());
+        final long durationMillis = (long) (secondsPerTier * tier.ordinal() * 1000L);
+        effectManager.addEffect(player, EffectTypes.SLOWNESS, level, durationMillis);
+    }
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/listeners/ClansMovementListener.java
@@ -213,7 +213,7 @@ public class ClansMovementListener extends ClanListener {
 
         clanManager.getClanByLocation(player.getLocation()).ifPresentOrElse(clan -> {
             if (clan.isAdmin() && clan.isSafe()) {
-                event.setDelayInSeconds(20);
+                event.setDelayInSeconds(0);
                 return;
             }
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -1,7 +1,15 @@
 package me.mykindos.betterpvp.clans.injector;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
 import me.mykindos.betterpvp.clans.Clans;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathFrequencyFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathLocalityFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.DistanceFromSafetyFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.FatigueFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
+import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
 
 public class ClansInjectorModule extends AbstractModule {
 
@@ -15,6 +23,18 @@ public class ClansInjectorModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Clans.class).toInstance(plugin);
+
+        // Battle fatigue strategies. Adding/removing a factor or punishment is a
+        // single line here — the manager and hold service never name a concrete
+        // implementation (Open/Closed).
+        final Multibinder<FatigueFactor> factors = Multibinder.newSetBinder(binder(), FatigueFactor.class);
+        factors.addBinding().to(RepeatKillerFactor.class);
+        factors.addBinding().to(DeathLocalityFactor.class);
+        factors.addBinding().to(DeathFrequencyFactor.class);
+        factors.addBinding().to(DistanceFromSafetyFactor.class);
+
+        final Multibinder<FatiguePunishment> punishments = Multibinder.newSetBinder(binder(), FatiguePunishment.class);
+        punishments.addBinding().to(SlownessPunishment.class);
     }
 
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathFrequencyFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathLocalityFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DistanceFromSafetyFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.FatigueFactor;
+import me.mykindos.betterpvp.clans.clans.fatigue.factor.PlayerDeathFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
@@ -32,6 +33,7 @@ public class ClansInjectorModule extends AbstractModule {
         factors.addBinding().to(DeathLocalityFactor.class);
         factors.addBinding().to(DeathFrequencyFactor.class);
         factors.addBinding().to(DistanceFromSafetyFactor.class);
+        factors.addBinding().to(PlayerDeathFactor.class);
 
         final Multibinder<FatiguePunishment> punishments = Multibinder.newSetBinder(binder(), FatiguePunishment.class);
         punishments.addBinding().to(SlownessPunishment.class);


### PR DESCRIPTION
## Describe your changes

Adds the **Battle Fatigue** system to clans — a recklessness-based death penalty that discourages players from mindlessly throwing themselves back into fights.

**How Battle Fatigue works**

- Every death builds up a hidden fatigue score. The more recklessly you die, the faster it grows.
- Several things make a death count for more, and they compound when they happen together:
  - Dying many times in a short span.
  - Dying over and over in the same area.
  - Dying close to your own base.
  - Dying repeatedly to the same player.
  - Dying to any player.
- If only one of those is true, the death barely registers; if several are true at once, fatigue spikes hard.
- The score steadily drains on its own when you stop dying, so playing carefully lets you recover.
- A single death can never jump you straight to the worst state — there is a cap per death.
- Fatigue moves through four states: Rested, Worn, Weary, Exhausted.
  - Crossing into a worse state shows an on-screen title and a message.
  - Recovering back to a calmer state shows a relief message.
- Once you are Worn or higher, dying puts you through a short recovery hold before you return:
  - You are held safely, unable to move or take damage, with a visible countdown and heartbeat.
  - The worse your state, the longer the hold.
  - Menus stay closed during the hold so only the recovery is shown.
  - You are always returned to wherever you would normally have respawned (clan home, bed, or spawn), with safeguards so you can never get stuck.
- After the hold you stagger free with lingering slowness — stronger and longer the more exhausted you were.
- While Worn or higher, casting `/c home` takes noticeably longer, scaling with how exhausted you are.
- All thresholds, weights, timers, and penalty magnitudes are configurable.

<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/23cd4934-f08e-4a22-a9e0-e08ea859f94f" />


**Other change**

- Removed the base `/c home` cast timer inside safe admin claims (previously 20 seconds, now instant).

## Link to issue (if applicable)

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
