### PR TITLE
Tree Respawning

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnCommand.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnCommand.java
@@ -1,0 +1,131 @@
+package me.mykindos.betterpvp.clans.world;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.ICommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.world.model.BPvPWorld;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+/**
+ * Admin command for manually queuing chunks for tree-respawn evaluation.
+ *
+ * <p>Usage:
+ * <ul>
+ *   <li>{@code /treerespawn} – queues the chunk the sender is currently standing in.</li>
+ *   <li>{@code /treerespawn <chunkX> <chunkZ>} – queues a specific chunk by its chunk
+ *       coordinates (the chunk must already be loaded).</li>
+ *   <li>{@code /treerespawn status} – shows the current queue size.</li>
+ * </ul>
+ *
+ * <p>Required rank defaults to {@code ADMIN} (set in {@code command.treerespawn.requiredRank}
+ * inside the Clans plugin config).
+ */
+@Singleton
+public class TreeRespawnCommand extends Command {
+
+    private final TreeRespawnManager treeRespawnManager;
+
+    @Inject
+    public TreeRespawnCommand(TreeRespawnManager treeRespawnManager) {
+        this.treeRespawnManager = treeRespawnManager;
+    }
+
+    @Override
+    public String getName() {
+        return "treerespawn";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Queues a chunk for tree-respawn evaluation";
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        if (argCount == 1) return "POSITION_X"; // chunkX suggestion
+        if (argCount == 2) return "POSITION_Z"; // chunkZ suggestion
+        return ICommand.ArgumentType.NONE.name();
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        World world = Bukkit.getWorld(BPvPWorld.MAIN_WORLD_NAME);
+        if (world == null) {
+            UtilMessage.simpleMessage(player, "TreeRespawn", "Main world not found.");
+            return;
+        }
+
+        // /treerespawn status
+        if (args.length == 1 && args[0].equalsIgnoreCase("status")) {
+            UtilMessage.simpleMessage(player, "TreeRespawn",
+                    "Queue size: <yellow>%d</yellow> | Enabled: <yellow>%s</yellow>",
+                    treeRespawnManager.getQueueSize(),
+                    treeRespawnManager.isEnabled());
+            return;
+        }
+
+        // /treerespawn <chunkX> <chunkZ>
+        if (args.length == 2) {
+            int chunkX;
+            int chunkZ;
+            try {
+                chunkX = Integer.parseInt(args[0]);
+                chunkZ = Integer.parseInt(args[1]);
+            } catch (NumberFormatException e) {
+                UtilMessage.simpleMessage(player, "TreeRespawn",
+                        "Usage: <white>/treerespawn [chunkX chunkZ]</white>");
+                return;
+            }
+
+            if (!world.isChunkLoaded(chunkX, chunkZ)) {
+                UtilMessage.simpleMessage(player, "TreeRespawn",
+                        "Chunk <yellow>%d, %d</yellow> is not loaded. Only loaded chunks can be queued.",
+                        chunkX, chunkZ);
+                return;
+            }
+
+            Chunk chunk = world.getChunkAt(chunkX, chunkZ);
+            queueAndReport(player, chunk);
+            return;
+        }
+
+        // /treerespawn  (no args – use the player's current chunk)
+        if (args.length == 0) {
+            if (!player.getWorld().getName().equalsIgnoreCase(BPvPWorld.MAIN_WORLD_NAME)) {
+                UtilMessage.simpleMessage(player, "TreeRespawn",
+                        "You must be in the main world to queue your current chunk.");
+                return;
+            }
+            queueAndReport(player, player.getChunk());
+            return;
+        }
+
+        UtilMessage.simpleMessage(player, "TreeRespawn",
+                "Usage: <white>/treerespawn [chunkX chunkZ | status]</white>");
+    }
+
+    private void queueAndReport(Player player, Chunk chunk) {
+        int sizeBefore = treeRespawnManager.getQueueSize();
+        treeRespawnManager.queueChunk(chunk);
+        int sizeAfter = treeRespawnManager.getQueueSize();
+
+        if (sizeAfter > sizeBefore) {
+            UtilMessage.simpleMessage(player, "TreeRespawn",
+                    "Chunk <yellow>%d, %d</yellow> queued for tree-respawn evaluation. Queue size: <yellow>%d</yellow>.",
+                    chunk.getX(), chunk.getZ(), sizeAfter);
+        } else {
+            UtilMessage.simpleMessage(player, "TreeRespawn",
+                    "Chunk <yellow>%d, %d</yellow> was <red>not queued</red> "
+                            + "(already queued, claimed, queue full, or system disabled).",
+                    chunk.getX(), chunk.getZ());
+        }
+    }
+}
+
+

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnListener.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnListener.java
@@ -1,0 +1,88 @@
+package me.mykindos.betterpvp.clans.world;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.world.model.BPvPWorld;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.event.Listener;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Schedules and drives the {@link TreeRespawnManager}.
+ *
+ * <h3>Two-phase approach</h3>
+ * <ol>
+ *   <li><b>Scanner</b> (every 5 minutes) – iterates all currently loaded chunks in
+ *       the main world and enqueues any unclaimed chunk that needs evaluation.</li>
+ *   <li><b>Worker</b> (every 1 second) – dequeues and processes exactly one chunk,
+ *       keeping the main-thread impact to an absolute minimum.</li>
+ * </ol>
+ *
+ * <h3>Performance notes</h3>
+ * <ul>
+ *   <li>Chunks are <b>never force-loaded</b>; we only ever visit chunks that the
+ *       server has already loaded for player activity.</li>
+ *   <li>Processing is deliberately throttled to one chunk per second so that the
+ *       cumulative cost of block reads and (occasional) tree generation is spread
+ *       out and never spikes the server TPS.</li>
+ *   <li>The queue caps at {@code trees.respawn.max-queue-size} entries to bound
+ *       memory when many chunks are loaded simultaneously.</li>
+ * </ul>
+ */
+@BPvPListener
+@Singleton
+public class TreeRespawnListener implements Listener {
+
+    private final TreeRespawnManager treeRespawnManager;
+
+    @Inject
+    public TreeRespawnListener(TreeRespawnManager treeRespawnManager) {
+        this.treeRespawnManager = treeRespawnManager;
+    }
+
+    /**
+     * Every 5 minutes: scan all loaded chunks in the main world and add unclaimed,
+     * potentially deforested chunks to the respawn queue.
+     *
+     * <p>The chunk array is <b>shuffled</b> before iteration so that when the queue
+     * fills up ({@code trees.respawn.max-queue-size}), every chunk has an equal
+     * chance of being selected — preventing the same set of "early-in-iteration-order"
+     * chunks from always winning while later ones are starved indefinitely.
+     */
+    @UpdateEvent(delay = 300_000L) // 5 minutes
+    public void scanLoadedChunks() {
+        if (!treeRespawnManager.isEnabled()) return;
+
+        World world = Bukkit.getWorld(BPvPWorld.MAIN_WORLD_NAME);
+        if (world == null) return;
+
+        // Shuffle so every chunk gets a fair shot when the queue cap is hit
+        List<Chunk> chunks = Arrays.asList(world.getLoadedChunks());
+        Collections.shuffle(chunks);
+
+        for (Chunk chunk : chunks) {
+            treeRespawnManager.queueChunk(chunk);
+        }
+    }
+
+    /**
+     * Every 1 second: process one chunk from the queue.
+     *
+     * <p>One chunk per second means that even a full queue of 200 chunks is
+     * drained in ~3 minutes, well within the 5-minute scan cycle.
+     */
+    @UpdateEvent(delay = 1_000L) // 1 second
+    public void processNextChunk() {
+        treeRespawnManager.processNext();
+    }
+}
+
+
+

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnManager.java
@@ -1,0 +1,344 @@
+package me.mykindos.betterpvp.clans.world;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import lombok.Getter;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.core.config.Config;
+import me.mykindos.betterpvp.core.world.model.BPvPWorld;
+import org.bukkit.Chunk;
+import org.bukkit.HeightMap;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.TreeType;
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+import org.bukkit.block.Block;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Manages the periodic respawning of trees in wilderness chunks.
+ *
+ * <p>Design goals:
+ * <ul>
+ *   <li>Never force-load unloaded chunks – only operate on already-loaded chunks.</li>
+ *   <li>Never touch any chunk owned by a clan (including admin clans).</li>
+ *   <li>Process one chunk per second to keep main-thread impact negligible.</li>
+ *   <li>Use a chunk-coordinate-seeded {@link Random} so that the same chunk always
+ *       gets the same tree type/position (deterministic, seed-based behavior).</li>
+ * </ul>
+ */
+@CustomLog
+@Singleton
+public class TreeRespawnManager {
+
+    // -----------------------------------------------------------------------
+    // Dependencies
+    // -----------------------------------------------------------------------
+
+    private final ClanManager clanManager;
+
+    // -----------------------------------------------------------------------
+    // Config
+    // -----------------------------------------------------------------------
+
+    /**
+     * Master on/off switch.  Set to {@code false} to disable the entire system.
+     */
+    @Getter
+    @Config(path = "trees.respawn.enabled", defaultValue = "true")
+    @Inject
+    private boolean enabled;
+
+    /**
+     * Minimum number of log-column samples (out of 16 sampled positions) that must
+     * be present in a chunk before the system considers the chunk "forested enough"
+     * and skips it.  A lower value means only very barren chunks are targeted.
+     *
+     * <p>The chunk is sampled at a 4×4 grid (16 positions total).  Each position
+     * contributes +1 if any log or wood block exists within 10 blocks above the
+     * surface at that x/z.  Typical untouched-forest chunks score 6–12.
+     */
+    @Config(path = "trees.respawn.min-log-count", defaultValue = "2")
+    @Inject
+    private int minLogCount;
+
+    /**
+     * Maximum number of chunks held in the pending queue at any one time.
+     * Prevents unbounded memory growth when many chunks are loaded.
+     */
+    @Config(path = "trees.respawn.max-queue-size", defaultValue = "200")
+    @Inject
+    private int maxQueueSize;
+
+    // -----------------------------------------------------------------------
+    // Queue state
+    // -----------------------------------------------------------------------
+
+    /** Chunks waiting to be evaluated for tree respawn. */
+    private final Queue<Chunk> pendingChunks = new ArrayDeque<>();
+
+    /** Tracks the keys of chunks currently in {@link #pendingChunks} for O(1) dedup. */
+    private final Set<Long> queuedChunkKeys = new HashSet<>();
+
+    // -----------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------
+
+    @Inject
+    public TreeRespawnManager(ClanManager clanManager) {
+        this.clanManager = clanManager;
+    }
+
+
+    /** Returns the number of chunks currently waiting in the processing queue. */
+    public int getQueueSize() {
+        return pendingChunks.size();
+    }
+
+    /**
+     * Attempts to add {@code chunk} to the processing queue.
+     *
+     * <p>The chunk is silently rejected if:
+     * <ul>
+     *   <li>the system is disabled,</li>
+     *   <li>the queue is full,</li>
+     *   <li>the chunk is already queued, or</li>
+     *   <li>the chunk belongs to a clan.</li>
+     * </ul>
+     *
+     * @param chunk the chunk to evaluate
+     */
+    public void queueChunk(Chunk chunk) {
+        if (!enabled) return;
+        if (pendingChunks.size() >= maxQueueSize) return;
+
+        long key = chunkKey(chunk);
+        if (queuedChunkKeys.contains(key)) return;
+        if (clanManager.getClanByChunk(chunk).isPresent()) return;
+
+        queuedChunkKeys.add(key);
+        pendingChunks.offer(chunk);
+    }
+
+    /**
+     * Dequeues one chunk and processes it.
+     * <b>Must be called on the main server thread.</b>
+     */
+    public void processNext() {
+        if (!enabled) return;
+
+        Chunk chunk = pendingChunks.poll();
+        if (chunk == null) return;
+
+        queuedChunkKeys.remove(chunkKey(chunk));
+        processChunk(chunk);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal logic
+    // -----------------------------------------------------------------------
+
+    /**
+     * Evaluates one chunk and, if it is deforested enough and has a valid spot,
+     * spawns one tree.
+     */
+    private void processChunk(Chunk chunk) {
+        World world = chunk.getWorld();
+
+        // Only operate on the main overworld
+        if (!world.getName().equalsIgnoreCase(BPvPWorld.MAIN_WORLD_NAME)) return;
+
+        // Confirm the chunk is still loaded (it may have unloaded while queued)
+        if (!world.isChunkLoaded(chunk.getX(), chunk.getZ())) return;
+
+        // Re-check territory claim (claim may have changed while chunk was queued)
+        if (clanManager.getClanByChunk(chunk).isPresent()) return;
+
+        // Count existing log-columns in the chunk sample
+        int logCount = countLogColumnsInChunk(chunk);
+        if (logCount >= minLogCount) return; // chunk is forested enough
+
+        // Deterministic RNG seeded by world seed + chunk coordinates
+        long seed = world.getSeed() ^ ((long) chunk.getX() << 32) ^ (chunk.getZ() & 0xFFFFFFFFL);
+        Random random = new Random(seed);
+
+        // Find a valid planting spot
+        Location spot = findValidTreeSpot(chunk, random);
+        if (spot == null) return; // no valid spot exists (terrain altered, etc.)
+
+        // Determine tree type from biome at that spot
+        Biome biome = world.getBiome(spot.getBlockX(), spot.getBlockY(), spot.getBlockZ());
+        TreeType treeType = getTreeTypeForBiome(biome, random);
+
+        // generateTree(Location, Random, TreeType) is the non-deprecated overload in Paper 1.21.6+
+        boolean spawned = world.generateTree(spot, random, treeType);
+        if (spawned) {
+            log.info("TreeRespawn: spawned {} at {},{},{} (chunk {},{}, logSample={})",
+                    treeType,
+                    spot.getBlockX(), spot.getBlockY(), spot.getBlockZ(),
+                    chunk.getX(), chunk.getZ(),
+                    logCount).submit();
+        }
+    }
+
+    /**
+     * Samples a 4×4 grid across the chunk (16 positions, every 4 blocks in X and Z)
+     * and counts how many sampled columns contain at least one log or wood block
+     * within 10 blocks above the surface.
+     *
+     * <p>This is intentionally cheap: we only read 16×10 = 160 block types maximum.
+     */
+    private int countLogColumnsInChunk(Chunk chunk) {
+        World world = chunk.getWorld();
+        int baseX = chunk.getX() << 4;
+        int baseZ = chunk.getZ() << 4;
+        int count = 0;
+
+        for (int dx = 0; dx < 16; dx += 4) {
+            for (int dz = 0; dz < 16; dz += 4) {
+                int wx = baseX + dx;
+                int wz = baseZ + dz;
+                int surfaceY = world.getHighestBlockYAt(wx, wz, HeightMap.MOTION_BLOCKING_NO_LEAVES);
+                for (int dy = 0; dy <= 10; dy++) {
+                    Block block = world.getBlockAt(wx, surfaceY + dy, wz);
+                    if (isLog(block.getType())) {
+                        count++;
+                        break; // only count one per column
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Tries up to 8 random positions within the chunk (using the deterministic
+     * {@code random}) and returns the first location that is:
+     * <ul>
+     *   <li>a natural tree-compatible surface block (grass, dirt, podzol, etc.), and</li>
+     *   <li>has full sky light (15) at the block immediately above it.</li>
+     * </ul>
+     *
+     * @return a planting {@link Location}, or {@code null} if no valid spot was found
+     *         after 8 attempts (e.g., the terrain has been built over or is fully shaded)
+     */
+    private Location findValidTreeSpot(Chunk chunk, Random random) {
+        World world = chunk.getWorld();
+        int baseX = chunk.getX() << 4;
+        int baseZ = chunk.getZ() << 4;
+
+        for (int attempt = 0; attempt < 8; attempt++) {
+            int wx = baseX + random.nextInt(16);
+            int wz = baseZ + random.nextInt(16);
+
+            int surfaceY = world.getHighestBlockYAt(wx, wz, HeightMap.MOTION_BLOCKING_NO_LEAVES);
+            Block surface = world.getBlockAt(wx, surfaceY, wz);
+            Block above = world.getBlockAt(wx, surfaceY + 1, wz);
+
+            if (!isValidTreeBase(surface.getType())) continue;
+            if (!above.getType().isAir()) continue;
+            if (above.getLightFromSky() < 15) continue;
+
+            // Return the block *on top of* the surface block (where the sapling would be)
+            return new Location(world, wx, surfaceY + 1, wz);
+        }
+
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Encodes chunk coordinates into a single {@code long} for fast dedup. */
+    private static long chunkKey(Chunk chunk) {
+        return ((long) chunk.getX() << 32) | (chunk.getZ() & 0xFFFFFFFFL);
+    }
+
+    private static boolean isLog(Material material) {
+        String name = material.name();
+        return name.endsWith("_LOG") || name.endsWith("_WOOD");
+    }
+
+    private static boolean isValidTreeBase(Material material) {
+        return switch (material) {
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, ROOTED_DIRT, MYCELIUM -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Maps a {@link Biome} to a {@link TreeType}.
+     *
+     * <p>{@code Biome} is a registry interface in Paper 1.21+ (not an enum), so a
+     * switch expression cannot be used.  Instead, every comparison is written as
+     * {@code biome == Biome.CONSTANT}, which gives a <b>compile-time error</b> if
+     * Paper ever renames or removes a constant — the same "hard-fail" guarantee as
+     * an exhaustive enum switch.
+     */
+    private static TreeType getTreeTypeForBiome(Biome biome, Random random) {
+        // --- Birch ---
+        if (biome == Biome.BIRCH_FOREST || biome == Biome.OLD_GROWTH_BIRCH_FOREST)
+            return random.nextBoolean() ? TreeType.BIRCH : TreeType.TALL_BIRCH;
+
+        // --- Dark oak ---
+        if (biome == Biome.DARK_FOREST)
+            return TreeType.DARK_OAK;
+
+        // --- Jungle ---
+        if (biome == Biome.JUNGLE || biome == Biome.BAMBOO_JUNGLE)
+            return random.nextInt(3) == 0 ? TreeType.JUNGLE : TreeType.SMALL_JUNGLE;
+        if (biome == Biome.SPARSE_JUNGLE)
+            return TreeType.SMALL_JUNGLE;
+
+        // --- Mangrove ---
+        if (biome == Biome.MANGROVE_SWAMP)
+            return TreeType.MANGROVE;
+
+        // --- Cherry ---
+        if (biome == Biome.CHERRY_GROVE)
+            return TreeType.CHERRY;
+
+        // --- Pale oak (added 1.21.4) ---
+        if (biome == Biome.PALE_GARDEN)
+            return TreeType.PALE_OAK;
+
+        // --- Spruce / taiga ---
+        if (biome == Biome.OLD_GROWTH_PINE_TAIGA || biome == Biome.OLD_GROWTH_SPRUCE_TAIGA)
+            return random.nextBoolean() ? TreeType.MEGA_REDWOOD : TreeType.REDWOOD;
+        if (biome == Biome.TAIGA || biome == Biome.SNOWY_TAIGA
+                || biome == Biome.GROVE || biome == Biome.SNOWY_SLOPES)
+            return TreeType.REDWOOD;
+
+        // --- Acacia ---
+        if (biome == Biome.SAVANNA || biome == Biome.SAVANNA_PLATEAU || biome == Biome.WINDSWEPT_SAVANNA)
+            return TreeType.ACACIA;
+
+        // --- Swamp oak ---
+        if (biome == Biome.SWAMP)
+            return TreeType.SWAMP;
+
+        // --- Forest oak / birch mix ---
+        if (biome == Biome.FOREST || biome == Biome.FLOWER_FOREST || biome == Biome.WINDSWEPT_FOREST)
+            return random.nextBoolean() ? TreeType.TREE : TreeType.BIRCH;
+
+        // --- Open overworld biomes (lone oak) ---
+        if (biome == Biome.PLAINS || biome == Biome.SUNFLOWER_PLAINS || biome == Biome.MEADOW
+                || biome == Biome.WINDSWEPT_HILLS || biome == Biome.WINDSWEPT_GRAVELLY_HILLS)
+            return TreeType.TREE;
+
+        // --- All remaining biomes (desert, ocean, nether, end, caves, etc.).
+        //     The spot-validity check (grass/dirt + sky-light 15) prevents trees
+        //     from actually spawning in these biomes anyway. ---
+        return random.nextInt(4) == 0 ? TreeType.BIG_TREE : TreeType.TREE;
+    }
+}
+

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/TreeRespawnManager.java
@@ -16,6 +16,7 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Queue;
@@ -81,8 +82,16 @@ public class TreeRespawnManager {
     // Queue state
     // -----------------------------------------------------------------------
 
+    /**
+     * Pairs a pre-computed chunk key with a weak reference to the chunk so that
+     * (a) the queue never prevents an unloaded chunk from being garbage-collected,
+     * and (b) the key can still be removed from {@link #queuedChunkKeys} even after
+     * the referent has been collected.
+     */
+    private record ChunkRef(long key, WeakReference<Chunk> ref) {}
+
     /** Chunks waiting to be evaluated for tree respawn. */
-    private final Queue<Chunk> pendingChunks = new ArrayDeque<>();
+    private final Queue<ChunkRef> pendingChunks = new ArrayDeque<>();
 
     /** Tracks the keys of chunks currently in {@link #pendingChunks} for O(1) dedup. */
     private final Set<Long> queuedChunkKeys = new HashSet<>();
@@ -124,7 +133,7 @@ public class TreeRespawnManager {
         if (clanManager.getClanByChunk(chunk).isPresent()) return;
 
         queuedChunkKeys.add(key);
-        pendingChunks.offer(chunk);
+        pendingChunks.offer(new ChunkRef(key, new WeakReference<>(chunk)));
     }
 
     /**
@@ -134,10 +143,15 @@ public class TreeRespawnManager {
     public void processNext() {
         if (!enabled) return;
 
-        Chunk chunk = pendingChunks.poll();
-        if (chunk == null) return;
+        ChunkRef entry = pendingChunks.poll();
+        if (entry == null) return;
 
-        queuedChunkKeys.remove(chunkKey(chunk));
+        // Always remove the key first so the slot is freed regardless of GC state
+        queuedChunkKeys.remove(entry.key());
+
+        Chunk chunk = entry.ref().get();
+        if (chunk == null) return; // chunk was unloaded and GC'd while queued
+
         processChunk(chunk);
     }
 


### PR DESCRIPTION
Add a system that periodically respawns trees. This only happens in wilderness (no claimed chunk), only if there are not enough trees, and only if it is a valid spot to spawn a tree. Trees will spawn periodically over time, as they get queued into a limited 200 chunk queue. Only uses loaded chunks.

This is intended to replace trees that are felled by players in wilderness and not replanted. This allows players to then re-fell them to get wood and xp.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.
