### PR TITLE
Fix No More Mobs not removing swimmers, and make loot events reliable

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/loot/DroppedClanEnergyLoot.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/loot/DroppedClanEnergyLoot.java
@@ -18,7 +18,7 @@ public final class DroppedClanEnergyLoot extends ClanEnergyLoot<Item> {
     }
 
     @Override
-    public Item award(LootContext context) {
+    protected Item award(LootContext context) {
         int amount = (minAmount == maxAmount) ? minAmount : ThreadLocalRandom.current().nextInt(minAmount, maxAmount + 1);
         ItemStack item = energyType.generateItem(amount, autoDeposit);
         return context.getLocation().getWorld().dropItemNaturally(context.getLocation(), item);

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/loot/GivenClanEnergyLoot.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/loot/GivenClanEnergyLoot.java
@@ -23,7 +23,7 @@ public final class GivenClanEnergyLoot extends ClanEnergyLoot<Map<Clan, Integer>
     }
 
     @Override
-    public Map<Clan, Integer> award(LootContext context) {
+    protected Map<Clan, Integer> award(LootContext context) {
         ClanManager clanManager = JavaPlugin.getPlugin(Clans.class).getInjector().getInstance(ClanManager.class);
         Map<Clan, Integer> results = new HashMap<>();
         context.getSession().getAudience().forEachAudience(audience -> {
@@ -32,7 +32,7 @@ public final class GivenClanEnergyLoot extends ClanEnergyLoot<Map<Clan, Integer>
             }
             clanManager.getClanByPlayer(player).ifPresent(clan -> {
                 int amount = (minAmount == maxAmount) ? minAmount : ThreadLocalRandom.current().nextInt(minAmount, maxAmount + 1);
-                clan.grantEnergy(player, amount, context.getSource());
+                clan.grantEnergy(player, amount, context.getSource().getDisplayName());
                 results.merge(clan, amount, Integer::sum);
             });
         });

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/ClansFishingListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/progression/listener/ClansFishingListener.java
@@ -80,7 +80,7 @@ public class ClansFishingListener implements Listener {
         if(true) {
             return;
         }
-        if (!"Fishing".equals(event.getContext().getSource())) return;
+        if (!event.getContext().getSource().getId().startsWith("fishing:")) return;
         if (!(event.getLoot() instanceof DroppedItemLoot droppedLoot)) return;
 
         final Audience audience = event.getContext().getSession().getAudience();

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/weapon/listeners/WeaponListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/weapon/listeners/WeaponListener.java
@@ -12,17 +12,14 @@ import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.item.model.WeaponItem;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilSound;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
@@ -52,26 +49,15 @@ public class WeaponListener implements Listener {
 
         final String clazzName = item.getBaseItem().getClass().getSimpleName();
         final Component name = item.getView().getName();
-        if (event.getSource().equalsIgnoreCase("Fishing")) {
-            UtilMessage.broadcast(Component.text("A ", NamedTextColor.YELLOW).append(name.hoverEvent(item.getView().get()))
-                    .append(Component.text(" was caught by a fisherman!", NamedTextColor.YELLOW)));
-            log.info("A legendary weapon was caught by a fisherman! ({})", clazzName)
-                    .setAction("FISH_LEGENDARY")
-                    .addLocationContext(event.getLocation())
-                    .addContext("Source", event.getSource()).submit();
-
-            for (Player player : Bukkit.getOnlinePlayers()) {
-                UtilSound.playSound(player, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1.0f, 1.0f, false);
-            }
-        } else {
-            UtilMessage.broadcast(Component.text("Announcement> ", NamedTextColor.BLUE)
-                    .append(Component.text(event.getSource(), NamedTextColor.RED)
-                            .append(Component.text(" dropped a legendary ", NamedTextColor.GRAY))
-                            .append(name.hoverEvent(item.getView().get()))));
-            log.info("A legendary weapon was dropped by {}! ({})", event.getSource(), clazzName)
-                    .addLocationContext(event.getLocation())
-                    .addContext("Source", event.getSource()).submit();
-        }
+        final String sourceId = event.getSource().getId();
+        final String sourceDisplay = event.getSource().getDisplayName();
+        UtilMessage.broadcast(Component.text("Announcement> ", NamedTextColor.BLUE)
+                .append(Component.text(sourceDisplay, NamedTextColor.RED)
+                        .append(Component.text(" dropped a legendary ", NamedTextColor.GRAY))
+                        .append(name.hoverEvent(item.getView().get()))));
+        log.info("A legendary weapon was dropped by {}! ({})", sourceDisplay, clazzName)
+                .addLocationContext(event.getLocation())
+                .addContext("Source", sourceId).submit();
 
         new SoundEffect(Sound.ENTITY_FIREWORK_ROCKET_BLAST, 0.8f, 2.0f).play(event.getLocation());
         new SoundEffect(Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1.2f, 2.0f).play(event.getLocation());

--- a/core/src/main/java/me/mykindos/betterpvp/core/framework/events/items/SpecialItemLootEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/framework/events/items/SpecialItemLootEvent.java
@@ -5,36 +5,22 @@ import lombok.EqualsAndHashCode;
 import me.mykindos.betterpvp.core.framework.events.CustomEvent;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import org.bukkit.Location;
-import org.jetbrains.annotations.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class SpecialItemLootEvent extends CustomEvent {
 
-    @Nullable private final LootContext lootContext;
+    private final LootContext lootContext;
     private final Location location;
     private final ItemInstance itemInstance;
-    private final String source;
+    private final LootSource source;
 
-    /**
-     * We *need* the context to be non-null. For now this solves incompatibility issues with Fishing loot tables
-     * not complying with the new loot system.
-     * @deprecated Use {@link SpecialItemLootEvent#SpecialItemLootEvent(LootContext, ItemInstance, String)} instead
-     */
-    @Deprecated(forRemoval = true)
-    public SpecialItemLootEvent(Location location, ItemInstance itemInstance, String source) {
-        this.lootContext = null;
-        this.location = location;
-        this.itemInstance = itemInstance;
-        this.source = source;
-    }
-
-    public SpecialItemLootEvent(LootContext lootContext, ItemInstance itemInstance, String source) {
+    public SpecialItemLootEvent(LootContext lootContext, ItemInstance itemInstance, LootSource source) {
         this.lootContext = lootContext;
         this.itemInstance = itemInstance;
         this.source = source;
         this.location = lootContext.getLocation();
     }
-
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/uuid/UUIDController.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/component/impl/uuid/UUIDController.java
@@ -133,10 +133,10 @@ public class UUIDController implements Listener {
         getUUIDItem(event.getItemInstance().getItemStack()).ifPresent(uuidItem -> {
             Location location = event.getLocation();
             log.info("({}) was looted from {} at {}",
-                    uuidItem.getUuid(), event.getSource(), UtilWorld.locationToString(location))
+                    uuidItem.getUuid(), event.getSource().getId(), UtilWorld.locationToString(location))
                     .setAction("ITEM_LOOT_SPAWN")
                     .addItemContext(itemFactory.getItemRegistry(), event.getItemInstance())
-                    .addContext(LogContext.SOURCE, event.getSource())
+                    .addContext(LogContext.SOURCE, event.getSource().getId())
                     .addLocationContext(location).submit();
         });
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/item/impl/buildersbox/BuildersBoxAbility.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/item/impl/buildersbox/BuildersBoxAbility.java
@@ -13,9 +13,11 @@ import me.mykindos.betterpvp.core.interaction.InteractionResult;
 import me.mykindos.betterpvp.core.interaction.actor.InteractionActor;
 import me.mykindos.betterpvp.core.interaction.context.InteractionContext;
 import me.mykindos.betterpvp.core.item.ItemInstance;
+import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.item.DroppedItemLoot;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
@@ -86,9 +88,9 @@ public class BuildersBoxAbility extends AbstractInteraction implements Displayed
         // Generate Loot
         final LootTable lootTable = lootTableSupplier.get();
         final LootSession lootSession = LootSession.newSession(lootTable, player);
-        final LootContext lootContext = new LootContext(lootSession, location.clone().add(0, 0.9, 0), source);
+        final LootContext lootContext = new LootContext(lootSession, location.clone().add(0, 0.9, 0),
+                LootSource.of(source, "builders_box:" + source.toLowerCase().replace(' ', '_')));
         final LootBundle bundle = lootTable.generateLoot(lootContext);
-        final Iterator<Loot<?, ?>> iterator = bundle.iterator();
 
         // Spawn the model using ModelEngine
         final Dummy<?> dummy = new Dummy<>();
@@ -119,49 +121,52 @@ public class BuildersBoxAbility extends AbstractInteraction implements Displayed
         // Play particle effects
         queueEffects(location, fallDuration + 2L);
 
-        // Then spawn the items AFTER
-        new BukkitRunnable() {
-            double angle = 0;
+        // Drip-feed strategy: schedules awards on a BukkitRunnable timer and routes each
+        // through awardSingle so a LootAwardedEvent fires per item.
+        bundle.setAwardStrategy(new AwardStrategy() {
             @Override
-            public void run() {
-                if (!iterator.hasNext()) {
-                    this.cancel();
-                    dummy.setRemoved(true);
-                    new SoundEffect(Sound.ENTITY_PLAYER_TELEPORT, 0.4F, 1.2F).play(location);
-                    Particle.POOF.builder()
-                            .count(25)
-                            .offset(0.2, 0.2, 0.2)
-                            .extra(0.1)
-                            .location(location)
-                            .receivers(60)
-                            .spawn();
-                    return; // No more items
-                }
+            public void award(LootBundle b) {
+                final Iterator<Loot<?, ?>> iterator = b.iterator();
+                new BukkitRunnable() {
+                    double angle = 0;
+                    @Override
+                    public void run() {
+                        if (!iterator.hasNext()) {
+                            this.cancel();
+                            dummy.setRemoved(true);
+                            new SoundEffect(Sound.ENTITY_PLAYER_TELEPORT, 0.4F, 1.2F).play(location);
+                            Particle.POOF.builder()
+                                    .count(25)
+                                    .offset(0.2, 0.2, 0.2)
+                                    .extra(0.1)
+                                    .location(location)
+                                    .receivers(60)
+                                    .spawn();
+                            return;
+                        }
 
-                final Loot<?, ?> loot = iterator.next();
-                if (loot instanceof DroppedItemLoot itemLoot) {
-                    final Item item = itemLoot.award(lootContext);
-                    // Shoot it out in a circle
-                    final double radians = Math.toRadians(angle);
-                    angle += 22.5; // controls spacing and spiral motion
-                    angle += (Math.random() * 6 - 3); // small chaotic variance
-                    shootItem(radians, item);
+                        final Loot<?, ?> loot = iterator.next();
+                        final Object awarded = awardSingle(b, loot);
+                        if (loot instanceof DroppedItemLoot && awarded instanceof Item item) {
+                            final double radians = Math.toRadians(angle);
+                            angle += 22.5;
+                            angle += (Math.random() * 6 - 3);
+                            shootItem(radians, item);
 
-                    // Prevent despawning
-                    item.setPickupDelay(20); // 1-second pickup delay
-                    item.setUnlimitedLifetime(true);
-                    item.setCanMobPickup(false);
-                    item.setThrower(player.getUniqueId());
-                    item.setWillAge(false);
-                    item.setInvulnerable(true);
+                            item.setPickupDelay(20);
+                            item.setUnlimitedLifetime(true);
+                            item.setCanMobPickup(false);
+                            item.setThrower(player.getUniqueId());
+                            item.setWillAge(false);
+                            item.setInvulnerable(true);
 
-                    // Sound
-                    new SoundEffect(Sound.BLOCK_BEEHIVE_EXIT, 2f, 1f).play(location);
-                } else {
-                    loot.award(lootContext);
-                }
+                            new SoundEffect(Sound.BLOCK_BEEHIVE_EXIT, 2f, 1f).play(location);
+                        }
+                    }
+                }.runTaskTimer(JavaPlugin.getPlugin(Core.class), openDuration + fallDuration + 20L, 1L);
             }
-        }.runTaskTimer(JavaPlugin.getPlugin(Core.class), openDuration + fallDuration + 20L, 1L);
+        });
+        bundle.award();
 
         return InteractionResult.Success.ADVANCE;
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/AwardStrategy.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/AwardStrategy.java
@@ -2,16 +2,32 @@ package me.mykindos.betterpvp.core.loot;
 
 import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Defines the strategy for awarding loot from a {@link LootBundle}.
+ * <p>
+ * This is an abstract class — not an interface — so that the per-loot award path is owned
+ * by the framework. Concrete strategies invoke {@link #awardSingle(LootBundle, Loot)} to
+ * trigger {@link Loot#award(LootContext)} for a single entry; that helper is the ONLY way
+ * to award a loot, and it always fires a {@link LootAwardedEvent} with the result. There
+ * is intentionally no way for a strategy implementation to award loot without firing the
+ * event.
+ * <p>
+ * Use the {@link #DEFAULT} singleton for "award every entry immediately". Strategies that
+ * need custom ordering, scheduling, or per-item processing subclass this and call
+ * {@code awardSingle} from their own {@link #award(LootBundle)} implementation. Strategies
+ * that only need to observe awards (set velocity, send a message, increment a counter)
+ * should NOT subclass — they should listen to {@link LootAwardedEvent} instead.
  */
-public interface AwardStrategy {
+public abstract class AwardStrategy {
 
-    AwardStrategy DEFAULT = bundle -> {
-        for (Loot<?, ?> loot : bundle) {
-            loot.award(bundle.getContext());
-            UtilServer.callEvent(new LootAwardedEvent(bundle, bundle.getContext(), loot));
+    public static final AwardStrategy DEFAULT = new AwardStrategy() {
+        @Override
+        public void award(LootBundle bundle) {
+            for (Loot<?, ?> loot : bundle) {
+                awardSingle(bundle, loot);
+            }
         }
     };
 
@@ -19,6 +35,21 @@ public interface AwardStrategy {
      * Awards the loot in the bundle.
      * @param bundle The bundle containing the loot to award.
      */
-    void award(LootBundle bundle);
+    public abstract void award(LootBundle bundle);
 
+    /**
+     * Awards a single {@link Loot} entry and fires the {@link LootAwardedEvent} carrying
+     * its result. This is the only callable path to {@link Loot#award(LootContext)}.
+     *
+     * @param bundle the bundle currently being awarded
+     * @param loot   the loot entry to award
+     * @param <R>    the loot's reward type
+     * @return the raw result produced by {@code loot.award(context)}, or {@code null}
+     */
+    protected final <T, R> @Nullable R awardSingle(LootBundle bundle, Loot<T, R> loot) {
+        final LootContext context = bundle.getContext();
+        final R result = loot.award(context);
+        UtilServer.callEvent(new LootAwardedEvent(bundle, context, loot, result));
+        return result;
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/Loot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/Loot.java
@@ -38,9 +38,16 @@ public abstract class Loot<T, R> {
 
     /**
      * Awards this loot to the given context.
+     * <p>
+     * Visibility is {@code protected} to force external callers to go through
+     * {@link AwardStrategy#awardLoot(LootBundle, Loot)} (or {@link LootBundle#award()}),
+     * which guarantees a {@link me.mykindos.betterpvp.core.loot.event.LootAwardedEvent}
+     * is fired for every awarded entry. Subclasses must override with the same or wider
+     * visibility ({@code protected}).
+     *
      * @param context The context to award the loot to.
      */
-    public abstract R award(LootContext context);
+    protected abstract R award(LootContext context);
 
     /**
      * Gets the icon for this loot in a menu

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootContext.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootContext.java
@@ -1,6 +1,5 @@
 package me.mykindos.betterpvp.core.loot;
 
-import com.google.common.base.Preconditions;
 import lombok.Value;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import org.bukkit.Location;
@@ -32,7 +31,7 @@ public class LootContext {
      */
     @NotNull LootSession session;
 
-    @NotNull String source;
+    @NotNull LootSource source;
 
     /**
      * Caller-supplied named values made available to expression-based roll counts, weights
@@ -40,12 +39,11 @@ public class LootContext {
      */
     @NotNull Map<String, Object> inputs;
 
-    public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull String source) {
+    public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull LootSource source) {
         this(session, location, source, Map.of());
     }
 
-    public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull String source, @NotNull Map<String, Object> inputs) {
-        Preconditions.checkArgument(!source.isEmpty(), "Source cannot be empty");
+    public LootContext(@NotNull LootSession session, @NotNull Location location, @NotNull LootSource source, @NotNull Map<String, Object> inputs) {
         this.location = location;
         this.session = session;
         this.source = source;

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootSource.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootSource.java
@@ -1,0 +1,31 @@
+package me.mykindos.betterpvp.core.loot;
+
+import com.google.common.base.Preconditions;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Identifies the originating flow of a {@link LootContext}.
+ * <p>
+ * The {@code displayName} is the human-facing label (e.g. "Fishing") and may collide across
+ * distinct flows. The {@code id} is the unique, machine-facing identifier (e.g.
+ * "fishing:catch" vs. "fishing:treasure") that listeners filter on to differentiate flows
+ * that share a display name.
+ */
+@Value
+public class LootSource {
+
+    @NotNull String displayName;
+    @NotNull String id;
+
+    public LootSource(@NotNull String displayName, @NotNull String id) {
+        Preconditions.checkArgument(!displayName.isEmpty(), "displayName cannot be empty");
+        Preconditions.checkArgument(!id.isEmpty(), "id cannot be empty");
+        this.displayName = displayName;
+        this.id = id;
+    }
+
+    public static @NotNull LootSource of(@NotNull String displayName, @NotNull String id) {
+        return new LootSource(displayName, id);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/chest/LootChest.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/chest/LootChest.java
@@ -7,7 +7,6 @@ import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
-import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import org.bukkit.Location;
@@ -22,7 +21,7 @@ import java.util.Iterator;
 import java.util.Objects;
 
 // Only usable with MythicMobs on
-public class LootChest implements AwardStrategy {
+public class LootChest extends AwardStrategy {
 
     private final String mythicMobName;
     private final SoundEffect dropSound;
@@ -73,14 +72,12 @@ public class LootChest implements AwardStrategy {
     private void dropItem(LootBundle bundle, Loot<?, ?> loot) {
         final LootContext context = bundle.getContext();
         dropSound.play(context.getLocation());
-        if (loot.award(context) instanceof Item item) {
+        if (awardSingle(bundle, loot) instanceof Item item) {
             final Vector direction = context.getLocation().clone().getDirection().clone().multiply(0.2 + Math.random() * 0.15);
             direction.rotateAroundY(Math.toRadians(Math.random() * 25));
             direction.setY(0.2 + Math.random() * 0.15);
             item.setVelocity(direction);
         }
-        // Fire event for loot awarded from chest
-        UtilServer.callEvent(new LootAwardedEvent(bundle, context, loot));
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/economy/DroppedCoinLoot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/economy/DroppedCoinLoot.java
@@ -18,7 +18,7 @@ public final class DroppedCoinLoot extends CoinLoot<Item> {
     }
 
     @Override
-    public Item award(LootContext context) {
+    protected Item award(LootContext context) {
         int amount = (minAmount == maxAmount) ? minAmount : ThreadLocalRandom.current().nextInt(minAmount, maxAmount + 1);
         ItemStack item = coinType.generateItem(amount);
         return context.getLocation().getWorld().dropItemNaturally(context.getLocation(), item);

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/economy/GivenCoinLoot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/economy/GivenCoinLoot.java
@@ -25,7 +25,7 @@ public final class GivenCoinLoot extends CoinLoot<Map<Player, Integer>> {
     }
 
     @Override
-    public Map<Player, Integer> award(LootContext context) {
+    protected Map<Player, Integer> award(LootContext context) {
         Map<Player, Integer> results = new HashMap<>();
         ClientManager clientManager = JavaPlugin.getPlugin(Core.class).getInjector().getInstance(ClientManager.class);
         context.getSession().getAudience().forEachAudience(audience -> {

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/entity/EntitySpawnLoot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/entity/EntitySpawnLoot.java
@@ -67,7 +67,7 @@ public final class EntitySpawnLoot extends Loot<EntityType, Entity> {
     }
 
     @Override
-    public Entity award(LootContext context) {
+    protected Entity award(LootContext context) {
         final Location location = context.getLocation();
 
         // Find the nearest player within 10 blocks to use as the launch target.

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/event/LootAwardedEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/event/LootAwardedEvent.java
@@ -1,28 +1,45 @@
 package me.mykindos.betterpvp.core.loot.event;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import me.mykindos.betterpvp.core.framework.events.CustomEvent;
 import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when loot is awarded from a {@link LootBundle}.
  * This event is fired for each individual {@link Loot} item awarded.
  */
 @EqualsAndHashCode(callSuper = true)
-@Data
+@Getter
 public class LootAwardedEvent extends CustomEvent {
 
     private final LootBundle bundle;
     private final LootContext context;
     private final Loot<?, ?> loot;
+    private final @Nullable Object rawResult;
 
-    public LootAwardedEvent(LootBundle bundle, LootContext context, Loot<?, ?> loot) {
+    public LootAwardedEvent(LootBundle bundle, LootContext context, Loot<?, ?> loot, @Nullable Object rawResult) {
         this.bundle = bundle;
         this.context = context;
         this.loot = loot;
+        this.rawResult = rawResult;
     }
 
+    /**
+     * Returns the value produced by {@link Loot#award(LootContext)} cast to the caller-expected type.
+     * <p>
+     * The cast is unchecked — callers must know the awarded reward type for the specific {@link Loot}
+     * subtype they are reacting to (e.g. {@code Item} for {@code DroppedItemLoot}, {@code Entity}
+     * for {@code EntitySpawnLoot}). A wrong inferred type fails at the use site with ClassCastException.
+     *
+     * @param <R> the expected reward type
+     * @return the awarded result, or {@code null} if the loot's award produced no value
+     */
+    @SuppressWarnings("unchecked")
+    public <R> @Nullable R getResult() {
+        return (R) rawResult;
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngine.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngine.java
@@ -79,7 +79,7 @@ public final class ExpressionEngine {
         for (Map.Entry<String, Object> e : extras.entrySet()) {
             jc.set(e.getKey(), e.getValue());
         }
-        jc.set(VAR_SOURCE, context.getSource());
+        jc.set(VAR_SOURCE, context.getSource().getId());
         jc.set(VAR_HISTORY_SIZE, context.getSession().getProgress().getHistory().size());
 
         try {

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/item/DroppedItemLoot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/item/DroppedItemLoot.java
@@ -26,7 +26,7 @@ public final class DroppedItemLoot extends ItemLoot<Item> {
      * @param context The context to award the loot to.
      */
     @Override
-    public Item award(LootContext context) {
+    protected Item award(LootContext context) {
         final Location location = context.getLocation();
         final ItemInstance reward = this.getReward();
         int count;

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/item/GivenItemLoot.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/item/GivenItemLoot.java
@@ -29,7 +29,7 @@ public final class GivenItemLoot extends ItemLoot<List<ItemStack>> {
      * @param context The context to award the loot to.
      */
     @Override
-    public List<ItemStack> award(LootContext context) {
+    protected List<ItemStack> award(LootContext context) {
         List<ItemStack> results = new ArrayList<>();
         context.getSession().getAudience().forEachAudience(audience -> {
             if (!(audience instanceof Player player)) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/listener/EntityLootController.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/listener/EntityLootController.java
@@ -7,6 +7,7 @@ import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
@@ -57,7 +58,9 @@ public class EntityLootController implements Listener {
             lootSession = sessionController.resolve(killer, lootTable, () -> LootSession.newSession(lootTable, killer));
         }
 
-        final LootContext context = new LootContext(lootSession, entity.getLocation(), entity.getName().replaceAll("§\\w", ""));
+        final String entityName = entity.getName().replaceAll("§\\w", "");
+        final LootContext context = new LootContext(lootSession, entity.getLocation(),
+                LootSource.of(entityName, "entity:" + entityName.toLowerCase().replace(' ', '_')));
         final LootBundle bundle = lootTable.generateLoot(context);
         bundle.award();
     }

--- a/core/src/main/java/me/mykindos/betterpvp/core/supplycrate/SupplyCrate.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/supplycrate/SupplyCrate.java
@@ -8,8 +8,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import me.mykindos.betterpvp.core.combat.cause.EnvironmentalDamageCause;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
@@ -36,8 +39,33 @@ public class SupplyCrate extends Projectile {
     @Getter(AccessLevel.NONE)
     private ActiveModel activeModel;
     private final SupplyCrateType type;
-    private Iterator<Loot<?, ?>> lootIterator;
+    private LootBundle lootBundle;
+    private final CrateAwardStrategy awardStrategy = new CrateAwardStrategy();
     private LootContext lootContext;
+
+    /**
+     * Captures the bundle's iterator on first award so the crate can drip-feed entries
+     * later via {@link #awardNextLoot()}, routed through {@link AwardStrategy#awardSingle}
+     * so {@link me.mykindos.betterpvp.core.loot.event.LootAwardedEvent} fires per entry.
+     */
+    private final class CrateAwardStrategy extends AwardStrategy {
+        private Iterator<Loot<?, ?>> iterator;
+
+        @Override
+        public void award(LootBundle b) {
+            this.iterator = b.iterator();
+        }
+
+        boolean hasNext() {
+            return iterator != null && iterator.hasNext();
+        }
+
+        void awardNext(LootBundle b) {
+            if (hasNext()) {
+                awardSingle(b, iterator.next());
+            }
+        }
+    }
 
     protected SupplyCrate(Player caller, Location location, SupplyCrateType type, long crateAliveTime) {
         super(caller, type.getSize(), location, crateAliveTime);
@@ -63,11 +91,15 @@ public class SupplyCrate extends Projectile {
     }
 
     public boolean hasLoot() {
-        return lootIterator != null && lootIterator.hasNext();
+        return awardStrategy.hasNext();
     }
 
-    public Loot<?, ?> consumeLoot() {
-        return lootIterator.next();
+    /**
+     * Awards the next loot entry through the strategy, which fires
+     * {@link me.mykindos.betterpvp.core.loot.event.LootAwardedEvent} per entry.
+     */
+    public void awardNextLoot() {
+        awardStrategy.awardNext(lootBundle);
     }
 
     @Override
@@ -183,9 +215,13 @@ public class SupplyCrate extends Projectile {
         // Award the loot and stop moving
         final LootTable lootTable = type.getLootTable();
         final LootSession session = LootSession.newSession(lootTable, Bukkit.getServer());
-        this.lootContext = new LootContext(session, this.location.clone().add(0, hitboxSize, 0), this.type.getDisplayName())
+        final String typeSlug = this.type.getDisplayName().toLowerCase().replace(' ', '_');
+        this.lootContext = new LootContext(session, this.location.clone().add(0, hitboxSize, 0),
+                LootSource.of(this.type.getDisplayName(), "supply_crate:" + typeSlug))
                 .withInput("player_count", Bukkit.getOnlinePlayers().size());
-        this.lootIterator = lootTable.generateLoot(lootContext).iterator();
+        this.lootBundle = lootTable.generateLoot(lootContext);
+        this.lootBundle.setAwardStrategy(this.awardStrategy);
+        this.lootBundle.award(); // strategy captures the iterator; no entries awarded yet
 
         // Sounds
         new SoundEffect(Sound.BLOCK_CHEST_LOCKED, 0.4f, 4.5f).play(location);

--- a/core/src/main/java/me/mykindos/betterpvp/core/supplycrate/SupplyCrateListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/supplycrate/SupplyCrateListener.java
@@ -92,7 +92,7 @@ public class SupplyCrateListener implements Listener {
             return false;
         }
 
-        supplyCrate.consumeLoot().award(supplyCrate.getLootContext());
+        supplyCrate.awardNextLoot();
         new SoundEffect(Sound.BLOCK_BEEHIVE_EXIT, 0.7f, 1f).play(supplyCrate.getLocation());
         return true;
     }

--- a/core/src/test/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngineTest.java
+++ b/core/src/test/java/me/mykindos/betterpvp/core/loot/expression/ExpressionEngineTest.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.core.loot.expression;
 
 import me.mykindos.betterpvp.core.loot.LootContext;
 import me.mykindos.betterpvp.core.loot.LootProgress;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -24,7 +25,7 @@ class ExpressionEngineTest {
         final Location location = new Location(world, 0, 0, 0);
         final LootSession session = Mockito.mock(LootSession.class);
         when(session.getProgress()).thenReturn(new LootProgress());
-        context = new LootContext(session, location, "test", Map.of(
+        context = new LootContext(session, location, LootSource.of("Test", "test"), Map.of(
                 "slayer_standing", 1,
                 "dungeon_score", 75,
                 "tier", "boss",

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/FishingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/FishingHandler.java
@@ -10,6 +10,7 @@ import me.mykindos.betterpvp.core.client.stats.impl.ClientStat;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
@@ -125,7 +126,7 @@ public class FishingHandler extends ProfessionHandler implements Reloadable {
 
     public @NotNull LootBundle getRandomLoot(Player player, Location location) {
         final LootSession session = sessionController.resolve(player, lootTable, () -> LootSession.newSession(lootTable, player));
-        final LootContext context = new LootContext(session, location, "Fishing");
+        final LootContext context = new LootContext(session, location, LootSource.of("Fishing", "fishing:catch"));
         return this.lootTable.generateLoot(context);
     }
 

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingCatchLootListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingCatchLootListener.java
@@ -1,0 +1,65 @@
+package me.mykindos.betterpvp.progression.profession.fishing.listener;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
+import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.progression.Progression;
+import me.mykindos.betterpvp.progression.profession.fishing.FishingHandler;
+import me.mykindos.betterpvp.progression.profession.fishing.fish.Fish;
+import me.mykindos.betterpvp.progression.profession.fishing.loot.FishLoot;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * Per-entry side effects for the regular fishing catch flow. The {@link FishingListener}
+ * generates the bundle and calls {@link me.mykindos.betterpvp.core.loot.LootBundle#award()};
+ * this listener observes each awarded entry and applies item reservation, despawn lifetime,
+ * and FishLoot bookkeeping.
+ */
+@BPvPListener
+@Singleton
+public class FishingCatchLootListener implements Listener {
+
+    private final Progression progression;
+    private final FishingHandler fishingHandler;
+
+    @Inject
+    public FishingCatchLootListener(Progression progression, FishingHandler fishingHandler) {
+        this.progression = progression;
+        this.fishingHandler = fishingHandler;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCatchLootAwarded(LootAwardedEvent event) {
+        if (!"fishing:catch".equals(event.getContext().getSource().getId())) return;
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+
+        if (event.getResult() instanceof Item item) {
+            UtilItem.reserveItem(item, player, 30);
+            UtilServer.runTaskLater(progression, () -> {
+                if (item.isValid()) {
+                    item.remove();
+                }
+            }, 20L * 60L);
+        }
+
+        if (event.getLoot() instanceof FishLoot fishLoot) {
+            final Fish fish = fishLoot.getCurrentFish();
+            if (fish != null) {
+                fishingHandler.addFish(player, fish);
+                UtilMessage.message(player, "Fishing", "You caught a <alt>%s</alt> (<alt2>%slb</alt2>)!",
+                        fish.getTypeName(), UtilFormat.formatNumber(fish.getWeight()));
+            }
+        }
+    }
+}

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/listener/FishingListener.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
-import me.mykindos.betterpvp.core.loot.LootContext;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
@@ -262,30 +261,9 @@ public class FishingListener implements Listener {
 
         splash(hook.getLocation());
 
-        // Award all loot entries in the bundle.
-        for (Loot<?, ?> loot : bundle) {
-            final LootContext context = bundle.getContext();
-            if (loot.award(context) instanceof Item item) {
-                UtilItem.reserveItem(item, player, 30);
-                UtilServer.runTaskLater(progression, () -> {
-                    if (item.isValid()) {
-                        item.remove();
-                    }
-                }, 20L * 60L);
-            }
-
-            if (loot instanceof FishLoot fishLoot) {
-                // rollFish() was already called in onFish CAUGHT_FISH before the event was fired.
-                // Skills may have mutated the weight. Now award and grant XP.
-                final Fish fish = fishLoot.getCurrentFish();
-                if (fish != null) {
-                    fishingHandler.addFish(player, fish);
-                    UtilMessage.message(player, "Fishing", "You caught a <alt>%s</alt> (<alt2>%slb</alt2>)!",
-                            fish.getTypeName(), UtilFormat.formatNumber(fish.getWeight()));
-                }
-            }
-
-        }
+        // Per-entry side effects (item reservation, lifetime, FishLoot bookkeeping) live in
+        // FishingCatchLootListener as LootAwardedEvent handlers filtered on source = "fishing:catch".
+        bundle.award();
 
         player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 5f, 0F);
         UtilServer.callEvent(new PlayerStopFishingEvent(player, bundle, PlayerStopFishingEvent.FishingResult.CATCH));

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/loot/FishLoot.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/fishing/loot/FishLoot.java
@@ -98,7 +98,7 @@ public final class FishLoot extends Loot<Fish, Item> {
      * @return The last dropped {@link Item} entity, or {@code null} if none was dropped.
      */
     @Override
-    public Item award(LootContext context) {
+    protected Item award(LootContext context) {
         final Audience audience = context.getSession().getAudience();
 
         Player player = null;

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
@@ -7,11 +7,12 @@ import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
@@ -21,6 +22,7 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingDoubleTreasureDropEvent;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingTreasureDropEvent;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
@@ -78,31 +80,23 @@ public class DoubleTreasureChanceListener implements Listener, Reloadable {
             return;
         }
 
-        for (Loot<?, ?> loot : bundle) {
-            awardTreasure(player, location, loot, bundle.getContext());
-        }
+        bundle.award();
     }
 
-    private LootBundle rollTreasure(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Fishing");
-        return treasureLootTable.generateLoot(context);
-    }
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDoubleTreasureLootAwarded(LootAwardedEvent event) {
+        if (!"fishing:treasure_double".equals(event.getContext().getSource().getId())) return;
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+        final LootContext context = event.getContext();
+        final Location location = context.getLocation();
+        final Object award = event.getRawResult();
 
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
-        final Object award = loot.award(context);
         if (award instanceof Item item) {
-            // Reel-in vector pointing from the hook back toward the player, mirroring the
-            // velocity Minecraft applies to the natural fishing-rod caught Item entity.
-            final Vector reelVelocity;
-            if (player != null) {
-                reelVelocity = player.getLocation().toVector()
-                        .subtract(context.getLocation().toVector())
-                        .multiply(0.1)
-                        .add(new Vector(0, 0.2, 0));
-            } else {
-                reelVelocity = new Vector(0, 0.2, 0);
-            }
+            final Vector reelVelocity = player.getLocation().toVector()
+                    .subtract(location.toVector())
+                    .multiply(0.1)
+                    .add(new Vector(0, 0.2, 0));
             if (item.isValid()) {
                 item.setVelocity(reelVelocity);
             }
@@ -110,6 +104,12 @@ public class DoubleTreasureChanceListener implements Listener, Reloadable {
         } else if (award instanceof ItemStack itemStack) {
             sendMessage(player, location, itemStack);
         }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, LootSource.of("Fishing", "fishing:treasure_double"));
+        return treasureLootTable.generateLoot(context);
     }
 
     private void sendMessage(Player player, Location location, ItemStack itemStack) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingtreasurechance/TreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingtreasurechance/TreasureChanceListener.java
@@ -7,11 +7,12 @@ import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
@@ -22,6 +23,7 @@ import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.fishing.event.FishingTreasureChanceCalculationEvent;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerCaughtFishEvent;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingTreasureDropEvent;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
@@ -82,39 +84,38 @@ public class TreasureChanceListener implements Listener, Reloadable {
             return;
         }
 
-        for (Loot<?, ?> loot : bundle) {
-            awardTreasure(player, location, loot, bundle.getContext());
+        bundle.award();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTreasureLootAwarded(LootAwardedEvent event) {
+        if (!"fishing:treasure".equals(event.getContext().getSource().getId())) return;
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+        final LootContext context = event.getContext();
+        final Location location = context.getLocation();
+        final Object award = event.getRawResult();
+
+        if (award instanceof Item item) {
+            // Reel-in vector pointing from the hook back toward the player, mirroring the
+            // velocity Minecraft applies to the natural fishing-rod caught Item entity.
+            final Vector reelVelocity = player.getLocation().toVector()
+                    .subtract(location.toVector())
+                    .multiply(0.1)
+                    .add(new Vector(0, 0.2, 0));
+            if (item.isValid()) {
+                item.setVelocity(reelVelocity);
+            }
+            sendMessage(player, location, item.getItemStack());
+        } else if (award instanceof ItemStack itemStack) {
+            sendMessage(player, location, itemStack);
         }
     }
 
     private LootBundle rollTreasure(Player player, Location location) {
         final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Fishing");
+        final LootContext context = new LootContext(session, location, LootSource.of("Fishing", "fishing:treasure"));
         return treasureLootTable.generateLoot(context);
-    }
-
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
-        final Object award = loot.award(context);
-        if (award instanceof Item item) {
-            // Reel-in vector pointing from the hook back toward the player, mirroring the
-            // velocity Minecraft applies to the natural fishing-rod caught Item entity.
-            final Vector reelVelocity;
-            if (player != null) {
-                reelVelocity = player.getLocation().toVector()
-                        .subtract(context.getLocation().toVector())
-                        .multiply(0.1)
-                        .add(new Vector(0, 0.2, 0));
-            } else {
-                reelVelocity = new Vector(0, 0.2, 0);
-            }
-            if (item.isValid()) {
-                item.setVelocity(reelVelocity);
-            }
-
-            sendMessage(player, location, item.getItemStack());
-        } else if (award instanceof ItemStack itemStack) {
-            sendMessage(player, location, itemStack);
-        }
     }
 
     private void sendMessage(Player player, Location location, ItemStack itemStack) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/nomoremobs/NoMoreMobsListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/nomoremobs/NoMoreMobsListener.java
@@ -6,15 +6,15 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.loot.entity.EntitySpawnLoot;
 import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.progression.utility.ProgressionNamespacedKeys;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.persistence.PersistentDataType;
 
 @BPvPListener
 @Singleton
@@ -29,24 +29,29 @@ public class NoMoreMobsListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSwimmerAwarded(LootAwardedEvent event) {
-        if (!"Fishing".equals(event.getContext().getSource())) return;
+        if (!event.getContext().getSource().getId().startsWith("fishing:")) return;
         if (!(event.getLoot() instanceof EntitySpawnLoot)) return;
 
         final Audience audience = event.getContext().getSession().getAudience();
         if (!(audience instanceof Player player)) return;
         if (skill.getSkillLevel(player) <= 0) return;
 
-        // The swimmer entity has just been spawned at context.getLocation() and tagged via PDC.
-        final Location location = event.getContext().getLocation();
-        location.getNearbyEntities(2.0, 2.0, 2.0).stream()
-                .filter(NoMoreMobsListener::isFishingSwimmer)
-                .forEach(Entity::remove);
+        final Entity swimmer = event.getResult();
+        if (swimmer == null) return;
+
+        UtilServer.runTaskLater(skill.getProgression(), () -> {
+            if (!swimmer.isValid()) return;
+            final Location at = swimmer.getLocation();
+            swimmer.remove();
+            Particle.CLOUD.builder()
+                    .location(at)
+                    .count(15)
+                    .offset(0.3, 0.3, 0.3)
+                    .extra(0.02)
+                    .receivers(48)
+                    .spawn();
+        }, 1L);
 
         UtilMessage.message(player, "Fishing", "<alt>No More Mobs</alt> removed nearby swimmers!");
-    }
-
-    private static boolean isFishingSwimmer(Entity entity) {
-        return entity.getPersistentDataContainer().getOrDefault(
-                ProgressionNamespacedKeys.FISHING_SWIMMER, PersistentDataType.BOOLEAN, false);
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/attributes/salvagerstouch/SalvagersTouchAttributeListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/attributes/salvagerstouch/SalvagersTouchAttributeListener.java
@@ -4,9 +4,10 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.framework.blocktag.BlockTagManager;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.Loot;
+import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
@@ -54,13 +55,19 @@ public class SalvagersTouchAttributeListener implements Listener {
         Player player = event.getPlayer();
         LootTable table = lootTableRegistry.loadLootTable(LOOT_TABLE_ID);
         LootSession session = sessionController.resolve(player, table, () -> LootSession.newSession(table, player));
-        LootContext context = new LootContext(session, block.getLocation().toCenterLocation(), "Mining");
+        LootContext context = new LootContext(session, block.getLocation().toCenterLocation(), LootSource.of("Mining", "mining:salvagers_touch"));
         LootBundle bundle = table.generateLoot(context);
-        for (Loot<?, ?> loot : bundle) {
-            final Object award = loot.award(context);
-            if (award instanceof Item item) {
-                event.getItems().add(item);
+        bundle.setAwardStrategy(new AwardStrategy() {
+            @Override
+            public void award(LootBundle b) {
+                for (var loot : b) {
+                    final Object award = awardSingle(b, loot);
+                    if (award instanceof Item item) {
+                        event.getItems().add(item);
+                    }
+                }
             }
-        }
+        });
+        bundle.award();
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/buriedcache/BuriedCache.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/buriedcache/BuriedCache.java
@@ -9,6 +9,7 @@ import com.google.inject.Singleton;
 import me.mykindos.betterpvp.core.framework.blocktag.BlockTagManager;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
@@ -97,9 +98,9 @@ public class BuriedCache extends ProfessionSkill {
             UtilServer.runTaskLater(getProgression(), () -> {
                 block.setType(Material.CHEST);
                 LootSession session = sessionController.resolve(player, table, () -> LootSession.newSession(table, player));
-                LootContext context = new LootContext(session, block.getLocation(), "Mining");
+                LootContext context = new LootContext(session, block.getLocation(), LootSource.of("Mining", "mining:buried_cache"));
                 LootBundle bundle = table.generateLoot(context);
-                BuriedCacheChestStrategy.fillChest(block, bundle, context);
+                BuriedCacheChestStrategy.fillChest(block, bundle);
                 activeCaches.put(block.getLocation(), block);
                 playAppearanceEffect(block.getLocation());
             }, 1L);

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/buriedcache/BuriedCacheChestStrategy.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/mining/buriedcache/BuriedCacheChestStrategy.java
@@ -1,8 +1,8 @@
 package me.mykindos.betterpvp.progression.profession.skill.mining.buriedcache;
 
+import me.mykindos.betterpvp.core.loot.AwardStrategy;
 import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
-import me.mykindos.betterpvp.core.loot.LootContext;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Item;
@@ -15,27 +15,33 @@ public final class BuriedCacheChestStrategy {
 
     private BuriedCacheChestStrategy() {}
 
-    public static void fillChest(Block block, LootBundle bundle, LootContext context) {
+    public static void fillChest(Block block, LootBundle bundle) {
         if (!(block.getState(false) instanceof Chest chest)) return;
 
-        Inventory inventory = chest.getBlockInventory();
-        for (Loot<?, ?> loot : bundle) {
-            Object awarded = loot.award(context);
-            ItemStack itemStack = null;
-            if (awarded instanceof Item worldItem) {
-                itemStack = worldItem.getItemStack().clone();
-                worldItem.remove();
-            } else if (awarded instanceof ItemStack is) {
-                itemStack = is;
-            }
+        final Inventory inventory = chest.getBlockInventory();
+        bundle.setAwardStrategy(new AwardStrategy() {
+            @Override
+            public void award(LootBundle b) {
+                for (Loot<?, ?> loot : b) {
+                    final Object awarded = awardSingle(b, loot);
+                    ItemStack itemStack = null;
+                    if (awarded instanceof Item worldItem) {
+                        itemStack = worldItem.getItemStack().clone();
+                        worldItem.remove();
+                    } else if (awarded instanceof ItemStack is) {
+                        itemStack = is;
+                    }
 
-            if (itemStack == null) continue;
+                    if (itemStack == null) continue;
 
-            Map<Integer, ItemStack> overflow = inventory.addItem(itemStack);
-            for (ItemStack leftover : overflow.values()) {
-                block.getWorld().dropItemNaturally(block.getLocation(), leftover);
+                    final Map<Integer, ItemStack> overflow = inventory.addItem(itemStack);
+                    for (ItemStack leftover : overflow.values()) {
+                        block.getWorld().dropItemNaturally(block.getLocation(), leftover);
+                    }
+                }
             }
-        }
+        });
+        bundle.award();
         chest.update();
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
@@ -7,11 +7,12 @@ import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
@@ -22,6 +23,7 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingDoubleTreasureDropEvent;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
@@ -80,19 +82,17 @@ public class WoodcuttingDoubleTreasureChanceListener implements Listener, Reload
             return;
         }
 
-        for (Loot<?, ?> loot : bundle) {
-            awardTreasure(player, location, loot, bundle.getContext());
-        }
+        bundle.award();
     }
 
-    private LootBundle rollTreasure(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Woodcutting");
-        return treasureLootTable.generateLoot(context);
-    }
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDoubleTreasureLootAwarded(LootAwardedEvent event) {
+        if (!"woodcutting:treasure_double".equals(event.getContext().getSource().getId())) return;
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+        final Location location = event.getContext().getLocation();
+        final Object award = event.getRawResult();
 
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
-        final Object award = loot.award(context);
         if (award instanceof Item item) {
             sendMessage(player, location, item.getItemStack());
         } else if (award instanceof ItemStack itemStack) {
@@ -105,6 +105,12 @@ public class WoodcuttingDoubleTreasureChanceListener implements Listener, Reload
                 sendMessage(player, location, itemStack);
             }
         }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, LootSource.of("Woodcutting", "woodcutting:treasure_double"));
+        return treasureLootTable.generateLoot(context);
     }
 
     private void sendMessage(Player player, Location location, ItemStack itemStack) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
@@ -7,11 +7,12 @@ import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.Loot;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
@@ -22,6 +23,7 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
@@ -80,19 +82,17 @@ public class WoodcuttingTreasureChanceListener implements Listener, Reloadable {
             return;
         }
 
-        for (Loot<?, ?> loot : bundle) {
-            awardTreasure(player, location, loot, bundle.getContext());
-        }
+        bundle.award();
     }
 
-    private LootBundle rollTreasure(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, "Woodcutting");
-        return treasureLootTable.generateLoot(context);
-    }
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTreasureLootAwarded(LootAwardedEvent event) {
+        if (!"woodcutting:treasure".equals(event.getContext().getSource().getId())) return;
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+        final Location location = event.getContext().getLocation();
+        final Object award = event.getRawResult();
 
-    private void awardTreasure(Player player, Location location, Loot<?, ?> loot, LootContext context) {
-        final Object award = loot.award(context);
         if (award instanceof Item item) {
             sendMessage(player, location, item.getItemStack());
         } else if (award instanceof ItemStack itemStack) {
@@ -105,6 +105,12 @@ public class WoodcuttingTreasureChanceListener implements Listener, Reloadable {
                 sendMessage(player, location, itemStack);
             }
         }
+    }
+
+    private LootBundle rollTreasure(Player player, Location location) {
+        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
+        final LootContext context = new LootContext(session, location, LootSource.of("Woodcutting", "woodcutting:treasure"));
+        return treasureLootTable.generateLoot(context);
     }
 
     private void sendMessage(Player player, Location location, ItemStack itemStack) {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/WoodcuttingHandler.java
@@ -13,9 +13,9 @@ import me.mykindos.betterpvp.core.framework.blocktag.BlockTagManager;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
+import me.mykindos.betterpvp.core.loot.LootSource;
 import me.mykindos.betterpvp.core.loot.LootTable;
 import me.mykindos.betterpvp.core.loot.LootTableRegistry;
-import me.mykindos.betterpvp.core.loot.item.DroppedItemLoot;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.stats.repository.LeaderboardManager;
@@ -202,20 +202,12 @@ public class WoodcuttingHandler extends ProfessionHandler implements Reloadable 
     }
 
     public void processLogDropReplacement(Player player, Block block) {
-        boolean isProtected = effectManager.hasEffect(player, EffectTypes.PROTECTION);
         LootTable logLootTable = logLootTables.get(block.getType().name());
         LootSession lootSession = sessionController.resolve(player, logLootTable, () -> LootSession.newSession(logLootTable, player));
-        LootContext lootContext = new LootContext(lootSession, block.getLocation(), "Woodcutting");
+        LootContext lootContext = new LootContext(lootSession, block.getLocation(), LootSource.of("Woodcutting", "woodcutting:log_drop"));
         LootBundle loot = logLootTable.generateLoot(lootContext);
-
-        loot.getLoot().stream().filter(lootType -> lootType instanceof DroppedItemLoot)
-                .forEach(lootType -> {
-                    DroppedItemLoot droppedItemLoot = (DroppedItemLoot) lootType;
-                    Item item = droppedItemLoot.award(lootContext);
-                    if (isProtected) {
-                        UtilItem.reserveItem(item, player, 10);
-                    }
-                });
+        // Per-entry reservation lives in WoodcuttingLogDropLootListener (LootAwardedEvent).
+        loot.award();
     }
 
     /**

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingLogDropLootListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/woodcutting/listener/WoodcuttingLogDropLootListener.java
@@ -1,0 +1,45 @@
+package me.mykindos.betterpvp.progression.profession.woodcutting.listener;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.effects.EffectManager;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
+import me.mykindos.betterpvp.core.loot.item.DroppedItemLoot;
+import me.mykindos.betterpvp.core.utilities.UtilItem;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * Reserves dropped log items for the chopping player when they have the Protection effect.
+ * Observes the {@link LootAwardedEvent} fired by the woodcutting log-drop replacement flow.
+ */
+@BPvPListener
+@Singleton
+public class WoodcuttingLogDropLootListener implements Listener {
+
+    private final EffectManager effectManager;
+
+    @Inject
+    public WoodcuttingLogDropLootListener(EffectManager effectManager) {
+        this.effectManager = effectManager;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onLogDropAwarded(LootAwardedEvent event) {
+        if (!"woodcutting:log_drop".equals(event.getContext().getSource().getId())) return;
+        if (!(event.getLoot() instanceof DroppedItemLoot)) return;
+        if (!(event.getResult() instanceof Item item)) return;
+
+        final Audience audience = event.getContext().getSession().getAudience();
+        if (!(audience instanceof Player player)) return;
+        if (!effectManager.hasEffect(player, EffectTypes.PROTECTION)) return;
+
+        UtilItem.reserveItem(item, player, 10);
+    }
+}


### PR DESCRIPTION
## Describe your changes

Fixes the No More Mobs fishing perk doing nothing, plus the underlying reason
listeners watching for loot drops could silently miss them.

- **No More Mobs now actually removes the swimmer caught from fishing**
  - Previously the underlying loot-awarded event never fired for it, so the perk had no signal to react to.
  - Swimmer is now removed cleanly with a small cloud puff one tick after it spawns.
- **Every loot drop now fires its loot-awarded event**
  - Some flows used to award loot directly and bypass the event, so listeners (perks, loggers, side effects) could silently miss drops.
  - Awarding is routed through a single chokepoint, so listeners always see every drop.
  - Affected flows: regular fishing catch, fishing treasure, double fishing treasure, woodcutting log drops, woodcutting treasure, double woodcutting treasure, mining buried cache, mining salvager's touch, supply crates, builder's box, mythic loot chests.
- **Legendary weapon broadcasts use one consistent message** regardless of where the drop came from (no more separate "caught by a fisherman" branch).
- **Loot sources now carry a display name + unique id pair** instead of a single string.
  - Lets listeners tell apart flows that share a label, e.g. regular fishing vs fishing treasure vs double treasure.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes.