### PR TITLE
Add Runic Dust as a salvage and crafting material

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AnchorStone.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AnchorStone.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.NamespacedKey;
 
 /**
  * Reinforcement consumed to repair Legendary-tier items on the anvil.
@@ -16,9 +21,29 @@ import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementCompon
 @ItemKey("core:anchor_stone")
 public class AnchorStone extends BaseItem {
 
+    private transient boolean registered;
+
     @Inject
     private AnchorStone() {
         super("Anchor Stone", Item.model("anchor_stone", 64), ItemGroup.MATERIAL, ItemRarity.LEGENDARY);
         addBaseComponent(new ReinforcementComponent(ItemRarity.LEGENDARY));
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry,
+                                ItemFactory itemFactory,
+                                ForgeSpike forgeSpike,
+                                RunicDust runicDust) {
+        if (registered) return;
+        registered = true;
+        String[] pattern = new String[] {
+                "DDD",
+                "DPD",
+                "DDD",
+        };
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
+        builder.setIngredient('P', new RecipeIngredient(forgeSpike, 1));
+        registry.registerRecipe(new NamespacedKey("core", "anchor_stone"), builder.build());
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AttunementStone.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/AttunementStone.java
@@ -28,17 +28,19 @@ public class AttunementStone extends BaseItem {
     @Inject
     private void registerRecipe(CraftingRecipeRegistry registry,
                                 ItemFactory itemFactory,
-                                MagicSeal magicSeal) {
+                                MagicSeal magicSeal,
+                                RunicDust runicDust) {
         if (registered) return;
         registered = true;
         String[] pattern = new String[] {
-                "GGG",
-                "GMG",
-                "GGG",
+                "GDG",
+                "DMD",
+                "GDG",
         };
         final BaseItem goldIngot = itemFactory.getFallbackItem(Material.GOLD_INGOT);
         final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
         builder.setIngredient('G', new RecipeIngredient(goldIngot, 1));
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
         builder.setIngredient('M', new RecipeIngredient(magicSeal, 1));
         registry.registerRecipe(new NamespacedKey("core", "attunement_stone"), builder.build());
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BronzePlate.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/BronzePlate.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.NamespacedKey;
 
 /**
  * Reinforcement consumed to repair Uncommon-tier items on the anvil.
@@ -16,9 +21,29 @@ import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementCompon
 @ItemKey("core:bronze_plate")
 public class BronzePlate extends BaseItem {
 
+    private transient boolean registered;
+
     @Inject
     private BronzePlate() {
         super("Bronze Plate", Item.model("bronze_plate", 64), ItemGroup.MATERIAL, ItemRarity.UNCOMMON);
         addBaseComponent(new ReinforcementComponent(ItemRarity.UNCOMMON));
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry,
+                                ItemFactory itemFactory,
+                                IronPlate ironPlate,
+                                RunicDust runicDust) {
+        if (registered) return;
+        registered = true;
+        String[] pattern = new String[] {
+                "DDD",
+                "DPD",
+                "DDD",
+        };
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
+        builder.setIngredient('P', new RecipeIngredient(ironPlate, 1));
+        registry.registerRecipe(new NamespacedKey("core", "bronze_plate"), builder.build());
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/ForgeSpike.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/ForgeSpike.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.NamespacedKey;
 
 /**
  * Reinforcement consumed to repair Epic-tier items on the anvil.
@@ -16,9 +21,29 @@ import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementCompon
 @ItemKey("core:forge_spike")
 public class ForgeSpike extends BaseItem {
 
+    private transient boolean registered;
+
     @Inject
     private ForgeSpike() {
         super("Forge Spike", Item.model("forge_spike", 64), ItemGroup.MATERIAL, ItemRarity.EPIC);
         addBaseComponent(new ReinforcementComponent(ItemRarity.EPIC));
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry,
+                                ItemFactory itemFactory,
+                                TemperedPin temperedPin,
+                                RunicDust runicDust) {
+        if (registered) return;
+        registered = true;
+        String[] pattern = new String[] {
+                "DDD",
+                "DPD",
+                "DDD",
+        };
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
+        builder.setIngredient('P', new RecipeIngredient(temperedPin, 1));
+        registry.registerRecipe(new NamespacedKey("core", "forge_spike"), builder.build());
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Ichor.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/Ichor.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.NamespacedKey;
 
 /**
  * Reinforcement consumed to repair Mythical-tier items on the anvil. A droplet of
@@ -17,9 +22,29 @@ import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementCompon
 @ItemKey("core:ichor")
 public class Ichor extends BaseItem {
 
+    private transient boolean registered;
+
     @Inject
     private Ichor() {
         super("Ichor", Item.model("ichor", 64), ItemGroup.MATERIAL, ItemRarity.MYTHICAL);
         addBaseComponent(new ReinforcementComponent(ItemRarity.MYTHICAL));
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry,
+                                ItemFactory itemFactory,
+                                AnchorStone anchorStone,
+                                RunicDust runicDust) {
+        if (registered) return;
+        registered = true;
+        String[] pattern = new String[] {
+                "DDD",
+                "DPD",
+                "DDD",
+        };
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
+        builder.setIngredient('P', new RecipeIngredient(anchorStone, 1));
+        registry.registerRecipe(new NamespacedKey("core", "ichor"), builder.build());
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RunicDust.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/RunicDust.java
@@ -1,0 +1,19 @@
+package me.mykindos.betterpvp.core.item.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.item.BaseItem;
+import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemGroup;
+import me.mykindos.betterpvp.core.item.ItemKey;
+import me.mykindos.betterpvp.core.item.ItemRarity;
+
+@Singleton
+@ItemKey("core:runic_dust")
+public class RunicDust extends BaseItem {
+
+    @Inject
+    private RunicDust() {
+        super("Runic Dust", Item.model("runic_dust", 64), ItemGroup.MATERIAL, ItemRarity.RARE);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/TemperedPin.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/TemperedPin.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.item.BaseItem;
 import me.mykindos.betterpvp.core.item.Item;
+import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemGroup;
 import me.mykindos.betterpvp.core.item.ItemKey;
 import me.mykindos.betterpvp.core.item.ItemRarity;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
+import me.mykindos.betterpvp.core.recipe.RecipeIngredient;
+import me.mykindos.betterpvp.core.recipe.crafting.CraftingRecipeRegistry;
+import me.mykindos.betterpvp.core.recipe.crafting.ShapedCraftingRecipe;
+import org.bukkit.NamespacedKey;
 
 /**
  * Reinforcement consumed to repair Rare-tier items on the anvil.
@@ -16,9 +21,29 @@ import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementCompon
 @ItemKey("core:tempered_pin")
 public class TemperedPin extends BaseItem {
 
+    private transient boolean registered;
+
     @Inject
     private TemperedPin() {
         super("Tempered Pin", Item.model("tempered_pin", 64), ItemGroup.MATERIAL, ItemRarity.RARE);
         addBaseComponent(new ReinforcementComponent(ItemRarity.RARE));
+    }
+
+    @Inject
+    private void registerRecipe(CraftingRecipeRegistry registry,
+                                ItemFactory itemFactory,
+                                BronzePlate bronzePlate,
+                                RunicDust runicDust) {
+        if (registered) return;
+        registered = true;
+        String[] pattern = new String[] {
+                "DDD",
+                "DPD",
+                "DDD",
+        };
+        final ShapedCraftingRecipe.Builder builder = new ShapedCraftingRecipe.Builder(this, pattern, itemFactory);
+        builder.setIngredient('D', new RecipeIngredient(runicDust, 1));
+        builder.setIngredient('P', new RecipeIngredient(bronzePlate, 1));
+        registry.registerRecipe(new NamespacedKey("core", "tempered_pin"), builder.build());
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageService.java
@@ -12,6 +12,8 @@ import me.mykindos.betterpvp.core.item.component.impl.purity.ItemPurity;
 import me.mykindos.betterpvp.core.item.component.impl.purity.PurityComponent;
 import me.mykindos.betterpvp.core.item.component.impl.repair.ReinforcementComponent;
 import me.mykindos.betterpvp.core.item.component.impl.repair.RepairableComponent;
+import me.mykindos.betterpvp.core.item.component.impl.runes.RuneItem;
+import me.mykindos.betterpvp.core.item.impl.RunicDust;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +41,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class SalvageService {
 
     private final ItemRegistry itemRegistry;
+    private final RunicDust runicDust;
     private volatile Map<ItemRarity, BaseItem> reinforcementByTier;
 
     /** Probability that a salvage yields the reinforcement of the next rarity tier instead of the item's own tier. */
