### PR TITLE
Slight Assassin nerfs

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
@@ -107,7 +107,7 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
     public void loadSkillConfig() {
         baseMaxCharges = getConfig("baseMaxCharges", 5, Integer.class);
         chargeIncreasePerLevel = getConfig("chargeIncreasePerLevel", 0, Integer.class);
-        baseRechargeSeconds = getConfig("baseRechargeSeconds", 9.0, Double.class);
+        baseRechargeSeconds = getConfig("baseRechargeSeconds", 11.0, Double.class);
         rechargeReductionPerLevel = getConfig("rechargeReductionPerLevel", 1.0, Double.class);
         teleportDistance = getConfig("teleportDistance", 5.0, Double.class);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Flash.java
@@ -107,7 +107,7 @@ public class Flash extends Skill implements InteractSkill, Listener, MovementSki
     public void loadSkillConfig() {
         baseMaxCharges = getConfig("baseMaxCharges", 5, Integer.class);
         chargeIncreasePerLevel = getConfig("chargeIncreasePerLevel", 0, Integer.class);
-        baseRechargeSeconds = getConfig("baseRechargeSeconds", 11.0, Double.class);
+        baseRechargeSeconds = getConfig("baseRechargeSeconds", 10.0, Double.class);
         rechargeReductionPerLevel = getConfig("rechargeReductionPerLevel", 1.0, Double.class);
         teleportDistance = getConfig("teleportDistance", 5.0, Double.class);
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/axe/Leap.java
@@ -196,7 +196,7 @@ public class Leap extends Skill implements InteractSkill, CooldownSkill, Listene
     @Override
     public void loadSkillConfig() {
         leapStrength = getConfig("leapStrength", 1.3, Double.class);
-        wallKickStrength = getConfig("wallKickStrength", 0.9, Double.class);
+        wallKickStrength = getConfig("wallKickStrength", 0.75, Double.class);
         wallKickInternalCooldown = getConfig("wallKickInternalCooldown", 0.5, Double.class);
         wallkickEnergyCost = getConfig("wallkickEnergyCost", 35.0, Double.class);
         fallDamageLimit = getConfig("fallDamageLimit", 8.0, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Backstab.java
@@ -80,7 +80,7 @@ public class Backstab extends Skill implements PassiveSkill, Listener, DamageSki
 
     @Override
     public void loadSkillConfig() {
-        damageIncreasePerLevel = getConfig("increasePerLevel", 1.5, Double.class);
+        damageIncreasePerLevel = getConfig("increasePerLevel", 1.0, Double.class);
         damage = getConfig("baseDamage", 1.5, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Recall.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Recall.java
@@ -172,7 +172,7 @@ public class Recall extends Skill implements CooldownToggleSkill, Listener, Move
     @Override
     public void loadSkillConfig(){
         percentHealthRecovered = getConfig("percentHealthRecovered", 0.20, Double.class);
-        duration = getConfig("duration", 2.0, Double.class);
+        duration = getConfig("duration", 3.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 1.0, Double.class);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/SmokeBomb.java
@@ -308,7 +308,7 @@ public class SmokeBomb extends Skill implements CooldownToggleSkill, Listener, D
 
     @Override
     public void loadSkillConfig() {
-        baseDuration = getConfig("baseDuration", 4.0, Double.class);
+        baseDuration = getConfig("baseDuration", 3.0, Double.class);
         durationIncreasePerLevel = getConfig("durationIncreasePerLevel", 1.0, Double.class);
         blindDuration = getConfig("blindDuration", 1.75, Double.class);
         blindRadius = getConfig("blindRadius", 4.0, Double.class);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -265,11 +265,11 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
 
     @Override
     public void loadSkillConfig() {
-        activeBaseDuration = getConfig("activeBaseDuration", 0.7, Double.class);
+        activeBaseDuration = getConfig("activeBaseDuration", 0.6, Double.class);
         activeDurationIncreasePerLevel = getConfig("activeDurationIncreasePerLevel", 0.0, Double.class);
         baseDamageDelay = getConfig("baseDamageDelay", 0.4, Double.class);
         damageDelayIncreasePerLevel = getConfig("damageDelayIncreasePerLevel", 0.0, Double.class);
-        successBaseCooldown = getConfig("successBaseCooldown", 0.7, Double.class);
+        successBaseCooldown = getConfig("successBaseCooldown", 0.8, Double.class);
         successCooldownDecreasePerLevel = getConfig("successCooldownDecreasePerLevel", 0.1, Double.class);
         channelTimeCooldownMultiplier = getConfig("channelTimeCooldownMultiplier", 1.0, Double.class);
         channelTimeCooldownMultiplierDecreasePerLevel = getConfig("channelTimeCooldownMultiplierDecreasePerLevel", 0.0, Double.class);

--- a/champions/src/main/resources/configs/items/armor.yml
+++ b/champions/src/main/resources/configs/items/armor.yml
@@ -1,90 +1,161 @@
 # Assassin
-# 31 health
-assassin_helmet:
-  health: 2
-  durability: 500
-assassin_chestplate:
-  health: 4
-  durability: 500
-assassin_leggings:
-  health: 3
-  durability: 500
-assassin_boots:
-  health: 2
-  durability: 500
+# +12 health (set total)
+reinforced_assassin_helmet:
+  health:
+    base: 2.5
+    min: 0.0
+    max: 5.5
+  durability: 1020
+reinforced_assassin_chestplate:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_assassin_leggings:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_assassin_boots:
+  health:
+    base: 2.5
+    min: 0.0
+    max: 5.5
+  durability: 1020
 
 # Knight
-# 50 health
-knight_helmet:
-  health: 6
-  durability: 500
-knight_chestplate:
-  health: 10
-  durability: 500
-knight_leggings:
-  health: 8
-  durability: 500
-knight_boots:
-  health: 6
-  durability: 500
-
+# +18 health (set total)
+reinforced_knight_helmet:
+  health:
+    base: 4.5
+    min: 0.0
+    max: 9.0
+  durability: 1020
+reinforced_knight_chestplate:
+  health:
+    base: 5.5
+    min: 2.5
+    max: 10.0
+  durability: 1020
+reinforced_knight_leggings:
+  health:
+    base: 5.5
+    min: 2.5
+    max: 10.0
+  durability: 1020
+reinforced_knight_boots:
+  health:
+    base: 2.5
+    min: 0.0
+    max: 5.5
+  durability: 1020
 
 # Brute
-# 50 health
-brute_helmet:
-  health: 6
-  durability: 500
-brute_chestplate:
-  health: 10
-  durability: 500
-brute_leggings:
-  health: 8
-  durability: 500
-brute_boots:
-  health: 6
-  durability: 500
+# +18 health (set total)
+reinforced_brute_helmet:
+  health:
+    base: 4.5
+    min: 0.0
+    max: 9.0
+  durability: 1020
+reinforced_brute_chestplate:
+  health:
+    base: 5.5
+    min: 2.5
+    max: 10.0
+  durability: 1020
+reinforced_brute_leggings:
+  health:
+    base: 5.5
+    min: 2.5
+    max: 10.0
+  durability: 1020
+reinforced_brute_boots:
+  health:
+    base: 2.5
+    min: 0.0
+    max: 5.5
+  durability: 1020
 
 # Ranger
-# 37 health
-ranger_helmet:
-  health: 3
-  durability: 500
-ranger_chestplate:
-  health: 6
-  durability: 500
-ranger_leggings:
-  health: 5
-  durability: 500
-ranger_boots:
-  health: 3
-  durability: 500
+# +14 health (set total)
+reinforced_ranger_helmet:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_ranger_chestplate:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_ranger_leggings:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_ranger_boots:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
 
 # Mage
-# 40 health
-mage_helmet:
-  health: 4
-  durability: 500
-mage_chestplate:
-  health: 7
-  durability: 500
-mage_leggings:
-  health: 5
-  durability: 500
-mage_boots:
-  health: 4
-  durability: 500
+# +14 health (set total)
+reinforced_mage_helmet:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_mage_chestplate:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_mage_leggings:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_mage_boots:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
 
 # Warlock
-# 40 health
-warlock_helmet:
-  health: 4
-  durability: 500
-warlock_chestplate:
-  health: 7
-  durability: 500
-warlock_leggings:
-  health: 5
-  durability: 500
-warlock_boots:
-  health: 4
-  durability: 500
+# +14 health (set total)
+reinforced_warlock_helmet:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_warlock_chestplate:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_warlock_leggings:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020
+reinforced_warlock_boots:
+  health:
+    base: 3.5
+    min: 0.0
+    max: 6.5
+  durability: 1020

--- a/champions/src/main/resources/configs/items/armor.yml
+++ b/champions/src/main/resources/configs/items/armor.yml
@@ -1,28 +1,28 @@
 # Assassin
-# +12 health (set total)
+# +8 health (set total)
 reinforced_assassin_helmet:
   health:
-    base: 2.5
+    base: 1.5
     min: 0.0
-    max: 5.5
+    max: 4.5
   durability: 1020
 reinforced_assassin_chestplate:
   health:
-    base: 3.5
-    min: 0.0
-    max: 6.5
-  durability: 1020
-reinforced_assassin_leggings:
-  health:
-    base: 3.5
-    min: 0.0
-    max: 6.5
-  durability: 1020
-reinforced_assassin_boots:
-  health:
     base: 2.5
     min: 0.0
     max: 5.5
+  durability: 1020
+reinforced_assassin_leggings:
+  health:
+    base: 1.5
+    min: 0.0
+    max: 5.5
+  durability: 1020
+reinforced_assassin_boots:
+  health:
+    base: 1.5
+    min: 0.0
+    max: 4.5
   durability: 1020
 
 # Knight

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -40,7 +40,7 @@ skills:
       maxlevel: 3
       damageIncreasePerLevel: 1.5
       baseDamage: 1.5
-      increasePerLevel: 1.5
+      increasePerLevel: 1.0
     smokebomb:
       enabled: true
       cooldown: 40.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -123,7 +123,7 @@ skills:
       enabled: true
       maxlevel: 5
       baseMaxCharges: 5
-      baseRechargeSeconds: 9.0
+      baseRechargeSeconds: 11.0
       teleportDistance: 5.0
       canUseWhileSlowed: false
       chargeIncreasePerLevel: 0
@@ -159,11 +159,11 @@ skills:
       maxlevel: 3
       cooldown: 15.0
       cooldownDecreasePerLevel: 2.0
-      activeBaseDuration: 0.7
+      activeBaseDuration: 0.6
       activeDurationIncreasePerLevel: 0.0
       baseDamageDelay: 0.4
       damageDelayIncreasePerLevel: 0.0
-      successBaseCooldown: 0.7
+      successBaseCooldown: 0.8
       successCooldownDecreasePerLevel: 0.1
       channelTimeCooldownMultiplier: 1.0
       channelTimeCooldownMultiplierDecreasePerLevel: 0.0

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -3,14 +3,14 @@ skills:
   assassin:
     leap:
       enabled: true
-      cooldown: 8.0
+      cooldown: 9.0
       maxlevel: 5
       canUseWhileSlowed: false
       cooldownDecreasePerLevel: 0.5
       leapStrength: 1.3
-      wallKickStrength: 0.9
+      wallKickStrength: 0.75
       wallKickInternalCooldown: 0.5
-      wallkickEnergyCost: 25.0
+      wallkickEnergyCost: 35.0
       fallDamageLimit: 8.0
     sever:
       enabled: true
@@ -45,7 +45,7 @@ skills:
       enabled: true
       cooldown: 40.0
       maxlevel: 3
-      baseDuration: 4.0
+      baseDuration: 3.0
       blindDuration: 1.75
       blindRadius: 4.0
       cooldownDecreasePerLevel: 5.0
@@ -111,7 +111,7 @@ skills:
       durationPerLevel: 0.5
     blink:
       enabled: true
-      cooldown: 13.0
+      cooldown: 11.0
       maxlevel: 5
       maxTravelDistance: 14
       canUseWhileSlowed: false
@@ -123,7 +123,7 @@ skills:
       enabled: true
       maxlevel: 5
       baseMaxCharges: 5
-      baseRechargeSeconds: 11.0
+      baseRechargeSeconds: 10.0
       teleportDistance: 5.0
       canUseWhileSlowed: false
       chargeIncreasePerLevel: 0
@@ -150,7 +150,7 @@ skills:
       maxlevel: 3
       cooldown: 28.0
       percentHealthRecovered: 0.2
-      duration: 2.0
+      duration: 3.0
       canUseWhileSlowed: false
       cooldownDecreasePerLevel: 2.0
       durationIncreasePerLevel: 1.0


### PR DESCRIPTION
Assassin is the current most played class, almost more than the next 2 combined. Nerf Assassin reinforced armor to +8 overall (-1 from each piece). Very minor nerfs to Evade/Flash (high skill k/d and in top 3 used skills). Nerf backstab to 1.5 + 1.0L

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes.
