### PR TITLE
Style item tooltips by rarity

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/item/BaseItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/BaseItem.java
@@ -13,6 +13,7 @@ import me.mykindos.betterpvp.core.item.renderer.ItemNameRenderer;
 import me.mykindos.betterpvp.core.item.renderer.ItemStackRenderer;
 import me.mykindos.betterpvp.core.item.renderer.LoreComponentRenderer;
 import me.mykindos.betterpvp.core.item.renderer.NameRarityRenderer;
+import me.mykindos.betterpvp.core.item.renderer.RarityTooltipStyleRenderer;
 import net.kyori.adventure.text.Component;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -75,6 +76,7 @@ public class BaseItem implements Item {
         this.instanceRarityProvider = rarityProvider;
         this.modelBytes = model.serializeAsBytes();
         addItemStackRenderer(new DurabilityRenderer());
+        addItemStackRenderer(new RarityTooltipStyleRenderer());
     }
 
     public final @NotNull ItemStack getModel() {

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/renderer/RarityTooltipStyleRenderer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/renderer/RarityTooltipStyleRenderer.java
@@ -1,0 +1,34 @@
+package me.mykindos.betterpvp.core.item.renderer;
+
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.TooltipDisplay;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Changes the tooltip style attribute for items depending on their rarity
+ */
+public class RarityTooltipStyleRenderer implements ItemStackRenderer {
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public void write(ItemInstance item, ItemStack itemStack) {
+        final ItemRarity rarity = item.getRarity();
+        final Key tooltipStyle = getTooltipStyle(rarity);
+        itemStack.setData(DataComponentTypes.TOOLTIP_STYLE, tooltipStyle);
+    }
+
+    private Key getTooltipStyle(ItemRarity itemRarity) {
+        return switch (itemRarity) {
+            case COMMON -> Key.key("betterpvp", "rarity/common");
+            case UNCOMMON -> Key.key("betterpvp", "rarity/uncommon");
+            case RARE -> Key.key("betterpvp", "rarity/rare");
+            case EPIC -> Key.key("betterpvp", "rarity/epic");
+            case LEGENDARY -> Key.key("betterpvp", "rarity/legendary");
+            case MYTHICAL -> Key.key("betterpvp", "rarity/mythical");
+        };
+    }
+}


### PR DESCRIPTION
## Describe your changes

- Item tooltips now display with a custom frame styled to match the item's rarity.
- All rarities are covered: common, uncommon, rare, epic, legendary, mythical.
- Applies automatically to every item, with no per-item setup needed.
  - The matching tooltip frames are supplied by the resource pack.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.