@@ -72,8 +75,9 @@ public class SalvageService {
     private int purityBonusHigh;
 
     @Inject
-    private SalvageService(ItemRegistry itemRegistry) {
+    private SalvageService(ItemRegistry itemRegistry, RunicDust runicDust) {
         this.itemRegistry = itemRegistry;
+        this.runicDust = runicDust;
     }
 
     /**
@@ -83,6 +87,11 @@ public class SalvageService {
      * its tier has no registered reinforcement).
      */
     public @NotNull Optional<SalvagePlan> resolve(@NotNull ItemInstance instance, @NotNull ItemStack heldStack) {
+        if (instance.getBaseItem() instanceof RuneItem) {
+            final ItemRarity runeRarity = instance.getRarity();
+            return Optional.of(new SalvagePlan(instance, runicDust, runeRarity, rollRuneYield(runeRarity)));
+        }
+
         if (heldStack.getMaxStackSize() > 1) {
             return Optional.empty();
         }
@@ -130,6 +139,21 @@ public class SalvageService {
      */
     private int rollYield(double durabilityFraction) {
         return (int) Math.round(minYield + durabilityFraction * (maxYield - minYield));
+    }
+
+    /**
+     * Rune dust yield per rune rarity. Ranges are inclusive on both ends.
+     */
+    private int rollRuneYield(@NotNull ItemRarity rarity) {
+        final ThreadLocalRandom rng = ThreadLocalRandom.current();
+        return switch (rarity) {
+            case COMMON -> rng.nextInt(1, 3);
+            case UNCOMMON -> rng.nextInt(3, 5);
+            case RARE -> rng.nextInt(4, 6);
+            case EPIC -> rng.nextInt(5, 7);
+            case LEGENDARY -> rng.nextInt(10, 16);
+            case MYTHICAL -> rng.nextInt(20, 26);
+        };
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/repair/SalvageStationListener.java
@@ -129,9 +129,9 @@ public class SalvageStationListener implements Listener {
     }
 
     private void execute(Player player, ItemStack held, SalvagePlan plan) {
-        // maxStackSize == 1 is part of the salvage eligibility contract, so destroying
-        // the whole stack is exactly destroying the one unit the player clicked with.
-        held.setAmount(0);
+        // Consume a single unit. For gear (maxStackSize == 1) this empties the stack;
+        // for stackable items like runes only the one clicked unit is taken.
+        held.setAmount(held.getAmount() - 1);
 
         final ItemInstance produced = itemFactory.create(plan.getReinforcement());
         final ItemStack stack = produced.createItemStack();


### PR DESCRIPTION
## Describe your changes

Adds Runic Dust: a new material you earn by salvaging runes and spend on crafting reinforcements.

- **Salvaging runes**
  - Right-click a rune on the salvage station to break it down into Runic Dust.
  - Drop ranges scale with the rune's rarity:
    - Common: 1-2
    - Uncommon: 3-4
    - Rare: 4-5
    - Epic: 5-6
    - Legendary: 10-15
    - Mythical: 20-25
  - Only the single rune you clicked with is consumed, even when you're holding a stack.

- **Reinforcement recipes**
  - Bronze Plate, Tempered Pin, Forge Spike, Anchor Stone, and Ichor now have shaped recipes: 8 Runic Dust around the previous-tier reinforcement (Iron Plate at the bottom rung).
  - Attunement Stone recipe also uses Runic Dust alongside gold and the Magic Seal.

- **Runic Dust item**
  - Renamed from "Rune Dust" to "Runic Dust" and bumped to Rare so it stacks like the other reinforcement materials.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.

## Testing notes

- Salvage runes of each rarity at the salvage station and confirm the dust counts fall within the listed ranges.
- Salvage from a stack of runes and confirm only one is consumed per click.
- Craft each reinforcement using Runic Dust and confirm the recipes resolve.