### PR TITLE
Add item repair and salvage

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/item/BoosterPickaxe.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/item/BoosterPickaxe.java
@@ -11,6 +11,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
@@ -34,6 +35,7 @@ public class BoosterPickaxe extends BaseItem implements Reloadable {
     private BoosterPickaxe(Champions champions) {
         super("Booster Pickaxe", ItemStack.of(Material.GOLDEN_PICKAXE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/Anvil.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/Anvil.java
@@ -2,11 +2,11 @@ package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipeRegistry;
 import me.mykindos.betterpvp.core.block.SmartBlock;
 import me.mykindos.betterpvp.core.block.SmartBlockInstance;
 import me.mykindos.betterpvp.core.block.data.DataHolder;
 import me.mykindos.betterpvp.core.block.data.SmartBlockDataSerializer;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperationResolver;
 import me.mykindos.betterpvp.core.block.nexo.NexoBlock;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.item.ItemFactory;
@@ -29,16 +29,16 @@ public class Anvil extends SmartBlock implements NexoBlock, DataHolder<AnvilData
 
     private final ItemFactory itemFactory;
     private final ClientManager clientManager;
-    private final AnvilRecipeRegistry anvilRecipeRegistry;
+    private final AnvilOperationResolver operationResolver;
     private final AnvilDataSerializer dataSerializer;
 
     @Inject
-    private Anvil(ItemFactory itemFactory, AnvilRecipeRegistry anvilRecipeRegistry, ClientManager clientManager) {
+    private Anvil(ItemFactory itemFactory, AnvilOperationResolver operationResolver, ClientManager clientManager) {
         super("anvil", "Anvil");
         this.itemFactory = itemFactory;
         this.clientManager = clientManager;
-        this.anvilRecipeRegistry = anvilRecipeRegistry;
-        this.dataSerializer = new AnvilDataSerializer(itemFactory, anvilRecipeRegistry, clientManager);
+        this.operationResolver = operationResolver;
+        this.dataSerializer = new AnvilDataSerializer(itemFactory, operationResolver, clientManager);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class Anvil extends SmartBlock implements NexoBlock, DataHolder<AnvilData
 
     @Override
     public AnvilData createDefaultData() {
-        return new AnvilData(itemFactory, anvilRecipeRegistry, clientManager);
+        return new AnvilData(itemFactory, operationResolver, clientManager);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class Anvil extends SmartBlock implements NexoBlock, DataHolder<AnvilData
             return;
         }
 
-        if (data.getItemManager().getCurrentRecipe() == null) {
+        if (data.getItemManager().getCurrentOperation() == null) {
             new SoundEffect(Sound.BLOCK_ANVIL_BREAK, 0.5f, 0.5f).play(player);
             return;
         }

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilData.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilData.java
@@ -2,15 +2,17 @@ package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipeRegistry;
 import me.mykindos.betterpvp.core.block.SmartBlockInstance;
 import me.mykindos.betterpvp.core.block.data.BlockRemovalCause;
 import me.mykindos.betterpvp.core.block.data.LoadHandler;
 import me.mykindos.betterpvp.core.block.data.RemovalHandler;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperation;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperationResolver;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.client.stats.impl.ClientStat;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -20,14 +22,16 @@ import java.util.Map;
 
 /**
  * Main coordinator class for Anvil functionality.
- * Delegates responsibilities to specialized components.
+ * Delegates responsibilities to specialized components and is agnostic to whether the
+ * current job is crafting a recipe or repairing an item — that is decided by the
+ * resolved {@link AnvilOperation}.
  */
 @RequiredArgsConstructor
 @Getter
 public class AnvilData implements RemovalHandler, LoadHandler {
 
     private final ItemFactory itemFactory;
-    private final AnvilRecipeRegistry anvilRecipeRegistry;
+    private final AnvilOperationResolver operationResolver;
     private final ClientManager clientManager;
 
     // Component managers
@@ -37,20 +41,20 @@ public class AnvilData implements RemovalHandler, LoadHandler {
 
     // Constructor for dependency injection
     public AnvilData(@NotNull ItemFactory itemFactory,
-                     @NotNull AnvilRecipeRegistry anvilRecipeRegistry, ClientManager clientManager) {
+                     @NotNull AnvilOperationResolver operationResolver,
+                     ClientManager clientManager) {
         this.itemFactory = itemFactory;
-        this.anvilRecipeRegistry = anvilRecipeRegistry;
+        this.operationResolver = operationResolver;
         this.clientManager = clientManager;
 
         // Initialize component managers
-        this.itemManager = new AnvilItemManager(anvilRecipeRegistry);
-
+        this.itemManager = new AnvilItemManager(operationResolver);
         this.displayManager = new AnvilDisplayManager();
-        this.hammerExecutor = new AnvilHammerExecutor(itemFactory, clientManager);
+        this.hammerExecutor = new AnvilHammerExecutor();
     }
 
     /**
-     * Executes a hammer swing, incrementing the counter and checking for recipe completion.
+     * Executes a hammer swing, incrementing the counter and checking for operation completion.
      *
      * @param player   The player swinging the hammer
      * @param location The location to play effects at
@@ -64,10 +68,10 @@ public class AnvilData implements RemovalHandler, LoadHandler {
         updateHammerProgressDisplay();
         clientManager.incrementStat(player, ClientStat.ANVIL_SWING, 1L);
 
-        // Check if we have a current recipe and enough swings
-        if (itemManager.getCurrentRecipe() != null &&
-                hammerExecutor.hasEnoughSwings(itemManager.getCurrentRecipe())) {
-            executeRecipe(player, location);
+        // Check if we have a current operation and enough swings
+        final AnvilOperation operation = itemManager.getCurrentOperation();
+        if (operation != null && operation.isReady(hammerExecutor.getHammerSwings())) {
+            executeOperation(player, location);
         }
     }
 
@@ -115,49 +119,46 @@ public class AnvilData implements RemovalHandler, LoadHandler {
     }
 
     /**
-     * Executes the current recipe, consuming ingredients and producing results.
+     * Executes the current operation, consuming items and producing/repairing results.
      *
-     * @param player   The player who completed the recipe
+     * @param player   The player who completed the operation
      * @param location The location to play effects at
      */
-    private void executeRecipe(@NotNull Player player, @NotNull Location location) {
-        if (itemManager.getCurrentRecipe() == null) {
+    private void executeOperation(@NotNull Player player, @NotNull Location location) {
+        final AnvilOperation operation = itemManager.getCurrentOperation();
+        if (operation == null) {
             return;
         }
 
-        // Get items as map for recipe execution
+        // Get items as map for operation execution
         Map<Integer, ItemInstance> itemsMap = itemManager.getItemsAsMap();
 
-        // Execute recipe and get remaining items
-        List<ItemInstance> remainingItems = hammerExecutor.executeRecipe(
-                player, itemManager.getCurrentRecipe(), itemsMap, location
-        );
+        // Execute the operation and get remaining items
+        List<ItemInstance> remainingItems = operation.complete(player, itemsMap, location);
 
         // Update anvil items with remaining items
         itemManager.updateItemsAfterRecipe(remainingItems);
-        //todo stat with remaining items
 
         // Update display entities to match remaining items
         displayManager.updateDisplayEntitiesAfterRecipe(remainingItems);
+
+        // Reset hammer swings now the operation is done
+        hammerExecutor.reset();
 
         // Update progress display
         updateHammerProgressDisplay();
     }
 
     /**
-     * Updates the hammer progress display.
+     * Updates the hammer progress display, delegating the text content to the active operation.
      */
     private void updateHammerProgressDisplay() {
-        if (itemManager.getCurrentRecipe() != null) {
-            displayManager.updateHammerProgressDisplay(
-                    itemManager.hasRecipe(),
-                    itemManager.hasItems(),
-                    hammerExecutor.getHammerSwings(),
-                    itemManager.getCurrentRecipe().getRequiredHammerSwings()
-            );
-        } else {
-            displayManager.updateHammerProgressDisplay(false, itemManager.hasItems(), 0, 0);
+        final AnvilOperation operation = itemManager.getCurrentOperation();
+        if (operation == null || !itemManager.hasItems()) {
+            displayManager.updateHammerProgressDisplay(Component.empty());
+            return;
         }
+        displayManager.updateHammerProgressDisplay(operation.hologramText(hammerExecutor.getHammerSwings()));
     }
 
     /**
@@ -204,10 +205,11 @@ public class AnvilData implements RemovalHandler, LoadHandler {
     }
 
     public float getProgress() {
-        if (itemManager.getCurrentRecipe() == null) {
+        final AnvilOperation operation = itemManager.getCurrentOperation();
+        if (operation == null) {
             return 0.0f;
         }
-        return hammerExecutor.getProgress(itemManager.getCurrentRecipe());
+        return operation.progress(hammerExecutor.getHammerSwings());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilDataSerializer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilDataSerializer.java
@@ -1,8 +1,8 @@
 package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import lombok.CustomLog;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipeRegistry;
 import me.mykindos.betterpvp.core.block.data.SmartBlockDataSerializer;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperationResolver;
 import me.mykindos.betterpvp.core.block.data.impl.StorageBlockData;
 import me.mykindos.betterpvp.core.block.data.impl.StorageBlockDataSerializer;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
@@ -20,13 +20,13 @@ public class AnvilDataSerializer implements SmartBlockDataSerializer<AnvilData> 
 
     private final StorageBlockDataSerializer<StorageBlockData> storageSerializer;
     private final ItemFactory itemFactory;
-    private final AnvilRecipeRegistry anvilRecipeRegistry;
+    private final AnvilOperationResolver operationResolver;
     private final ClientManager clientManager;
 
-    public AnvilDataSerializer(ItemFactory itemFactory, AnvilRecipeRegistry anvilRecipeRegistry, ClientManager clientManager) {
+    public AnvilDataSerializer(ItemFactory itemFactory, AnvilOperationResolver operationResolver, ClientManager clientManager) {
         this.storageSerializer = new StorageBlockDataSerializer<>(StorageBlockData.class, itemFactory, StorageBlockData::new);
         this.itemFactory = itemFactory;
-        this.anvilRecipeRegistry = anvilRecipeRegistry;
+        this.operationResolver = operationResolver;
         this.clientManager = clientManager;
     }
 
@@ -68,7 +68,7 @@ public class AnvilDataSerializer implements SmartBlockDataSerializer<AnvilData> 
             int hammerSwings = dis.readInt();
 
             // Create AnvilData with the new component structure
-            AnvilData anvilData = new AnvilData(itemFactory, anvilRecipeRegistry, clientManager);
+            AnvilData anvilData = new AnvilData(itemFactory, operationResolver, clientManager);
             
             // Set the anvil items in the item manager
             anvilData.getItemManager().getAnvilItems().setContent(anvilItems.getContent());

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilDisplayManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilDisplayManager.java
@@ -2,9 +2,7 @@ package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import lombok.Getter;
 import me.mykindos.betterpvp.core.item.ItemInstance;
-import me.mykindos.betterpvp.core.utilities.model.ProgressColor;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.entity.Display;
@@ -221,28 +219,18 @@ public class AnvilDisplayManager {
 
     /**
      * Updates the hammer progress text display.
+     * <br>
+     * The text content (swing count, "Not Repairable", etc.) is owned by the active
+     * {@link me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperation};
+     * this manager only renders whatever component it is handed.
+     *
+     * @param text the component to show above the anvil ({@link Component#empty()} hides it)
      */
-    public void updateHammerProgressDisplay(boolean hasRecipe, boolean hasItems, int hammerSwings, int requiredSwings) {
+    public void updateHammerProgressDisplay(@NotNull Component text) {
         if (hammerProgressDisplay == null) {
             return;
         }
-
-        if (!hasRecipe || !hasItems) {
-            // Hide the display when no recipe or no items
-            hammerProgressDisplay.text(Component.empty());
-            return;
-        }
-
-        int remaining = requiredSwings - hammerSwings;
-
-        // Create progress text with color coding
-        Component progressText = Component.empty();
-        if (remaining > 0) {
-            // Show remaining swings
-            final TextColor color = ProgressColor.of((float) hammerSwings / requiredSwings).getTextColor();
-            progressText = Component.text(remaining, color);
-        }
-        hammerProgressDisplay.text(progressText);
+        hammerProgressDisplay.text(text);
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilHammerExecutor.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilHammerExecutor.java
@@ -2,42 +2,27 @@ package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import lombok.Getter;
 import lombok.Setter;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipe;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipeResult;
-import me.mykindos.betterpvp.core.client.repository.ClientManager;
-import me.mykindos.betterpvp.core.client.stats.impl.core.item.ItemStat;
-import me.mykindos.betterpvp.core.item.BaseItem;
-import me.mykindos.betterpvp.core.item.ItemFactory;
-import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import static me.mykindos.betterpvp.core.block.impl.anvil.AnvilConstants.SWING_COOLDOWN_MS;
 
 /**
- * Handles hammer swings, timing, and recipe execution for Anvil
+ * Tracks hammer-swing timing and the swing counter for an anvil.
+ * <br>
+ * This class is intentionally agnostic to <i>what</i> the swings accomplish — recipe
+ * crafting and item repair both completion logic lives in
+ * {@link me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperation}.
  */
 @Getter
 @Setter
 public class AnvilHammerExecutor {
 
-    private final ItemFactory itemFactory;
-    private final ClientManager clientManager;
     private int hammerSwings = 0;
     private long lastSwingTime = 0L; // System.currentTimeMillis()
-
-    public AnvilHammerExecutor(@NotNull ItemFactory itemFactory, ClientManager clientManager) {
-        this.itemFactory = itemFactory;
-        this.clientManager = clientManager;
-    }
 
     /**
      * Checks if a player can swing the hammer (cooldown check).
@@ -72,86 +57,9 @@ public class AnvilHammerExecutor {
     }
 
     /**
-     * Checks if enough swings have been completed for the given recipe.
-     *
-     * @param recipe The recipe to check
-     * @return true if enough swings have been completed
-     */
-    public boolean hasEnoughSwings(@NotNull AnvilRecipe recipe) {
-        return hammerSwings >= recipe.getRequiredHammerSwings();
-    }
-
-    /**
-     * Executes the recipe, consuming ingredients and producing results.
-     *
-     * @param player  The player executing the recipe
-     * @param recipe   The recipe to execute
-     * @param itemsMap The items currently on the anvil
-     * @param location The location to drop results at
-     * @return The items remaining after recipe execution
-     */
-    public List<ItemInstance> executeRecipe(@NotNull Player player,
-                                            @NotNull AnvilRecipe recipe,
-                                            @NotNull Map<Integer, ItemInstance> itemsMap,
-                                            @NotNull Location location) {
-
-        // Consume ingredients
-        recipe.consumeIngredients(itemsMap, itemFactory);
-
-        // Get remaining items after consumption
-        List<ItemInstance> remainingItems = itemsMap.values().stream()
-                .filter(Objects::nonNull)
-                .toList();
-
-        // Get the live recipe result
-        AnvilRecipeResult result = recipe.createResult();
-
-        //todo stats for this
-
-        // Drop the primary result
-        ItemStack primaryResult = result.getPrimaryResult().createItemStack();
-        location.getWorld().dropItemNaturally(location, primaryResult);
-
-        final ItemStat primaryStat = ItemStat.builder()
-                .itemStack(primaryResult)
-                .action(ItemStat.Action.ANVIL_PRIMARY)
-                .build();
-        clientManager.incrementStat(player, primaryStat, 1L);
-
-        // Drop secondary results
-        for (BaseItem secondaryResult : result.getSecondaryResults()) {
-            ItemStack secondaryStack = itemFactory.create(secondaryResult).createItemStack();
-            location.getWorld().dropItemNaturally(location, secondaryStack);
-            final ItemStat secondaryStat = ItemStat.builder()
-                    .itemStack(secondaryStack)
-                    .action(ItemStat.Action.ANVIL_SECONDARY)
-                    .build();
-            clientManager.incrementStat(player, secondaryStat, 1L);
-        }
-
-        // Play completion effects
-        new SoundEffect(Sound.BLOCK_ANVIL_LAND, 1.0f, 1.2f).play(location);
-
-        // Reset hammer swings
-        reset();
-
-        return remainingItems;
-    }
-
-    /**
      * Resets the hammer swing counter.
      */
     public void reset() {
         hammerSwings = 0;
     }
-
-    /**
-     * Gets the progress percentage for the given recipe.
-     *
-     * @param recipe The recipe to calculate progress for
-     * @return Progress as a float between 0.0 and 1.0, or 0.0 if no recipe
-     */
-    public float getProgress(@NotNull AnvilRecipe recipe) {
-        return Math.min(1.0f, (float) hammerSwings / recipe.getRequiredHammerSwings());
-    }
-} 
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilItemManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/AnvilItemManager.java
@@ -1,14 +1,16 @@
 package me.mykindos.betterpvp.core.block.impl.anvil;
 
 import lombok.Getter;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipe;
-import me.mykindos.betterpvp.core.anvil.AnvilRecipeRegistry;
 import me.mykindos.betterpvp.core.block.SmartBlockInstance;
 import me.mykindos.betterpvp.core.block.data.BlockRemovalCause;
 import me.mykindos.betterpvp.core.block.data.RemovalHandler;
 import me.mykindos.betterpvp.core.block.data.LoadHandler;
 import me.mykindos.betterpvp.core.block.data.impl.StorageBlockData;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperation;
+import me.mykindos.betterpvp.core.block.impl.anvil.operation.AnvilOperationResolver;
 import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -21,17 +23,18 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Manages item storage and recipe matching for Anvil
+ * Manages item storage and resolves the active {@link AnvilOperation} (crafting or
+ * repair) for an anvil.
  */
 @Getter
 public class AnvilItemManager implements RemovalHandler, LoadHandler {
 
-    private final AnvilRecipeRegistry anvilRecipeRegistry;
+    private final AnvilOperationResolver operationResolver;
     private final StorageBlockData anvilItems;
-    private AnvilRecipe currentRecipe = null;
+    private AnvilOperation currentOperation = null;
 
-    public AnvilItemManager(@NotNull AnvilRecipeRegistry anvilRecipeRegistry) {
-        this.anvilRecipeRegistry = anvilRecipeRegistry;
+    public AnvilItemManager(@NotNull AnvilOperationResolver operationResolver) {
+        this.operationResolver = operationResolver;
         this.anvilItems = new StorageBlockData(AnvilConstants.MAX_ANVIL_ITEMS);
     }
 
@@ -49,7 +52,7 @@ public class AnvilItemManager implements RemovalHandler, LoadHandler {
 
         currentItems.add(item);
         anvilItems.setContent(currentItems);
-        checkForRecipe();
+        resolveOperation();
         return true;
     }
 
@@ -68,49 +71,49 @@ public class AnvilItemManager implements RemovalHandler, LoadHandler {
         ItemInstance removedItem = currentItems.removeLast();
         if (removedItem != null) {
             anvilItems.setContent(currentItems);
-            checkForRecipe();
+            resolveOperation();
             return removedItem;
         }
         return null;
     }
 
     /**
-     * Updates the items after recipe execution, keeping remaining items.
+     * Updates the items after operation completion, keeping remaining items.
      *
-     * @param newItems The items remaining after recipe execution
+     * @param newItems The items remaining after the operation
      */
     public void updateItemsAfterRecipe(@NotNull List<ItemInstance> newItems) {
         anvilItems.setContent(newItems);
-        checkForRecipe();
+        resolveOperation();
     }
 
     /**
-     * Checks for a matching recipe with current items.
+     * Re-resolves the active operation against the current items.
      */
-    private void checkForRecipe() {
-        currentRecipe = null;
+    private void resolveOperation() {
+        currentOperation = null;
 
-        if (anvilItems.getContent().isEmpty()) {
+        List<ItemInstance> items = anvilItems.getContent();
+        if (items.isEmpty()) {
             return;
         }
 
-        // Convert items to the format expected by recipe matching
-        Map<Integer, ItemStack> itemMap = new HashMap<>();
-        List<ItemInstance> items = anvilItems.getContent();
+        Map<Integer, ItemStack> stackMap = new HashMap<>();
+        Map<Integer, ItemInstance> instanceMap = new HashMap<>();
         for (int i = 0; i < items.size(); i++) {
             ItemInstance item = items.get(i);
             if (item != null) {
-                itemMap.put(i, item.createItemStack());
+                stackMap.put(i, item.createItemStack());
+                instanceMap.put(i, item);
             }
         }
 
-        // Find a matching recipe through the registry
-        Optional<AnvilRecipe> recipeOpt = anvilRecipeRegistry.findRecipe(itemMap);
-        recipeOpt.ifPresent(recipe -> currentRecipe = recipe);
+        operationResolver.resolve(stackMap, instanceMap)
+                .ifPresent(operation -> currentOperation = operation);
     }
 
     /**
-     * Gets the items as a map for recipe execution.
+     * Gets the items as a map for operation execution.
      */
     public Map<Integer, ItemInstance> getItemsAsMap() {
         Map<Integer, ItemInstance> itemInstanceMap = new HashMap<>();
@@ -137,8 +140,8 @@ public class AnvilItemManager implements RemovalHandler, LoadHandler {
         return getItemCount() > 0;
     }
 
-    public boolean hasRecipe() {
-        return currentRecipe != null;
+    public boolean hasOperation() {
+        return currentOperation != null;
     }
 
     public List<ItemInstance> getItems() {
@@ -156,4 +159,4 @@ public class AnvilItemManager implements RemovalHandler, LoadHandler {
             loadHandler.onUnload(instance);
         }
     }
-} 
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/AnvilOperation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/AnvilOperation.java
@@ -1,0 +1,64 @@
+package me.mykindos.betterpvp.core.block.impl.anvil.operation;
+
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategy describing what an anvil does when its hammer-swing progress completes.
+ * <br>
+ * The anvil mechanics (swing timing, displays, persistence) are agnostic to whether
+ * the current job is crafting a recipe or repairing an item — they only ever talk to
+ * this interface. Each concrete operation owns its own progress text and completion
+ * side effects.
+ *
+ * @see CraftOperation
+ * @see RepairOperation
+ */
+public interface AnvilOperation {
+
+    /**
+     * @return the number of hammer swings required to complete this operation.
+     */
+    int requiredSwings();
+
+    /**
+     * @return whether enough swings have been performed to complete this operation.
+     */
+    default boolean isReady(int currentSwings) {
+        return currentSwings >= requiredSwings();
+    }
+
+    /**
+     * @return progress towards completion as a value in {@code [0.0, 1.0]}.
+     */
+    default float progress(int currentSwings) {
+        final int required = requiredSwings();
+        return required <= 0 ? 0.0f : Math.min(1.0f, (float) currentSwings / required);
+    }
+
+    /**
+     * The text shown on the hologram above the anvil for the given swing count.
+     *
+     * @return the component to render (may be {@link Component#empty()} to show nothing).
+     */
+    @NotNull Component hologramText(int currentSwings);
+
+    /**
+     * Performs the operation's side effects (consuming items, producing/repairing,
+     * dropping results) and returns the items that should remain on the anvil.
+     *
+     * @param player   the player who completed the operation
+     * @param items    slot → item instance currently on the anvil
+     * @param location the anvil location (drop point for any results)
+     * @return the items remaining on the anvil after completion
+     */
+    @NotNull List<ItemInstance> complete(@NotNull Player player,
+                                         @NotNull Map<Integer, ItemInstance> items,
+                                         @NotNull Location location);
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/AnvilOperationResolver.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/AnvilOperationResolver.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.block.impl.anvil.operation;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.anvil.AnvilRecipe;
+import me.mykindos.betterpvp.core.anvil.AnvilRecipeRegistry;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.repair.RepairService;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Decides which {@link AnvilOperation}, if any, applies to the current anvil contents.
+ * Crafting recipes take precedence; if no recipe matches, a repair is attempted.
+ */
+@Singleton
+public class AnvilOperationResolver {
+
+    private final AnvilRecipeRegistry anvilRecipeRegistry;
+    private final ItemFactory itemFactory;
+    private final ClientManager clientManager;
+    private final RepairService repairService;
+
+    @Inject
+    private AnvilOperationResolver(AnvilRecipeRegistry anvilRecipeRegistry,
+                                   ItemFactory itemFactory,
+                                   ClientManager clientManager,
+                                   RepairService repairService) {
+        this.anvilRecipeRegistry = anvilRecipeRegistry;
+        this.itemFactory = itemFactory;
+        this.clientManager = clientManager;
+        this.repairService = repairService;
+    }
+
+    /**
+     * @param stackItems    slot → item stack (for recipe matching)
+     * @param instanceItems slot → item instance (for repair resolution)
+     * @return the operation the anvil should perform, or empty if none applies.
+     */
+    public @NotNull Optional<AnvilOperation> resolve(@NotNull Map<Integer, ItemStack> stackItems,
+                                                     @NotNull Map<Integer, ItemInstance> instanceItems) {
+        final Optional<AnvilRecipe> recipe = anvilRecipeRegistry.findRecipe(stackItems);
+        if (recipe.isPresent()) {
+            return Optional.of(new CraftOperation(recipe.get(), itemFactory, clientManager));
+        }
+
+        return repairService.resolve(instanceItems)
+                .map(plan -> new RepairOperation(plan, itemFactory));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/CraftOperation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/CraftOperation.java
@@ -1,0 +1,94 @@
+package me.mykindos.betterpvp.core.block.impl.anvil.operation;
+
+import lombok.RequiredArgsConstructor;
+import me.mykindos.betterpvp.core.anvil.AnvilRecipe;
+import me.mykindos.betterpvp.core.anvil.AnvilRecipeResult;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.client.stats.impl.core.item.ItemStat;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.utilities.model.ProgressColor;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Anvil operation that crafts an {@link AnvilRecipe}: consumes the recipe ingredients
+ * and drops the primary and secondary results. This is the original anvil behaviour,
+ * extracted behind {@link AnvilOperation}.
+ */
+@RequiredArgsConstructor
+public class CraftOperation implements AnvilOperation {
+
+    private final AnvilRecipe recipe;
+    private final ItemFactory itemFactory;
+    private final ClientManager clientManager;
+
+    @Override
+    public int requiredSwings() {
+        return recipe.getRequiredHammerSwings();
+    }
+
+    @Override
+    public @NotNull Component hologramText(int currentSwings) {
+        final int required = requiredSwings();
+        final int remaining = required - currentSwings;
+        if (remaining <= 0) {
+            return Component.empty();
+        }
+        final TextColor color = ProgressColor.of((float) currentSwings / required).getTextColor();
+        return Component.text(remaining, color);
+    }
+
+    @Override
+    public @NotNull List<ItemInstance> complete(@NotNull Player player,
+                                                @NotNull Map<Integer, ItemInstance> items,
+                                                @NotNull Location location) {
+        // Consume ingredients
+        recipe.consumeIngredients(items, itemFactory);
+
+        // Get remaining items after consumption
+        final List<ItemInstance> remainingItems = items.values().stream()
+                .filter(Objects::nonNull)
+                .toList();
+
+        // Get the live recipe result
+        final AnvilRecipeResult result = recipe.createResult();
+
+        // Drop the primary result
+        final ItemStack primaryResult = result.getPrimaryResult().createItemStack();
+        location.getWorld().dropItemNaturally(location, primaryResult);
+
+        final ItemStat primaryStat = ItemStat.builder()
+                .itemStack(primaryResult)
+                .action(ItemStat.Action.ANVIL_PRIMARY)
+                .build();
+        clientManager.incrementStat(player, primaryStat, 1L);
+
+        // Drop secondary results
+        for (BaseItem secondaryResult : result.getSecondaryResults()) {
+            final ItemStack secondaryStack = itemFactory.create(secondaryResult).createItemStack();
+            location.getWorld().dropItemNaturally(location, secondaryStack);
+            final ItemStat secondaryStat = ItemStat.builder()
+                    .itemStack(secondaryStack)
+                    .action(ItemStat.Action.ANVIL_SECONDARY)
+                    .build();
+            clientManager.incrementStat(player, secondaryStat, 1L);
+        }
+
+        // Play completion effects
+        new SoundEffect(Sound.BLOCK_ANVIL_LAND, 1.0f, 1.2f).play(location);
+
+        return remainingItems;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/RepairOperation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/block/impl/anvil/operation/RepairOperation.java
@@ -1,0 +1,164 @@
+package me.mykindos.betterpvp.core.block.impl.anvil.operation;
+
+import lombok.RequiredArgsConstructor;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
+import me.mykindos.betterpvp.core.repair.RepairPlan;
+import me.mykindos.betterpvp.core.utilities.model.ProgressColor;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Anvil operation that repairs a damaged item in place: restores durability on the
+ * target item, consumes the planned number of tier-matching Reinforcement units, and
+ * leaves the repaired item on the anvil.
+ * <br>
+ * Roles are resolved by item identity and type, never by slot — placement order on
+ * the anvil is irrelevant. Unlike {@link CraftOperation} this produces no new item;
+ * it mutates an input, which is exactly why repair is an {@link AnvilOperation} and
+ * not a {@code Recipe}.
+ */
+@RequiredArgsConstructor
+public class RepairOperation implements AnvilOperation {
+
+    private final RepairPlan plan;
+    private final ItemFactory itemFactory;
+
+    @Override
+    public int requiredSwings() {
+        return plan.getRequiredSwings();
+    }
+
+    @Override
+    public @NotNull Component hologramText(int currentSwings) {
+        return switch (plan.getStatus()) {
+            // Exhausted item: red headline + the would-be cost so the player still knows
+            // which catalyst the repair would have demanded.
+            case EXHAUSTED -> Component.text("Not Repairable", NamedTextColor.RED)
+                    .append(Component.newline())
+                    .append(reinforcementCostLine());
+
+            // Player is missing catalyst — surface only the cost so they know what to add.
+            // No swing counter: swings are no-ops in this state.
+            case INSUFFICIENT_CATALYST -> reinforcementCostLine();
+
+            case READY -> {
+                final int required = requiredSwings();
+                final int remaining = required - currentSwings;
+                if (remaining <= 0) {
+                    yield Component.empty();
+                }
+                final TextColor color = ProgressColor.of((float) currentSwings / required).getTextColor();
+                final TextColor textColor = TextColor.color(
+                        (int) (color.red() + (255 - color.red()) *  0.3f),
+                        (int) (color.green() + (255 - color.green()) * 0.3f),
+                        (int) (color.blue() + (255 - color.blue()) * 0.3f)
+                );
+                yield reinforcementCostLine()
+                        .append(Component.newline())
+                        .append(Component.text(remaining + "x ", color).append(Component.text("Hammer Swings", textColor)));
+            }
+        };
+    }
+
+    /**
+     * Renders the reinforcement-cost line shown above the swing counter.
+     * Format: "<count>x <Tier> Reinforcement[s]" — count in white, tier+noun in the
+     * tier's rarity color so players can spot the required catalyst at a glance.
+     */
+    private @NotNull Component reinforcementCostLine() {
+        final int count = plan.getRequiredReinforcements();
+        // catalystTier is null on the non-repairable plan; fall back to the item's
+        // rarity since that is the tier the repair would have demanded.
+        final ItemRarity tier = plan.getCatalystTier() != null
+                ? plan.getCatalystTier()
+                : plan.getItem().getRarity();
+        final String noun = count == 1 ? "Reinforcement" : "Reinforcements";
+        return Component.text(count + "x ", NamedTextColor.YELLOW)
+                .append(Component.text(tier.getName() + " " + noun, tier.getColor()));
+    }
+
+    @Override
+    public @NotNull List<ItemInstance> complete(@NotNull Player player,
+                                                @NotNull Map<Integer, ItemInstance> items,
+                                                @NotNull Location location) {
+        // Exhausted items cannot be repaired; the swing does nothing but signal failure.
+        if (!plan.isCanRepair()) {
+            new SoundEffect(Sound.BLOCK_ANVIL_BREAK, 0.5f, 0.5f).play(location);
+            return new ArrayList<>(items.values());
+        }
+
+        // The service decided per-stack consumption up front (see RepairService#resolve).
+        // Anything not in this map — or with leftover units after a partial consumption —
+        // goes back on the anvil instead of being silently destroyed.
+        final Map<ItemInstance, Integer> toConsume = new HashMap<>();
+        for (RepairPlan.ReinforcementConsumption consumption : plan.getConsumptions()) {
+            toConsume.put(consumption.getInstance(), consumption.getUnitsConsumed());
+        }
+
+        final List<ItemInstance> remaining = new ArrayList<>();
+        for (ItemInstance instance : items.values()) {
+            if (instance == null) {
+                continue;
+            }
+
+            if (instance == plan.getItem()) {
+                applyRepair(instance);
+                remaining.add(instance);
+                continue;
+            }
+
+            final Integer units = toConsume.get(instance);
+            if (units == null || units <= 0) {
+                // Not part of the planned consumption — leave it untouched.
+                remaining.add(instance);
+            } else {
+                consume(instance, units).ifPresent(remaining::add);
+            }
+        }
+
+        new SoundEffect(Sound.BLOCK_ANVIL_LAND, 1.0f, 1.2f).play(location);
+        new SoundEffect(Sound.BLOCK_ANVIL_USE, 0.8f, 1.2f).play(location);
+        return remaining;
+    }
+
+    private void applyRepair(@NotNull ItemInstance target) {
+        final DurabilityComponent durability = target.getComponent(DurabilityComponent.class).orElse(null);
+        final RepairableComponent repairable = target.getComponent(RepairableComponent.class).orElse(null);
+        if (durability == null || repairable == null) {
+            return;
+        }
+
+        final int newDamage = Math.max(0, durability.getDamage() - plan.getRestoreAmount());
+        final int actuallyRestored = durability.getDamage() - newDamage;
+        durability.setDamage(newDamage);
+        repairable.addRestored(actuallyRestored);
+        target.serializeAllComponentsToItemStack();
+    }
+
+    private Optional<ItemInstance> consume(@NotNull ItemInstance source, int units) {
+        final ItemStack stack = source.createItemStack();
+        final int remaining = stack.getAmount() - units;
+        if (remaining <= 0) {
+            return Optional.empty();
+        }
+        stack.setAmount(remaining);
+        return itemFactory.fromItemStack(stack);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/CoreCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/CoreCommand.java
@@ -10,6 +10,9 @@ import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.IConsoleCommand;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.command.loader.CoreCommandLoader;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
 import me.mykindos.betterpvp.core.listener.loader.CoreListenerLoader;
 import me.mykindos.betterpvp.core.resourcepack.ResourcePackHandler;
 import me.mykindos.betterpvp.core.tips.TipManager;
@@ -19,14 +22,14 @@ import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.CraftingRecipe;
-import org.bukkit.inventory.Recipe;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Optional;
 
 @Singleton
 public class CoreCommand extends Command implements IConsoleCommand {
@@ -43,28 +46,13 @@ public class CoreCommand extends Command implements IConsoleCommand {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        final File serverFolder = Bukkit.getServer().getPluginsFolder().getParentFile();
-        final File recipes = new File(serverFolder, "recipes.txt");
-
-        try {
-            recipes.createNewFile();
-
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(recipes, false))) {
-                final Iterator<Recipe> recipeIterator = Bukkit.recipeIterator();
-
-                while (recipeIterator.hasNext()) {
-                    final Recipe recipe = recipeIterator.next();
-
-                    if (recipe instanceof CraftingRecipe craftingRecipe) {
-                        final NamespacedKey key = craftingRecipe.getKey();
-
-                        writer.write(key.toString());
-                        writer.newLine();
-                    }
-                }
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
+        final ItemFactory factory = JavaPlugin.getPlugin(Core.class).getInjector().getInstance(ItemFactory.class);
+        final ItemInstance itemInstance = factory.fromItemStack(player.getItemInHand()).orElseThrow();
+        final Optional<DurabilityComponent> component = itemInstance.getComponent(DurabilityComponent.class);
+        if (component.isPresent()) {
+            final DurabilityComponent durability = component.get();
+            durability.setDamage(durability.getMaxDamage() / 2);
+            itemInstance.serializeAllComponentsToItemStack();
         }
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/CoreCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/CoreCommand.java
@@ -10,26 +10,13 @@ import me.mykindos.betterpvp.core.command.Command;
 import me.mykindos.betterpvp.core.command.IConsoleCommand;
 import me.mykindos.betterpvp.core.command.SubCommand;
 import me.mykindos.betterpvp.core.command.loader.CoreCommandLoader;
-import me.mykindos.betterpvp.core.item.ItemFactory;
-import me.mykindos.betterpvp.core.item.ItemInstance;
-import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
 import me.mykindos.betterpvp.core.listener.loader.CoreListenerLoader;
 import me.mykindos.betterpvp.core.resourcepack.ResourcePackHandler;
 import me.mykindos.betterpvp.core.tips.TipManager;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
-import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
-
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Optional;
 
 @Singleton
 public class CoreCommand extends Command implements IConsoleCommand {
@@ -46,14 +33,6 @@ public class CoreCommand extends Command implements IConsoleCommand {
 
     @Override
     public void execute(Player player, Client client, String... args) {
-        final ItemFactory factory = JavaPlugin.getPlugin(Core.class).getInjector().getInstance(ItemFactory.class);
-        final ItemInstance itemInstance = factory.fromItemStack(player.getItemInHand()).orElseThrow();
-        final Optional<DurabilityComponent> component = itemInstance.getComponent(DurabilityComponent.class);
-        if (component.isPresent()) {
-            final DurabilityComponent durability = component.get();
-            durability.setDamage(durability.getMaxDamage() / 2);
-            itemInstance.serializeAllComponentsToItemStack();
-        }
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/purity/ItemPurity.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/purity/ItemPurity.java
@@ -74,6 +74,14 @@ public enum ItemPurity {
     }
 
     /**
+     * Returns true if this purity is at or above {@code other} in the ordered scale
+     * ({@link #PITIFUL} → {@link #PERFECT}). Mirrors {@code ItemRarity.isAtLeast}.
+     */
+    public boolean isAtLeast(@NotNull ItemPurity other) {
+        return this.ordinal() >= other.ordinal();
+    }
+
+    /**
      * Gets the name color override for this purity level.
      * Returns null if no override should be applied (use rarity color).
      * Currently only PERFECT purity overrides the name color.

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/ReinforcementComponent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/ReinforcementComponent.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.item.component.impl.repair;
+
+import lombok.Getter;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.AbstractItemComponent;
+import me.mykindos.betterpvp.core.item.component.LoreComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+import java.util.List;
+
+/**
+ * Marks an item as a "Reinforcement" — the consumable that authorises repairing gear
+ * of a given {@link ItemRarity} tier on the anvil.
+ * <br>
+ * This is a non-persistent definition component (added via {@code addBaseComponent}),
+ * not per-instance state. Because {@code ItemInstance} copies every base component onto
+ * each instance, the tier is discoverable at runtime via
+ * {@code instance.getComponent(ReinforcementComponent.class)} — no separate registry or
+ * registration step is required.
+ */
+@Getter
+public class ReinforcementComponent extends AbstractItemComponent implements LoreComponent {
+
+    private final ItemRarity tier;
+
+    public ReinforcementComponent(ItemRarity tier) {
+        super("reinforcement");
+        this.tier = tier;
+    }
+
+    @Override
+    public ReinforcementComponent copy() {
+        return new ReinforcementComponent(tier);
+    }
+
+    @Override
+    public List<Component> getLines(ItemInstance item) {
+        return List.of(
+                Component.text("Repairs ", NamedTextColor.GRAY)
+                        .append(Component.text(tier.getName(), tier.getColor()))
+                        .append(Component.text(" gear in an", NamedTextColor.GRAY))
+                        .append(Component.text(" Anvil", NamedTextColor.WHITE))
+                        .append(Component.text(".", NamedTextColor.GRAY))
+                        .decoration(TextDecoration.ITALIC, false)
+        );
+    }
+
+    @Override
+    public int getRenderPriority() {
+        return 0;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/RepairableComponent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/RepairableComponent.java
@@ -1,0 +1,73 @@
+package me.mykindos.betterpvp.core.item.component.impl.repair;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.Setter;
+import me.mykindos.betterpvp.core.item.component.AbstractItemComponent;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import org.bukkit.Bukkit;
+
+/**
+ * Marks an item as repairable on the anvil and tracks how much durability has been
+ * restored over the item's entire lifetime.
+ * <br>
+ * An item can be repaired until the cumulative restored durability reaches
+ * {@code lifetimeMultiplier * maxDamage} (default 3x its initial durability). Once
+ * that budget is exhausted the item can never be repaired again.
+ * <br>
+ * Only {@link #restoredLifetime} is persisted; the cap is derived live from the
+ * {@link DurabilityComponent}'s {@code maxDamage}, mirroring how durability already
+ * treats the {@code BaseItem} value as authoritative.
+ */
+@Getter
+@Setter
+public class RepairableComponent extends AbstractItemComponent {
+
+    /** Cumulative durability restored across every repair this item has received. */
+    private int restoredLifetime;
+
+    public RepairableComponent() {
+        super("repairable");
+    }
+
+    /**
+     * Records durability restored by a repair.
+     *
+     * @param amount the durability points restored (non-negative)
+     */
+    public void addRestored(int amount) {
+        Preconditions.checkArgument(amount >= 0, "Restored amount must be non-negative");
+        this.restoredLifetime += amount;
+    }
+
+    /**
+     * The total durability this item is allowed to have restored over its lifetime.
+     *
+     * @param maxDamage          the item's current max durability
+     * @param lifetimeMultiplier how many times {@code maxDamage} may be restored in total
+     */
+    public int lifetimeCap(int maxDamage, int lifetimeMultiplier) {
+        return maxDamage * lifetimeMultiplier;
+    }
+
+    /**
+     * The durability budget still available for future repairs.
+     */
+    public int remainingBudget(int maxDamage, int lifetimeMultiplier) {
+        return Math.max(0, lifetimeCap(maxDamage, lifetimeMultiplier) - restoredLifetime);
+    }
+
+    /**
+     * Whether this item still has lifetime budget left to be repaired.
+     */
+    public boolean isRepairable(int maxDamage, int lifetimeMultiplier) {
+        return remainingBudget(maxDamage, lifetimeMultiplier) > 0;
+    }
+
+    @Override
+    public RepairableComponent copy() {
+        final RepairableComponent component = new RepairableComponent();
+        component.setRestoredLifetime(restoredLifetime);
+        return component;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/RepairableComponentSerializer.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/repair/RepairableComponentSerializer.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.item.component.impl.repair;
+
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.component.serialization.ComponentDeserializer;
+import me.mykindos.betterpvp.core.item.component.serialization.ComponentSerializer;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+public class RepairableComponentSerializer implements ComponentSerializer<RepairableComponent>, ComponentDeserializer<RepairableComponent> {
+
+    private static final NamespacedKey KEY = new NamespacedKey("betterpvp", "repairable");
+    private static final NamespacedKey RESTORED_LIFETIME = new NamespacedKey("betterpvp", "restored-lifetime");
+
+    @Override
+    public @NotNull NamespacedKey getKey() {
+        return KEY;
+    }
+
+    @Override
+    public @NotNull Class<RepairableComponent> getType() {
+        return RepairableComponent.class;
+    }
+
+    @Override
+    public void serialize(RepairableComponent instance, @NotNull PersistentDataContainer container) {
+        PersistentDataContainer repairableContainer = container.get(KEY, PersistentDataType.TAG_CONTAINER);
+        if (repairableContainer == null) {
+            repairableContainer = container.getAdapterContext().newPersistentDataContainer();
+        }
+
+        repairableContainer.set(RESTORED_LIFETIME, PersistentDataType.INTEGER, instance.getRestoredLifetime());
+        container.set(KEY, PersistentDataType.TAG_CONTAINER, repairableContainer);
+    }
+
+    @Override
+    public RepairableComponent deserialize(@NotNull ItemInstance item, @NotNull PersistentDataContainer container) {
+        PersistentDataContainer repairableContainer = container.get(KEY, PersistentDataType.TAG_CONTAINER);
+        if (repairableContainer == null) {
+            throw new IllegalArgumentException("Repairable component not found in item");
+        }
+
+        final int restoredLifetime = repairableContainer.getOrDefault(RESTORED_LIFETIME, PersistentDataType.INTEGER, 0);
+
+        final RepairableComponent component = new RepairableComponent();
+        component.setRestoredLifetime(restoredLifetime);
+        return component;
+    }
+
+    @Override
+    public void delete(RepairableComponent instance, @NotNull PersistentDataContainer container) {
+        container.remove(KEY);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/serialization/ComponentSerializationRegistry.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/serialization/ComponentSerializationRegistry.java
@@ -6,6 +6,7 @@ import me.mykindos.betterpvp.core.item.component.ItemComponent;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponentSerializer;
 import me.mykindos.betterpvp.core.item.component.impl.fuel.FuelComponentSerializer;
 import me.mykindos.betterpvp.core.item.component.impl.purity.PurityComponentSerializer;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponentSerializer;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneRegistry;
 import me.mykindos.betterpvp.core.item.component.impl.runes.serialization.RuneContainerSerializer;
 import me.mykindos.betterpvp.core.item.component.impl.stat.serialization.StatSerializationRegistry;
@@ -46,6 +47,7 @@ public class ComponentSerializationRegistry {
         register(new FuelComponentSerializer());
         register(new DurabilityComponentSerializer());
         register(new PurityComponentSerializer());
+        register(new RepairableComponentSerializer());
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AnchorStone.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AnchorStone.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Legendary-tier items on the anvil.
+ */
+@Singleton
+@ItemKey("core:anchor_stone")
+public class AnchorStone extends BaseItem {
+
+    @Inject
+    private AnchorStone() {
+        super("Anchor Stone", Item.model("anchor_stone", 64), ItemGroup.MATERIAL, ItemRarity.LEGENDARY);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.LEGENDARY));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class AncientAxe extends BaseItem implements Reloadable {
     public AncientAxe() {
         super("Ancient Axe", ItemStack.of(Material.NETHERITE_AXE), ItemGroup.TOOL, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class AncientHoe extends BaseItem implements Reloadable {
     public AncientHoe() {
         super("Ancient Hoe", ItemStack.of(Material.NETHERITE_HOE), ItemGroup.TOOL, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientPickaxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientPickaxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class AncientPickaxe extends BaseItem implements Reloadable {
     public AncientPickaxe() {
         super("Ancient Pickaxe", ItemStack.of(Material.NETHERITE_PICKAXE), ItemGroup.TOOL, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class AncientShovel extends BaseItem implements Reloadable {
     public AncientShovel() {
         super("Ancient Shovel", ItemStack.of(Material.NETHERITE_SHOVEL), ItemGroup.TOOL, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AncientSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class AncientSword extends BaseItem implements Reloadable {
     public AncientSword() {
         super("Ancient Sword", ItemStack.of(Material.NETHERITE_SWORD), ItemGroup.WEAPON, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class BoosterAxe extends BaseItem implements Reloadable {
     public BoosterAxe() {
         super("Booster Axe", ItemStack.of(Material.GOLDEN_AXE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class BoosterHoe extends BaseItem implements Reloadable {
     public BoosterHoe() {
         super("Booster Hoe", ItemStack.of(Material.GOLDEN_HOE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class BoosterShovel extends BaseItem implements Reloadable {
     public BoosterShovel() {
         super("Booster Shovel", ItemStack.of(Material.GOLDEN_SHOVEL), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BoosterSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class BoosterSword extends BaseItem implements Reloadable {
     public BoosterSword() {
         super("Booster Sword", ItemStack.of(Material.GOLDEN_SWORD), ItemGroup.WEAPON, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Bow.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Bow.java
@@ -6,6 +6,7 @@ import me.mykindos.betterpvp.core.item.FallbackItem;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.item.model.VanillaItem;
@@ -24,6 +25,7 @@ public class Bow extends VanillaItem implements Reloadable {
         super("Bow", ItemStack.of(Material.BOW), ItemRarity.COMMON);
         addSerializableComponent(new RuneContainerComponent(0, 0));
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BronzePlate.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BronzePlate.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Uncommon-tier items on the anvil.
+ */
+@Singleton
+@ItemKey("core:bronze_plate")
+public class BronzePlate extends BaseItem {
+
+    @Inject
+    private BronzePlate() {
+        super("Bronze Plate", Item.model("bronze_plate", 64), ItemGroup.MATERIAL, ItemRarity.UNCOMMON);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.UNCOMMON));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class CrudeAxe extends BaseItem implements Reloadable {
     public CrudeAxe() {
         super("Crude Axe", ItemStack.of(Material.STONE_AXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class CrudeHoe extends BaseItem implements Reloadable {
     public CrudeHoe() {
         super("Crude Hoe", ItemStack.of(Material.STONE_HOE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudePickaxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudePickaxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class CrudePickaxe extends BaseItem implements Reloadable {
     public CrudePickaxe() {
         super("Crude Pickaxe", ItemStack.of(Material.STONE_PICKAXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class CrudeShovel extends BaseItem implements Reloadable {
     public CrudeShovel() {
         super("Crude Shovel", ItemStack.of(Material.STONE_SHOVEL), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/CrudeSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class CrudeSword extends BaseItem implements Reloadable {
     public CrudeSword() {
         super("Crude Sword", ItemStack.of(Material.STONE_SWORD), ItemGroup.WEAPON, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/FishingRod.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/FishingRod.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.core.item.FallbackItem;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.item.model.VanillaItem;
@@ -25,6 +26,7 @@ public class FishingRod extends VanillaItem implements Reloadable {
         super(Material.FISHING_ROD, ItemRarity.COMMON);
         addSerializableComponent(new RuneContainerComponent(0, 0));
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/ForgeSpike.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/ForgeSpike.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Epic-tier items on the anvil.
+ */
+@Singleton
+@ItemKey("core:forge_spike")
+public class ForgeSpike extends BaseItem {
+
+    @Inject
+    private ForgeSpike() {
+        super("Forge Spike", Item.model("forge_spike", 64), ItemGroup.MATERIAL, ItemRarity.EPIC);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.EPIC));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Ichor.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Ichor.java
@@ -1,0 +1,25 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Mythical-tier items on the anvil. A droplet of
+ * divine essence used to mend gear no mundane material could touch.
+ */
+@Singleton
+@ItemKey("core:ichor")
+public class Ichor extends BaseItem {
+
+    @Inject
+    private Ichor() {
+        super("Ichor", Item.model("ichor", 64), ItemGroup.MATERIAL, ItemRarity.MYTHICAL);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.MYTHICAL));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/IronPlate.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/IronPlate.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Common-tier items on the anvil.
+ */
+@Singleton
+@ItemKey("core:iron_plate")
+public class IronPlate extends BaseItem {
+
+    @Inject
+    private IronPlate() {
+        super("Iron Plate", Item.model("iron_plate", 64), ItemGroup.MATERIAL, ItemRarity.COMMON);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.COMMON));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class PowerAxe extends BaseItem implements Reloadable {
     public PowerAxe() {
         super("Power Axe", ItemStack.of(Material.DIAMOND_AXE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class PowerHoe extends BaseItem implements Reloadable {
     public PowerHoe() {
         super("Power Hoe", ItemStack.of(Material.DIAMOND_HOE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerPickaxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerPickaxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class PowerPickaxe extends BaseItem implements Reloadable {
     public PowerPickaxe() {
         super("Power Pickaxe", ItemStack.of(Material.DIAMOND_PICKAXE), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class PowerShovel extends BaseItem implements Reloadable {
     public PowerShovel() {
         super("Power Shovel", ItemStack.of(Material.DIAMOND_SHOVEL), ItemGroup.TOOL, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/PowerSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class PowerSword extends BaseItem implements Reloadable {
     public PowerSword() {
         super("Power Sword", ItemStack.of(Material.DIAMOND_SWORD), ItemGroup.WEAPON, ItemRarity.UNCOMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class RusticAxe extends BaseItem implements Reloadable {
     public RusticAxe() {
         super("Rustic Axe", ItemStack.of(Material.WOODEN_AXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class RusticHoe extends BaseItem implements Reloadable {
     public RusticHoe() {
         super("Rustic Hoe", ItemStack.of(Material.WOODEN_HOE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticPickaxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticPickaxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class RusticPickaxe extends BaseItem implements Reloadable {
     public RusticPickaxe() {
         super("Rustic Pickaxe", ItemStack.of(Material.WOODEN_PICKAXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class RusticShovel extends BaseItem implements Reloadable {
     public RusticShovel() {
         super("Rustic Shovel", ItemStack.of(Material.WOODEN_SHOVEL), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RusticSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class RusticSword extends BaseItem implements Reloadable {
     public RusticSword() {
         super("Rustic Sword", ItemStack.of(Material.WOODEN_SWORD), ItemGroup.WEAPON, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardAxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardAxe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -24,6 +25,7 @@ public class StandardAxe extends BaseItem implements Reloadable {
     public StandardAxe() {
         super("Standard Axe", ItemStack.of(Material.IRON_AXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardHoe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardHoe.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class StandardHoe extends BaseItem implements Reloadable {
     public StandardHoe() {
         super("Standard Hoe", ItemStack.of(Material.IRON_HOE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardPickaxe.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardPickaxe.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
@@ -22,6 +23,7 @@ public class StandardPickaxe extends BaseItem implements Reloadable {
     public StandardPickaxe() {
         super("Standard Pickaxe", ItemStack.of(Material.IRON_PICKAXE), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardShovel.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardShovel.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class StandardShovel extends BaseItem implements Reloadable {
     public StandardShovel() {
         super("Standard Shovel", ItemStack.of(Material.IRON_SHOVEL), ItemGroup.TOOL, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardSword.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/StandardSword.java
@@ -8,6 +8,7 @@ import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class StandardSword extends BaseItem implements Reloadable {
     public StandardSword() {
         super("Standard Sword", ItemStack.of(Material.IRON_SWORD), ItemGroup.WEAPON, ItemRarity.COMMON);
         addSerializableComponent(new DurabilityComponent(DEFAULT_DURABILITY));
+        addSerializableComponent(new RepairableComponent());
     }
 
     @Override

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/TemperedPin.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/TemperedPin.java
@@ -1,0 +1,24 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+
+/**
+ * Reinforcement consumed to repair Rare-tier items on the anvil.
+ */
+@Singleton
+@ItemKey("core:tempered_pin")
+public class TemperedPin extends BaseItem {
+
+    @Inject
+    private TemperedPin() {
+        super("Tempered Pin", Item.model("tempered_pin", 64), ItemGroup.MATERIAL, ItemRarity.RARE);
+        addBaseComponent(new ReinforcementComponent(ItemRarity.RARE));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/model/ArmorItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/model/ArmorItem.java
@@ -5,6 +5,7 @@ import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.component.impl.stat.ItemStat;
 import me.mykindos.betterpvp.core.item.component.impl.stat.StatContainerComponent;
@@ -22,6 +23,7 @@ public abstract class ArmorItem extends BaseItem implements Reloadable {
         this.plugin = plugin;
         addSerializableComponent(new StatContainerComponent().withBaseStat(new ItemStat<>(StatTypes.HEALTH, 1d)));
         addSerializableComponent(new DurabilityComponent(500));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent(0, 0));
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/model/WeaponItem.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/model/WeaponItem.java
@@ -5,6 +5,7 @@ import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.component.impl.stat.ItemStat;
 import me.mykindos.betterpvp.core.item.component.impl.stat.StatContainerComponent;
@@ -27,6 +28,7 @@ public abstract class WeaponItem extends BaseItem implements Reloadable {
         this.groups = groups;
         addSerializableComponent(new RuneContainerComponent(0, 0));
         addSerializableComponent(new DurabilityComponent(500));
+        addSerializableComponent(new RepairableComponent());
 
         if (groups.contains(Group.MELEE)) {
             addSerializableComponent(new StatContainerComponent()

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/RepairPlan.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/RepairPlan.java
@@ -1,0 +1,86 @@
+package me.mykindos.betterpvp.core.repair;
+
+import lombok.Value;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * An immutable, fully-resolved description of a repair the anvil can perform with its
+ * current contents. Produced by {@link RepairService#resolve} and executed by the
+ * RepairOperation.
+ * <br>
+ * Roles are identified by item identity/type, never by anvil slot — placement order
+ * and slots are irrelevant to anvil operations.
+ */
+@Value
+public class RepairPlan {
+
+    /**
+     * Three states an anvil can surface for a damaged repairable item.
+     * Only {@link #READY} actually progresses on swings; the others exist so the anvil
+     * can show informational holograms without committing to a repair.
+     */
+    public enum Status {
+        /** All conditions met — swings will consume catalyst and restore durability. */
+        READY,
+        /** The item has spent its lifetime repair budget; no further repairs are possible. */
+        EXHAUSTED,
+        /** Damaged item is present but the anvil lacks enough matching-tier reinforcements. */
+        INSUFFICIENT_CATALYST
+    }
+
+    /** The damaged item being repaired (mutated in place when the repair completes). */
+    ItemInstance item;
+
+    /** Live durability component of {@link #item}. */
+    DurabilityComponent durability;
+
+    /** Live repairable component of {@link #item}. */
+    RepairableComponent repairable;
+
+    /** The Reinforcement tier required (matches the item's rarity); null when not repairable. */
+    @Nullable ItemRarity catalystTier;
+
+    /** Durability points this repair will restore (already clamped to the lifetime budget). */
+    int restoreAmount;
+
+    /** Convenience flag equal to {@code status == Status.READY} — the only state that mutates items. */
+    boolean canRepair;
+
+    /** Fine-grained outcome state; drives the hologram and whether {@link #complete} mutates items. */
+    Status status;
+
+    /** Hammer swings required to complete this repair. */
+    int requiredSwings;
+
+    /**
+     * Total matching-tier reinforcement units this repair will consume. Equals the sum
+     * of {@link ReinforcementConsumption#getUnitsConsumed()} across {@link #consumptions}
+     * for a valid plan; preserved on non-repairable plans so the anvil can still show
+     * the intended cost to the player.
+     */
+    int requiredReinforcements;
+
+    /**
+     * Pre-computed per-stack reinforcement consumption. Items on the anvil that are
+     * <i>not</i> in this list (and are not the target) are returned untouched — only
+     * the listed reinforcement units are consumed. Always non-null; empty for a
+     * non-repairable plan.
+     */
+    List<ReinforcementConsumption> consumptions;
+
+    /**
+     * One reinforcement stack and the exact number of units to remove from it.
+     * The remainder of the stack is left on the anvil.
+     */
+    @Value
+    public static class ReinforcementConsumption {
+        ItemInstance instance;
+        int unitsConsumed;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/RepairService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/RepairService.java
@@ -1,0 +1,192 @@
+package me.mykindos.betterpvp.core.repair;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.purity.ItemPurity;
+import me.mykindos.betterpvp.core.item.component.impl.purity.PurityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves whether the items currently on an anvil constitute a valid repair, and
+ * computes the resulting {@link RepairPlan}.
+ * <br>
+ * A repair requires: exactly one damaged item carrying both a {@link DurabilityComponent}
+ * and a {@link RepairableComponent}, plus a sufficient number of matching-tier
+ * {@link ReinforcementComponent} items. The required count scales with the target's
+ * {@link ItemPurity}: {@code reinforcementsPerPurityOrder * (purity.level + 1)} —
+ * defaults to {@code 2 * (level + 1)}, so Pitiful=2, Fragile=4, Moderate=6, Polished=8,
+ * Pristine=10, Perfect=12. Purity only influences cost when the item is <i>attuned</i>;
+ * an unattuned item — or one lacking a {@link PurityComponent} entirely — is billed as
+ * {@link ItemPurity#FRAGILE} so the cost cannot leak a hidden purity roll.
+ * <br>
+ * Any other items on the anvil are returned to the player untouched — they are neither
+ * required nor consumed. Roles are derived purely from item identity/type; anvil slots
+ * and placement order are never consulted.
+ */
+@Singleton
+public class RepairService {
+
+    @Inject
+    @Config(path = "repair.requiredSwings", defaultValue = "3")
+    private int requiredSwings;
+
+    @Inject
+    @Config(path = "repair.lifetimeMultiplier", defaultValue = "3")
+    private int lifetimeMultiplier;
+
+    /** Durability restored per repair execution, as a fraction of the item's max durability. */
+    @Inject
+    @Config(path = "repair.baseFraction", defaultValue = "0.10")
+    private double baseFraction;
+
+    /** Reinforcements consumed per repair execution per purity order (level + 1). */
+    @Inject
+    @Config(path = "repair.reinforcementsPerPurityOrder", defaultValue = "3")
+    private int reinforcementsPerPurityOrder;
+
+    /**
+     * Attempts to resolve a repair from the given anvil contents.
+     *
+     * @param items the items on the anvil (keys/slots are ignored — only values matter)
+     * @return a plan describing the repair, or empty if these items are not a repair.
+     * A plan with {@link RepairPlan#isCanRepair()} == false is still returned for an
+     * exhausted item so the anvil can show the "Not Repairable" indicator.
+     */
+    public @NotNull Optional<RepairPlan> resolve(@NotNull Map<Integer, ItemInstance> items) {
+        final List<ItemInstance> contents = new ArrayList<>();
+        for (ItemInstance instance : items.values()) {
+            if (instance != null) {
+                contents.add(instance);
+            }
+        }
+
+        // Find the single repairable target (carries both durability and repairable).
+        ItemInstance target = null;
+        for (ItemInstance instance : contents) {
+            final boolean repairable = instance.getComponent(DurabilityComponent.class).isPresent()
+                    && instance.getComponent(RepairableComponent.class).isPresent();
+            if (!repairable) {
+                continue;
+            }
+            if (target != null) {
+                return Optional.empty(); // Ambiguous — more than one repairable item.
+            }
+            target = instance;
+        }
+
+        if (target == null) {
+            return Optional.empty();
+        }
+
+        final DurabilityComponent durability = target.getComponent(DurabilityComponent.class).orElseThrow();
+        final RepairableComponent repairable = target.getComponent(RepairableComponent.class).orElseThrow();
+        final int maxDamage = durability.getMaxDamage();
+        final ItemRarity rarity = target.getRarity();
+
+        // Nothing to repair — let the anvil fall back to showing no operation.
+        if (durability.getDamage() <= 0) {
+            return Optional.empty();
+        }
+
+        final int requiredReinforcements = requiredReinforcements(target);
+
+        // Exhausted lifetime budget takes priority: the item can never be repaired again,
+        // regardless of how much catalyst is present. Surface that state first so the
+        // hologram never misleads the player into stockpiling reinforcements.
+        if (!repairable.isRepairable(maxDamage, lifetimeMultiplier)) {
+            return Optional.of(new RepairPlan(target, durability, repairable, rarity, 0,
+                    false, RepairPlan.Status.EXHAUSTED, requiredSwings, requiredReinforcements,
+                    Collections.emptyList()));
+        }
+
+        // Collect every matching-tier reinforcement on the anvil. Cost scales with purity:
+        // higher-purity items demand more of the same tier reinforcement per execution.
+        final List<ItemInstance> reinforcements = new ArrayList<>();
+        int reinforcementUnits = 0;
+        for (ItemInstance instance : contents) {
+            if (instance == target) {
+                continue;
+            }
+            final boolean isMatching = instance.getComponent(ReinforcementComponent.class)
+                    .map(reinforcement -> reinforcement.getTier() == rarity)
+                    .orElse(false);
+            if (!isMatching) {
+                continue; // Non-reinforcement items are ignored and returned untouched.
+            }
+            reinforcements.add(instance);
+            reinforcementUnits += Math.max(1, instance.createItemStack().getAmount());
+        }
+
+        // Not enough matching catalyst — still surface a plan so the anvil can show the
+        // required cost. The plan does not mutate items; complete() is a no-op for this
+        // status. AnvilOperationResolver checks recipes before us, so a real recipe will
+        // never be shadowed by this informational plan.
+        if (reinforcementUnits < requiredReinforcements) {
+            return Optional.of(new RepairPlan(target, durability, repairable, rarity, 0,
+                    false, RepairPlan.Status.INSUFFICIENT_CATALYST, requiredSwings,
+                    requiredReinforcements, Collections.emptyList()));
+        }
+
+        final int budget = repairable.remainingBudget(maxDamage, lifetimeMultiplier);
+        final int perExecution = (int) Math.floor(maxDamage * baseFraction);
+        final int restoreAmount = Math.min(durability.getDamage(), Math.min(budget, perExecution));
+        if (restoreAmount <= 0) {
+            return Optional.empty();
+        }
+
+        final List<RepairPlan.ReinforcementConsumption> consumptions =
+                planReinforcementConsumption(reinforcements, requiredReinforcements);
+
+        return Optional.of(new RepairPlan(target, durability, repairable, rarity, restoreAmount,
+                true, RepairPlan.Status.READY, requiredSwings, requiredReinforcements,
+                consumptions));
+    }
+
+    /**
+     * Number of matching-tier reinforcements consumed by one repair execution for this item.
+     * Scales linearly with purity level so higher-purity items cost more to maintain — but
+     * <i>only</i> when the item is attuned. Unattuned items (and items missing a
+     * {@link PurityComponent} altogether) are billed as {@link ItemPurity#FRAGILE} so the
+     * cost displayed at the anvil cannot leak a hidden purity roll.
+     */
+    private int requiredReinforcements(@NotNull ItemInstance target) {
+        final ItemPurity purity = target.getComponent(PurityComponent.class)
+                .filter(PurityComponent::isAttuned)
+                .map(PurityComponent::getPurity)
+                .orElse(ItemPurity.FRAGILE);
+        return reinforcementsPerPurityOrder * (purity.getLevel() + 1);
+    }
+
+    /**
+     * Distributes the required reinforcement units across the available stacks in
+     * iteration order. Returned consumptions can be applied directly by {@code RepairOperation}.
+     */
+    private @NotNull List<RepairPlan.ReinforcementConsumption> planReinforcementConsumption(
+            @NotNull List<ItemInstance> reinforcements,
+            int requiredReinforcements) {
+        final List<RepairPlan.ReinforcementConsumption> consumptions = new ArrayList<>();
+        int remaining = requiredReinforcements;
+        for (ItemInstance reinforcement : reinforcements) {
+            if (remaining <= 0) {
+                break;
+            }
+            final int available = Math.max(1, reinforcement.createItemStack().getAmount());
+            final int take = Math.min(available, remaining);
+            consumptions.add(new RepairPlan.ReinforcementConsumption(reinforcement, take));
+            remaining -= take;
+        }
+        return List.copyOf(consumptions);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvagePlan.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvagePlan.java
@@ -1,0 +1,19 @@
+package me.mykindos.betterpvp.core.repair;
+
+import lombok.Value;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+
+/**
+ * Immutable description of a pending salvage: the gear being consumed, the
+ * reinforcement BaseItem to mint, and the rolled yield count. Produced by
+ * {@link SalvageService#resolve} and executed by {@link SalvageStationListener}.
+ */
+@Value
+public class SalvagePlan {
+    ItemInstance source;
+    BaseItem reinforcement;
+    ItemRarity tier;
+    int yield;
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
@@ -1,0 +1,96 @@
+package me.mykindos.betterpvp.core.repair;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.ItemRegistry;
+import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Resolves whether a held {@link ItemStack} is salvageable at a Salvage Station, and
+ * picks the matching-tier reinforcement that the salvage will yield.
+ * <br>
+ * Salvageability mirrors the repair contract: the item must carry both a
+ * {@link DurabilityComponent} and a {@link RepairableComponent} (i.e. it's gear that
+ * could have been repaired in the first place) and be non-stackable (max stack size 1)
+ * so that a single right-click unambiguously consumes a single unique item.
+ * <br>
+ * The reinforcement is chosen by scanning the {@link ItemRegistry} for a BaseItem whose
+ * {@link ReinforcementComponent#getTier()} equals the salvaged item's runtime rarity;
+ * the mapping is cached on first use because {@link ItemRegistry} is populated
+ * asynchronously at startup and may be empty if we eagerly resolved.
+ */
+@Singleton
+public class SalvageService {
+
+    private static final int MIN_YIELD = 1;
+    private static final int MAX_YIELD = 3;
+
+    private final ItemRegistry itemRegistry;
+    private volatile Map<ItemRarity, BaseItem> reinforcementByTier;
+
+    @Inject
+    private SalvageService(ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
+
+    /**
+     * Resolves a salvage plan from the player's held {@link ItemInstance}.
+     *
+     * @return the plan, or empty if the item is not eligible (not gear, stackable, or
+     * its tier has no registered reinforcement).
+     */
+    public @NotNull Optional<SalvagePlan> resolve(@NotNull ItemInstance instance, @NotNull ItemStack heldStack) {
+        if (heldStack.getMaxStackSize() > 1) {
+            return Optional.empty();
+        }
+        final boolean isGear = instance.getComponent(DurabilityComponent.class).isPresent()
+                && instance.getComponent(RepairableComponent.class).isPresent();
+        if (!isGear) {
+            return Optional.empty();
+        }
+
+        final ItemRarity rarity = instance.getRarity();
+        final BaseItem reinforcement = reinforcementFor(rarity);
+        if (reinforcement == null) {
+            return Optional.empty();
+        }
+
+        final int yield = ThreadLocalRandom.current().nextInt(MIN_YIELD, MAX_YIELD + 1);
+        return Optional.of(new SalvagePlan(instance, reinforcement, rarity, yield));
+    }
+
+    /**
+     * Finds the registered Reinforcement BaseItem for the given rarity tier, building
+     * the cache on first call. Returns null if no reinforcement exists for that tier
+     * (which shouldn't happen for current rarities — all six are registered today).
+     */
+    private BaseItem reinforcementFor(@NotNull ItemRarity rarity) {
+        Map<ItemRarity, BaseItem> cache = reinforcementByTier;
+        if (cache == null) {
+            cache = buildCache();
+            reinforcementByTier = cache;
+        }
+        return cache.get(rarity);
+    }
+
+    private @NotNull Map<ItemRarity, BaseItem> buildCache() {
+        final Map<ItemRarity, BaseItem> built = new EnumMap<>(ItemRarity.class);
+        for (BaseItem item : itemRegistry.getItems().values()) {
+            item.getComponent(ReinforcementComponent.class)
+                    .ifPresent(component -> built.putIfAbsent(component.getTier(), item));
+        }
+        return built;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
@@ -2,15 +2,19 @@ package me.mykindos.betterpvp.core.repair;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.ItemRegistry;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.purity.ItemPurity;
+import me.mykindos.betterpvp.core.item.component.impl.purity.PurityComponent;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
 import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -34,11 +38,38 @@ import java.util.concurrent.ThreadLocalRandom;
 @Singleton
 public class SalvageService {
 
-    private static final int MIN_YIELD = 1;
-    private static final int MAX_YIELD = 3;
-
     private final ItemRegistry itemRegistry;
     private volatile Map<ItemRarity, BaseItem> reinforcementByTier;
+
+    /** Probability that a salvage yields the reinforcement of the next rarity tier instead of the item's own tier. */
+    @Inject
+    @Config(path = "salvage.tierUpgradeChance", defaultValue = "0.20")
+    private double tierUpgradeChance;
+
+    /** Minimum yield, awarded when the item is fully broken (durability fraction = 0). */
+    @Inject
+    @Config(path = "salvage.minYield", defaultValue = "1")
+    private int minYield;
+
+    /** Maximum durability-driven yield, awarded when the item is pristine (durability fraction = 1). Purity bonuses stack on top. */
+    @Inject
+    @Config(path = "salvage.maxYield", defaultValue = "3")
+    private int maxYield;
+
+    /** Extra reinforcements awarded for an attuned item of PITIFUL or FRAGILE purity. */
+    @Inject
+    @Config(path = "salvage.purityBonus.low", defaultValue = "0")
+    private int purityBonusLow;
+
+    /** Extra reinforcements awarded for an attuned item of MODERATE or POLISHED purity. */
+    @Inject
+    @Config(path = "salvage.purityBonus.mid", defaultValue = "1")
+    private int purityBonusMid;
+
+    /** Extra reinforcements awarded for an attuned item of PRISTINE or PERFECT purity. */
+    @Inject
+    @Config(path = "salvage.purityBonus.high", defaultValue = "2")
+    private int purityBonusHigh;
 
     @Inject
     private SalvageService(ItemRegistry itemRegistry) {
@@ -62,13 +93,67 @@ public class SalvageService {
         }
 
         final ItemRarity rarity = instance.getRarity();
-        final BaseItem reinforcement = reinforcementFor(rarity);
-        if (reinforcement == null) {
+        final BaseItem baseReinforcement = reinforcementFor(rarity);
+        if (baseReinforcement == null) {
             return Optional.empty();
         }
 
-        final int yield = ThreadLocalRandom.current().nextInt(MIN_YIELD, MAX_YIELD + 1);
-        return Optional.of(new SalvagePlan(instance, reinforcement, rarity, yield));
+        final DurabilityComponent durability = instance.getComponent(DurabilityComponent.class).orElseThrow();
+        final double durabilityFraction = Math.max(0d, Math.min(1d,
+                (durability.getMaxDamage() - durability.getDamage()) / (double) durability.getMaxDamage()));
+
+        // With probability `tierUpgradeChance`, promote the yield to the next rarity's
+        // reinforcement. At MYTHICAL there is no higher tier, so the roll is skipped.
+        // If the upgraded tier has no registered reinforcement, fall back to the base tier.
+        BaseItem finalReinforcement = baseReinforcement;
+        ItemRarity finalTier = rarity;
+        final ItemRarity upgradedTier = nextTier(rarity);
+        if (upgradedTier != null && ThreadLocalRandom.current().nextDouble() < tierUpgradeChance) {
+            final BaseItem upgraded = reinforcementFor(upgradedTier);
+            if (upgraded != null) {
+                finalReinforcement = upgraded;
+                finalTier = upgradedTier;
+            }
+        }
+
+        final int baseYield = rollYield(durabilityFraction);
+        final int yield = baseYield + purityBonus(instance);
+        return Optional.of(new SalvagePlan(instance, finalReinforcement, finalTier, yield));
+    }
+
+    /**
+     * Maps remaining-durability fraction in [0, 1] to a salvage yield in [minYield, maxYield].
+     * Higher durability should bias toward higher yields.
+     *
+     * @param durabilityFraction (maxDamage - damage) / maxDamage, clamped to [0, 1].
+     *                           1.0 = pristine, 0.0 = broken.
+     */
+    private int rollYield(double durabilityFraction) {
+        return (int) Math.round(minYield + durabilityFraction * (maxYield - minYield));
+    }
+
+    /**
+     * Returns the extra reinforcements awarded by the item's purity, or 0 if the item
+     * has no {@link PurityComponent} or is unattuned. Bonuses are grouped in pairs along
+     * the {@link ItemPurity} scale and are configurable via {@code salvage.purityBonus.*}.
+     */
+    private int purityBonus(@NotNull ItemInstance instance) {
+        final PurityComponent component = instance.getComponent(PurityComponent.class).orElse(null);
+        if (component == null || !component.isAttuned()) {
+            return 0;
+        }
+        return switch (component.getPurity()) {
+            case PITIFUL, FRAGILE -> purityBonusLow;
+            case MODERATE, POLISHED -> purityBonusMid;
+            case PRISTINE, PERFECT -> purityBonusHigh;
+        };
+    }
+
+    /** Returns the rarity one tier above {@code rarity}, or null if it is already the top tier. */
+    private @Nullable ItemRarity nextTier(@NotNull ItemRarity rarity) {
+        final ItemRarity[] all = ItemRarity.values();
+        final int next = rarity.ordinal() + 1;
+        return next < all.length ? all[next] : null;
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStation.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStation.java
@@ -1,0 +1,33 @@
+package me.mykindos.betterpvp.core.repair;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.FallbackItem;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.DescriptionComponent;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Placeable stonecutter used to break repairable gear down into matching-tier
+ * {@link me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent
+ * Reinforcement} catalysts. The actual interaction is handled by
+ * {@link SalvageStationListener} — this class only defines the inventory item and
+ * the fallback block material that the listener watches for.
+ */
+@ItemKey("core:salvage_station")
+@Singleton
+@FallbackItem(Material.STONECUTTER)
+public class SalvageStation extends BaseItem {
+
+    @Inject
+    public SalvageStation() {
+        super("Salvage Station", ItemStack.of(Material.STONECUTTER), ItemGroup.BLOCK, ItemRarity.UNCOMMON);
+        addBaseComponent(new DescriptionComponent(1,
+                Component.text("Place and right-click with a piece of gear to salvage it into Reinforcements of matching rarity.")));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
@@ -1,0 +1,146 @@
+package me.mykindos.betterpvp.core.repair;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.ItemFactory;
+import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.menu.impl.ConfirmationMenu;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Right-clicking a placed stonecutter with a salvageable piece of gear consumes the
+ * gear and yields 1–3 matching-tier Reinforcements. Items of {@link ItemRarity#EPIC}
+ * or higher go through a {@link ConfirmationMenu} first — these are scarce, so a
+ * misclick should not silently destroy them.
+ * <br>
+ * The listener watches the stonecutter material directly rather than verifying the
+ * block is a registered {@link SalvageStation} placement; this mirrors how
+ * {@code BuildListener} treats any enchanting table as a build editor on this server,
+ * and keeps us out of the persistent-block-storage path for what's a stateless action.
+ */
+@BPvPListener
+@Singleton
+public class SalvageStationListener implements Listener {
+
+    @Inject
+    private ItemFactory itemFactory;
+
+    @Inject
+    private SalvageService salvageService;
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+
+        final Block block = event.getClickedBlock();
+        if (block == null || block.getType() != Material.STONECUTTER) return;
+
+        // Block the vanilla stonecutter GUI unconditionally — this stonecutter is a
+        // salvage station, not a recipe selector. Whether the player is holding a
+        // salvageable item, an unrelated item, or nothing at all, the GUI never opens.
+        event.setCancelled(true);
+
+        final Player player = event.getPlayer();
+        final ItemStack held = player.getInventory().getItemInMainHand();
+        if (held.getType() == Material.AIR) {
+            tellNotSalvageable(player);
+            return;
+        }
+
+        final ItemInstance instance = itemFactory.fromItemStack(held).orElse(null);
+        if (instance == null) {
+            tellNotSalvageable(player);
+            return;
+        }
+
+        salvageService.resolve(instance, held).ifPresentOrElse(
+                plan -> handlePlan(player, held, plan),
+                () -> tellNotSalvageable(player));
+    }
+
+    /**
+     * Executes immediately for sub-Epic items; otherwise opens a confirmation menu
+     * showing the rolled yield. The yield is rolled before the prompt so the player
+     * can see exactly what they will get — there's no second roll on confirm.
+     */
+    private void handlePlan(Player player, ItemStack held, SalvagePlan plan) {
+        if (plan.getTier().isAtLeast(ItemRarity.EPIC)) {
+            promptConfirmation(player, held, plan);
+        } else {
+            execute(player, held, plan);
+        }
+    }
+
+    private void promptConfirmation(Player player, ItemStack held, SalvagePlan plan) {
+        final String sourceName = plain(displayName(plan.getSource()));
+        final ItemInstance preview = itemFactory.createPreview(plan.getReinforcement());
+        final String rewardName = plain(displayName(preview));
+        final String description = String.format(
+                "Salvage %s for %s? This will destroy the item.",
+                sourceName, rewardName);
+
+        new ConfirmationMenu(description, confirmed -> {
+            if (!confirmed) return;
+            // Re-fetch the held stack — the player may have swapped items while the
+            // menu was open. Identity equality on the stack reference catches both
+            // a swap (different stack) and a drop (held becomes AIR -> different instance).
+            final ItemStack nowHeld = player.getInventory().getItemInMainHand();
+            if (!nowHeld.equals(held)) {
+                UtilMessage.message(player, "Salvage", Component.text(
+                        "You are no longer holding the item you wanted to salvage.", NamedTextColor.RED));
+                return;
+            }
+            execute(player, nowHeld, plan);
+        }).show(player);
+    }
+
+    private void execute(Player player, ItemStack held, SalvagePlan plan) {
+        // maxStackSize == 1 is part of the salvage eligibility contract, so destroying
+        // the whole stack is exactly destroying the one unit the player clicked with.
+        held.setAmount(0);
+
+        final ItemInstance produced = itemFactory.create(plan.getReinforcement());
+        final ItemStack stack = produced.createItemStack();
+        stack.setAmount(plan.getYield());
+        UtilItem.insert(player, stack);
+
+        final Location loc = player.getLocation();
+        loc.getWorld().playSound(loc, Sound.UI_STONECUTTER_TAKE_RESULT, 1.0f, 1.0f);
+
+        UtilMessage.message(player, "Salvage", Component.text("You salvaged ", NamedTextColor.GRAY)
+                .append(Component.text("x" + plan.getYield() + " ", NamedTextColor.YELLOW))
+                .append(displayName(produced))
+                .append(Component.text(".", NamedTextColor.GRAY)));
+    }
+
+    private static Component displayName(ItemInstance instance) {
+        return instance.getBaseItem().getItemNameRenderer().createName(instance);
+    }
+
+    private void tellNotSalvageable(Player player) {
+        UtilMessage.message(player, "Salvage",
+                Component.text("Hold a piece of repairable gear to salvage it here.", NamedTextColor.GRAY));
+    }
+
+    private static String plain(Component component) {
+        return net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(component);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
@@ -5,13 +5,14 @@ import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.item.ItemRarity;
+import me.mykindos.betterpvp.core.item.component.impl.purity.ItemPurity;
+import me.mykindos.betterpvp.core.item.component.impl.purity.PurityComponent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.menu.impl.ConfirmationMenu;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -82,11 +83,26 @@ public class SalvageStationListener implements Listener {
      * can see exactly what they will get — there's no second roll on confirm.
      */
     private void handlePlan(Player player, ItemStack held, SalvagePlan plan) {
-        if (plan.getTier().isAtLeast(ItemRarity.EPIC)) {
+        if (requiresConfirmation(plan)) {
             promptConfirmation(player, held, plan);
         } else {
             execute(player, held, plan);
         }
+    }
+
+    /**
+     * Whether salvaging this item is destructive enough to warrant a confirmation menu.
+     * Epic+ rarity items are scarce; attuned high-purity items are similarly hard to
+     * replace since purity rolls cannot be re-rolled once revealed.
+     */
+    private boolean requiresConfirmation(SalvagePlan plan) {
+        if (plan.getTier().isAtLeast(ItemRarity.EPIC)) {
+            return true;
+        }
+        return plan.getSource().getComponent(PurityComponent.class)
+                .filter(PurityComponent::isAttuned)
+                .map(component -> component.getPurity().isAtLeast(ItemPurity.PRISTINE))
+                .orElse(false);
     }
 
     private void promptConfirmation(Player player, ItemStack held, SalvagePlan plan) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/DeepResonator.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/DeepResonator.java
@@ -19,6 +19,7 @@ import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.access.RestrictedAccessComponent;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.item.impl.DivineAmulet;
@@ -73,6 +74,7 @@ public class DeepResonator extends BaseItem implements Reloadable {
         addBaseComponent(new RestrictedAccessComponent(Set.of(AccessScope.CRAFT, AccessScope.USE, AccessScope.DAMAGE)));
 
         addSerializableComponent(new DurabilityComponent(3584));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/RunedPickaxe.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/RunedPickaxe.java
@@ -20,6 +20,7 @@ import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.access.RestrictedAccessComponent;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.item.impl.ElderwoodCore;
@@ -73,6 +74,7 @@ public class RunedPickaxe extends BaseItem implements Reloadable {
         addBaseComponent(new RestrictedAccessComponent(Set.of(AccessScope.CRAFT, AccessScope.USE, AccessScope.DAMAGE)));
 
         addSerializableComponent(new DurabilityComponent(3584));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/TheRift.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/mining/item/TheRift.java
@@ -21,6 +21,7 @@ import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.access.RestrictedAccessComponent;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.config.Config;
 import me.mykindos.betterpvp.core.item.impl.DurakHandle;
@@ -107,6 +108,7 @@ public class TheRift extends BaseItem implements Reloadable {
         addBaseComponent(new RestrictedAccessComponent(Set.of(AccessScope.CRAFT, AccessScope.USE, AccessScope.DAMAGE)));
 
         addSerializableComponent(new DurabilityComponent(3584));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
     }
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/item/WillwoodAxe.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/item/WillwoodAxe.java
@@ -13,6 +13,7 @@ import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.access.RestrictedAccessComponent;
 import me.mykindos.betterpvp.core.item.component.impl.durability.DurabilityComponent;
+import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
 import me.mykindos.betterpvp.core.item.component.impl.runes.RuneContainerComponent;
 import me.mykindos.betterpvp.core.item.impl.interaction.TreeFellerInteraction;
 import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
@@ -33,6 +34,7 @@ public class WillwoodAxe extends BaseItem {
     private WillwoodAxe(TreeFellerInteraction interaction) {
         super("Willwood Axe", Item.model(Material.IRON_AXE, "willwood_axe"), ItemGroup.TOOL, ItemRarity.RARE);
         addSerializableComponent(new DurabilityComponent(1000));
+        addSerializableComponent(new RepairableComponent());
         addSerializableComponent(new RuneContainerComponent());
         addBaseComponent(InteractionContainerComponent.builder()
                 .root(InteractionInputs.BLOCK_BREAK, interaction)


### PR DESCRIPTION
## Describe your changes

- Players can now repair worn gear at the anvil using matching-tier Reinforcement items.
  - Each repair restores a small chunk of durability.
  - Higher-purity items cost more Reinforcements per repair.
  - Every item has a lifetime repair budget; once spent the anvil shows "Not Repairable".
- Players can now salvage gear into 1-3 Reinforcements of its rarity.
  - Epic and higher items ask for confirmation before they are consumed.
- Anvil interactions now choose between crafting and repairing based on what is placed on the anvil.
- Durable tools, weapons, and armor across core, champions, and progression are now repairable.
- Six new Reinforcement items cover the full rarity range from Common through Mythical.

## Link to issue (if applicable)

- N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
