### PR TITLE
Change Double Drops for Woodcutting/Fishing

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/loot/LootBundle.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/loot/LootBundle.java
@@ -47,6 +47,20 @@ public final class LootBundle implements Iterable<Loot<?, ?>> {
     }
 
     /**
+     * Returns a new {@link LootBundle} containing the same loot entries and award strategy
+     * as this bundle, but bound to the supplied {@code context}.
+     * <p>
+     * Useful when the same set of items should be awarded a second time under a different
+     * {@link LootSource} (e.g. a "double treasure" proc) without re-rolling the loot table.
+     *
+     * @param context the context to bind the duplicate bundle to
+     * @return a new bundle with the same loot and strategy
+     */
+    public @NotNull LootBundle duplicate(@NotNull LootContext context) {
+        return new LootBundle(context, awardStrategy, new java.util.ArrayList<>(loot));
+    }
+
+    /**
      * Returns an iterator over elements of type {@code T}.
      *
      * @return an Iterator.

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/fishing/attributes/fishingdoubletreasurechance/DoubleTreasureChanceListener.java
@@ -10,16 +10,11 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
 import me.mykindos.betterpvp.core.loot.LootSource;
-import me.mykindos.betterpvp.core.loot.LootTable;
-import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
-import me.mykindos.betterpvp.core.loot.session.LootSession;
-import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
-import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingDoubleTreasureDropEvent;
 import me.mykindos.betterpvp.progression.profession.fishing.event.PlayerFishingTreasureDropEvent;
 import net.kyori.adventure.audience.Audience;
@@ -40,28 +35,16 @@ import java.util.Optional;
 @BPvPListener
 @Singleton
 @CustomLog
-public class DoubleTreasureChanceListener implements Listener, Reloadable {
+public class DoubleTreasureChanceListener implements Listener {
 
     private final FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
-    private final LootTableRegistry lootTableRegistry;
-    private final LootSessionController sessionController;
     private final ItemFactory itemFactory;
-
-    private LootTable treasureLootTable;
 
     @Inject
     public DoubleTreasureChanceListener(FishingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute,
-                                        LootTableRegistry lootTableRegistry,
-                                        LootSessionController sessionController, ItemFactory itemFactory) {
+                                        ItemFactory itemFactory) {
         this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
-        this.lootTableRegistry = lootTableRegistry;
-        this.sessionController = sessionController;
         this.itemFactory = itemFactory;
-    }
-
-    @Override
-    public void reload() {
-        this.treasureLootTable = lootTableRegistry.loadLootTable("fishing_treasure_chance");
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -74,13 +57,20 @@ public class DoubleTreasureChanceListener implements Listener, Reloadable {
             return;
         }
 
-        LootBundle bundle = rollTreasure(player, location);
-        PlayerFishingDoubleTreasureDropEvent doubleEvent = UtilServer.callEvent(new PlayerFishingDoubleTreasureDropEvent(player, location, bundle));
+        final LootBundle original = event.getBundle();
+        final LootContext doubleContext = new LootContext(
+                original.getContext().getSession(),
+                location,
+                LootSource.of("Fishing", "fishing:treasure_double")
+        );
+        final LootBundle doubled = original.duplicate(doubleContext);
+
+        PlayerFishingDoubleTreasureDropEvent doubleEvent = UtilServer.callEvent(new PlayerFishingDoubleTreasureDropEvent(player, location, doubled));
         if (doubleEvent.isCancelled()) {
             return;
         }
 
-        bundle.award();
+        doubled.award();
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -106,16 +96,10 @@ public class DoubleTreasureChanceListener implements Listener, Reloadable {
         }
     }
 
-    private LootBundle rollTreasure(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, LootSource.of("Fishing", "fishing:treasure_double"));
-        return treasureLootTable.generateLoot(context);
-    }
-
     private void sendMessage(Player player, Location location, ItemStack itemStack) {
         final Component name;
         Optional<ItemInstance> itemInstanceOptional = itemFactory.fromItemStack(itemStack);
-        if(itemInstanceOptional.isPresent()) {
+        if (itemInstanceOptional.isPresent()) {
             ItemInstance itemInstance = itemInstanceOptional.get();
             name = itemInstance.getView().getName();
         } else {

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/doubletreasurechance/WoodcuttingDoubleTreasureChanceListener.java
@@ -7,22 +7,11 @@ import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
 import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.loot.LootBundle;
-import me.mykindos.betterpvp.core.loot.LootContext;
-import me.mykindos.betterpvp.core.loot.LootSource;
-import me.mykindos.betterpvp.core.loot.LootTable;
-import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
-import me.mykindos.betterpvp.core.loot.session.LootSession;
-import me.mykindos.betterpvp.core.loot.session.LootSessionController;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import me.mykindos.betterpvp.core.utilities.UtilServer;
-import me.mykindos.betterpvp.core.utilities.model.Reloadable;
-import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingDoubleTreasureDropEvent;
-import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -41,84 +30,56 @@ import java.util.Optional;
 @BPvPListener
 @Singleton
 @CustomLog
-public class WoodcuttingDoubleTreasureChanceListener implements Listener, Reloadable {
+public class WoodcuttingDoubleTreasureChanceListener implements Listener {
 
     private final WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute;
-    private final LootTableRegistry lootTableRegistry;
-    private final LootSessionController sessionController;
     private final ItemFactory itemFactory;
-
-    private LootTable treasureLootTable;
 
     @Inject
     public WoodcuttingDoubleTreasureChanceListener(WoodcuttingDoubleTreasureChanceAttribute doubleTreasureChanceAttribute,
-                                                   LootTableRegistry lootTableRegistry,
-                                                   LootSessionController sessionController,
                                                    ItemFactory itemFactory) {
         this.doubleTreasureChanceAttribute = doubleTreasureChanceAttribute;
-        this.lootTableRegistry = lootTableRegistry;
-        this.sessionController = sessionController;
         this.itemFactory = itemFactory;
     }
 
-    @Override
-    public void reload() {
-        this.treasureLootTable = lootTableRegistry.loadLootTable("woodcutting_treasure_chance");
-    }
-
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onTreasureDrop(PlayerWoodcuttingTreasureDropEvent event) {
-        final Player player = event.getPlayer();
-        final Location location = event.getLocation();
-
-        double chance = doubleTreasureChanceAttribute.getChance(player);
-        if (chance <= 0 || UtilMath.randDouble(0, 1) >= chance) {
-            return;
-        }
-
-        LootBundle bundle = rollTreasure(player, location);
-        PlayerWoodcuttingDoubleTreasureDropEvent doubleEvent = UtilServer.callEvent(new PlayerWoodcuttingDoubleTreasureDropEvent(player, location, bundle));
-        if (doubleEvent.isCancelled()) {
-            return;
-        }
-
-        bundle.award();
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onDoubleTreasureLootAwarded(LootAwardedEvent event) {
-        if (!"woodcutting:treasure_double".equals(event.getContext().getSource().getId())) return;
+    public void onTreasureLootAwarded(LootAwardedEvent event) {
+        if (!"woodcutting:treasure".equals(event.getContext().getSource().getId())) return;
         final Audience audience = event.getContext().getSession().getAudience();
         if (!(audience instanceof Player player)) return;
         final Location location = event.getContext().getLocation();
         final Object award = event.getRawResult();
 
+        double chance = doubleTreasureChanceAttribute.getChance(player);
+        boolean doubled = chance > 0 && UtilMath.randDouble(0, 1) < chance;
+
         if (award instanceof Item item) {
-            sendMessage(player, location, item.getItemStack());
+            if (doubled) {
+                UtilItem.insert(player, item.getItemStack().clone());
+            }
+            sendMessage(player, location, item.getItemStack(), doubled);
         } else if (award instanceof ItemStack itemStack) {
-            ItemStack finalItemStack = itemFactory.convertItemStack(itemStack).orElse(itemStack);
-            UtilItem.insert(player, finalItemStack);
-            sendMessage(player, location, finalItemStack);
+            ItemStack converted = itemFactory.convertItemStack(itemStack).orElse(itemStack);
+            if (doubled) {
+                UtilItem.insert(player, converted.clone());
+            }
+            sendMessage(player, location, converted, doubled);
         } else if (award instanceof List<?> itemStacks) {
             for (Object awardedItem : itemStacks) {
                 if (!(awardedItem instanceof ItemStack itemStack)) continue;
-                sendMessage(player, location, itemStack);
+                if (doubled) {
+                    UtilItem.insert(player, itemStack.clone());
+                }
+                sendMessage(player, location, itemStack, doubled);
             }
         }
     }
 
-    private LootBundle rollTreasure(Player player, Location location) {
-        final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
-        final LootContext context = new LootContext(session, location, LootSource.of("Woodcutting", "woodcutting:treasure_double"));
-        return treasureLootTable.generateLoot(context);
-    }
-
-    private void sendMessage(Player player, Location location, ItemStack itemStack) {
+    private void sendMessage(Player player, Location location, ItemStack itemStack, boolean doubled) {
         final Component name;
         Optional<ItemInstance> itemInstanceOptional = itemFactory.fromItemStack(itemStack);
-        if(itemInstanceOptional.isPresent()) {
-            ItemInstance itemInstance = itemInstanceOptional.get();
-            name = itemInstance.getView().getName();
+        if (itemInstanceOptional.isPresent()) {
+            name = itemInstanceOptional.get().getView().getName();
         } else {
             if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
                 name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
@@ -131,13 +92,16 @@ public class WoodcuttingDoubleTreasureChanceListener implements Listener, Reload
         TextComponent message = Component.text("You found ")
                 .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
                 .append(Component.text(" "))
-                .append(name)
-                .append(Component.text(" (doubled!)"));
+                .append(name);
+
+        if (doubled) {
+            message = message.append(Component.text(" (doubled!)"));
+        }
 
         UtilMessage.message(player, "Woodcutting", message);
 
-        log.info("{} found {}x {} from woodcutting treasure (doubled)", player.getName(), itemStack.getAmount(),
-                        itemStack.getType().name().toLowerCase())
+        log.info("{} found {}x {} from woodcutting treasure{}", player.getName(), itemStack.getAmount(),
+                        itemStack.getType().name().toLowerCase(), doubled ? " (doubled)" : "")
                 .addClientContext(player).addLocationContext(location).submit();
     }
 }

--- a/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
+++ b/progression/src/main/java/me/mykindos/betterpvp/progression/profession/skill/woodcutting/attributes/treasurechance/WoodcuttingTreasureChanceListener.java
@@ -2,10 +2,8 @@ package me.mykindos.betterpvp.progression.profession.skill.woodcutting.attribute
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.papermc.paper.datacomponent.DataComponentTypes;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.item.ItemFactory;
-import me.mykindos.betterpvp.core.item.ItemInstance;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.loot.LootBundle;
 import me.mykindos.betterpvp.core.loot.LootContext;
@@ -15,19 +13,14 @@ import me.mykindos.betterpvp.core.loot.LootTableRegistry;
 import me.mykindos.betterpvp.core.loot.event.LootAwardedEvent;
 import me.mykindos.betterpvp.core.loot.session.LootSession;
 import me.mykindos.betterpvp.core.loot.session.LootSessionController;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilItem;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
-import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.model.Reloadable;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerChopLogEvent;
 import me.mykindos.betterpvp.progression.profession.woodcutting.event.PlayerWoodcuttingTreasureDropEvent;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import org.bukkit.Location;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -35,8 +28,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 @BPvPListener
 @Singleton
@@ -90,19 +81,18 @@ public class WoodcuttingTreasureChanceListener implements Listener, Reloadable {
         if (!"woodcutting:treasure".equals(event.getContext().getSource().getId())) return;
         final Audience audience = event.getContext().getSession().getAudience();
         if (!(audience instanceof Player player)) return;
-        final Location location = event.getContext().getLocation();
         final Object award = event.getRawResult();
 
-        if (award instanceof Item item) {
-            sendMessage(player, location, item.getItemStack());
-        } else if (award instanceof ItemStack itemStack) {
+        // Deliver ItemStack awards into the player's inventory.
+        // Messaging is handled by WoodcuttingDoubleTreasureChanceListener so it can append
+        // "(doubled!)" when appropriate without sending two separate messages.
+        if (award instanceof ItemStack itemStack) {
             ItemStack finalItemStack = itemFactory.convertItemStack(itemStack).orElse(itemStack);
             UtilItem.insert(player, finalItemStack);
-            sendMessage(player, location, finalItemStack);
         } else if (award instanceof List<?> itemStacks) {
             for (Object awardedItem : itemStacks) {
                 if (!(awardedItem instanceof ItemStack itemStack)) continue;
-                sendMessage(player, location, itemStack);
+                UtilItem.insert(player, itemStack);
             }
         }
     }
@@ -111,32 +101,5 @@ public class WoodcuttingTreasureChanceListener implements Listener, Reloadable {
         final LootSession session = sessionController.resolve(player, treasureLootTable, () -> LootSession.newSession(treasureLootTable, player));
         final LootContext context = new LootContext(session, location, LootSource.of("Woodcutting", "woodcutting:treasure"));
         return treasureLootTable.generateLoot(context);
-    }
-
-    private void sendMessage(Player player, Location location, ItemStack itemStack) {
-        final Component name;
-        Optional<ItemInstance> itemInstanceOptional = itemFactory.fromItemStack(itemStack);
-        if(itemInstanceOptional.isPresent()) {
-            ItemInstance itemInstance = itemInstanceOptional.get();
-            name = itemInstance.getView().getName();
-        } else {
-            if (itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName()) {
-                name = Objects.requireNonNull(itemStack.getItemMeta().displayName());
-            } else {
-                name = Objects.requireNonNullElse(itemStack.getData(DataComponentTypes.ITEM_NAME),
-                        Component.translatable(itemStack.getType().translationKey()));
-            }
-        }
-
-        TextComponent message = Component.text("You found ")
-                .append(Component.text(UtilFormat.formatNumber(itemStack.getAmount())))
-                .append(Component.text(" "))
-                .append(name);
-
-        UtilMessage.message(player, "Woodcutting", message);
-
-        log.info("{} found {}x {} from woodcutting treasure", player.getName(), itemStack.getAmount(),
-                        itemStack.getType().name().toLowerCase())
-                .addClientContext(player).addLocationContext(location).submit();
     }
 }


### PR DESCRIPTION
Actually double the drops, it currently adds another roll.

 Only show the original drop with a (doubled) message at the end for drops that are doubled

Does not duplicate UUIDItems

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
