### PR TITLE
Fix bulk craft not respecting item stacks

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/database/connection/PostgresDatabaseConnection.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/database/connection/PostgresDatabaseConnection.java
@@ -22,6 +22,9 @@ public class PostgresDatabaseConnection implements IDatabaseConnection {
     public PostgresDatabaseConnection(Core core) {
         this.core = core;
         configureHikari("core.database.global");
+        // Run core migrations immediately so the schema exists before any other beans
+        // (e.g. PropertyMapper) attempt to query the database during Guice injection.
+        runDatabaseMigrations(getClass().getClassLoader(), "classpath:core-migrations/postgres/", "global");
     }
 
     private void configureHikari(String configPath) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/recipe/resolver/HasIngredientsParameter.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/recipe/resolver/HasIngredientsParameter.java
@@ -118,21 +118,21 @@ public class HasIngredientsParameter implements LookupParameter {
             amount++;
         }
 
-        // backpropagate the recipes until all stack sizes are respected
+        // Cap amount by how many crafts' worth of each ingredient can physically fit in one matrix slot.
+        // A recipe slot holding N items of stack-size S can represent at most floor(S/N) crafts.
+        // We must use the item's effective max stack size: prefer the explicit DataComponent value,
+        // then fall back to ItemStack.getMaxStackSize() so items whose stack size is set by their
+        // Material (e.g. stack-size-1 unique items without an explicit component) are handled correctly.
         final RecipeIngredient[] recipeContents = recipe.getIngredients().values().toArray(new RecipeIngredient[0]);
-        outer:
-        while (amount > 0) {
-            for (RecipeIngredient ingredient : recipeContents) {
-                final ItemStack itemStack = ingredient.getBaseItem().getModel();
-
-                final Integer stackSize = itemStack.getData(DataComponentTypes.MAX_STACK_SIZE);
-                if (stackSize != null && amount > stackSize) {
-                    amount--;
-                    continue outer;
-                }
+        for (RecipeIngredient ingredient : recipeContents) {
+            if (ingredient.getAmount() <= 0) continue;
+            final ItemStack itemStack = ingredient.getBaseItem().getModel();
+            final Integer explicitStackSize = itemStack.getData(DataComponentTypes.MAX_STACK_SIZE);
+            final int stackSize = explicitStackSize != null ? explicitStackSize : itemStack.getMaxStackSize();
+            final int maxCraftsForIngredient = stackSize / ingredient.getAmount();
+            if (maxCraftsForIngredient < amount) {
+                amount = maxCraftsForIngredient;
             }
-
-            break;
         }
         return amount;
     }


### PR DESCRIPTION
Fix bulk craft not respecting item stacks. Fix issue with migrations not running in the proper order on a fresh DB


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes.
