### PR TITLE
Add zone discovery with first-visit notifications

### DIFF
--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/zone/ClanZoneProvider.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/zone/ClanZoneProvider.java
@@ -16,6 +16,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -48,6 +50,11 @@ public class ClanZoneProvider implements ZoneProvider, Listener {
         return clanManager.getClanByChunk(location.getChunk())
                 .stream()
                 .map(this::zoneFor);
+    }
+
+    @Override
+    public @NotNull Collection<Zone> zones() {
+        return List.copyOf(zones.values());
     }
 
     /**

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/world/veloran/gateway/SunderedGate.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/world/veloran/gateway/SunderedGate.java
@@ -18,6 +18,7 @@ import me.mykindos.betterpvp.core.world.zone.RegionBounds;
 import me.mykindos.betterpvp.core.world.zone.Zone;
 import me.mykindos.betterpvp.core.world.zone.ZoneRuleContainer;
 import me.mykindos.betterpvp.core.world.zone.Zones;
+import me.mykindos.betterpvp.core.world.zone.discovery.ZoneDiscovery;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -131,6 +132,8 @@ public class SunderedGate implements WorldContent {
                 .tag(TAG)
                 .tag(Zones.NO_BUILD)
                 .rules(rules)
+                // Defaults render "Area Discovered" / the zone name / an "Unlocked area" line with a chime.
+                .discovery(ZoneDiscovery.builder().build())
                 .build();
     }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/AbstractZoneDiscoverySubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/AbstractZoneDiscoverySubCommand.java
@@ -1,0 +1,80 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Inject;
+import me.mykindos.betterpvp.core.Core;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import me.mykindos.betterpvp.core.world.zone.ZoneManager;
+import me.mykindos.betterpvp.core.world.zone.discovery.ZoneDiscoveryService;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Shared base for the {@code /zone discovery} leaf subcommands: holds the injected services, resolves player and zone
+ * arguments, and tab-completes online players ({@code PLAYER}) and discoverable zone keys ({@code ZONE}).
+ */
+abstract class AbstractZoneDiscoverySubCommand extends Command {
+
+    private static final String ZONE = "ZONE";
+
+    @Inject
+    protected ClientManager clientManager;
+    @Inject
+    protected ZoneDiscoveryService discoveryService;
+    @Inject
+    protected ZoneManager zoneManager;
+    @Inject
+    protected Core core;
+
+    @Override
+    public List<String> processTabComplete(CommandSender sender, String[] args) {
+        final List<String> completions = new ArrayList<>();
+        if (args.length == 0) {
+            return completions;
+        }
+        final String arg = args[args.length - 1].toLowerCase();
+        switch (getArgumentType(args.length)) {
+            case "PLAYER" -> Bukkit.getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(arg))
+                    .forEach(completions::add);
+            case ZONE -> zoneManager.getAllZones().stream()
+                    .filter(Zone::isDiscoverable)
+                    .map(zone -> zone.getKey().asString())
+                    .filter(key -> key.toLowerCase().startsWith(arg))
+                    .forEach(completions::add);
+        }
+        return completions;
+    }
+
+    /**
+     * Removes a leading token equal to this subcommand's name. Two-level-deep subcommands (under {@code /zone
+     * discovery}) receive their own name as {@code args[0]} from the command dispatcher, so this normalizes the args.
+     */
+    protected String[] stripName(String[] args) {
+        if (args.length > 0 && args[0].equalsIgnoreCase(getName())) {
+            return Arrays.copyOfRange(args, 1, args.length);
+        }
+        return args;
+    }
+
+    protected @Nullable Zone resolveZone(String keyArg) {
+        try {
+            return zoneManager.getZone(Key.key(keyArg)).orElse(null);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    protected String zoneArgType() {
+        return ZONE;
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneCommand.java
@@ -1,0 +1,35 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.entity.Player;
+
+/**
+ * Root {@code /zone} command for zone tooling. Holds the {@code list} subcommand and the {@code discovery} group; left
+ * open for future zone subcommands. Defaults to the ADMIN rank via the command loader config.
+ */
+@Singleton
+public class ZoneCommand extends Command {
+
+    @Override
+    public String getName() {
+        return "zone";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Zone management and discovery tooling";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone <list|discovery>");
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? ArgumentType.SUBCOMMAND.name() : ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryAddSubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryAddSubCommand.java
@@ -1,0 +1,65 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import org.bukkit.entity.Player;
+
+/**
+ * {@code /zone discovery add <player> <zoneKey>} — records a discovery for a player without them visiting the zone.
+ */
+@Singleton
+@SubCommand(ZoneDiscoverySubCommand.class)
+public class ZoneDiscoveryAddSubCommand extends AbstractZoneDiscoverySubCommand {
+
+    @Override
+    public String getName() {
+        return "add";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Manually record a zone discovery for a player";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final String[] stripped = stripName(args);
+        if (stripped.length < 2) {
+            UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone discovery add <player> <zoneKey>");
+            return;
+        }
+
+        final String targetName = stripped[0];
+        final Zone zone = resolveZone(stripped[1]);
+        if (zone == null) {
+            UtilMessage.message(player, "Zones", "<red>Unknown zone <yellow>%s</yellow>.", stripped[1]);
+            return;
+        }
+
+        clientManager.search(player).offline(targetName).thenAccept(result -> {
+            if (result.isEmpty()) {
+                UtilServer.runTask(core, () -> UtilMessage.message(player, "Zones", "<red>Player <yellow>%s</yellow> was not found.", targetName));
+                return;
+            }
+            final Client target = result.get();
+            discoveryService.addManual(target, zone).thenRun(() -> UtilServer.runTask(core, () ->
+                    UtilMessage.message(player, "Zones", "<green>Added</green> discovery <white>%s</white> to <yellow>%s</yellow>.",
+                            zone.getKey().asString(), target.getName())));
+        });
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        if (argCount == 1) {
+            return ArgumentType.PLAYER.name();
+        }
+        if (argCount == 2) {
+            return zoneArgType();
+        }
+        return ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryListSubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryListSubCommand.java
@@ -1,0 +1,69 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.world.zone.discovery.ZoneDiscoveryRecord;
+import org.bukkit.entity.Player;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * {@code /zone discovery list <player>} — prints the zones a player has discovered, with timestamps.
+ */
+@Singleton
+@SubCommand(ZoneDiscoverySubCommand.class)
+public class ZoneDiscoveryListSubCommand extends AbstractZoneDiscoverySubCommand {
+
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public String getName() {
+        return "list";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List the zones a player has discovered";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final String[] stripped = stripName(args);
+        if (stripped.length < 1) {
+            UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone discovery list <player>");
+            return;
+        }
+
+        final String targetName = stripped[0];
+        clientManager.search(player).offline(targetName).thenAccept(result -> {
+            if (result.isEmpty()) {
+                UtilServer.runTask(core, () -> UtilMessage.message(player, "Zones", "<red>Player <yellow>%s</yellow> was not found.", targetName));
+                return;
+            }
+            final Client target = result.get();
+            discoveryService.list(target).thenAccept(records ->
+                    UtilServer.runTask(core, () -> printDiscoveries(player, target, records)));
+        });
+    }
+
+    private void printDiscoveries(Player player, Client target, List<ZoneDiscoveryRecord> records) {
+        if (records.isEmpty()) {
+            UtilMessage.message(player, "Zones", "<yellow>%s</yellow> has not discovered any zones.", target.getName());
+            return;
+        }
+        UtilMessage.message(player, "Zones", "<yellow>%s</yellow> has discovered <yellow>%s</yellow> zone(s):", target.getName(), records.size());
+        for (ZoneDiscoveryRecord record : records) {
+            UtilMessage.message(player, "Zones", "  <white>%s</white> <dark_gray>(%s) <gray>%s",
+                    record.getDisplayName(), record.getZoneKey(), TIMESTAMP_FORMAT.format(record.getDiscoveredAt()));
+        }
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? ArgumentType.PLAYER.name() : ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryRemoveSubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryRemoveSubCommand.java
@@ -1,0 +1,66 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import org.bukkit.entity.Player;
+
+/**
+ * {@code /zone discovery remove <player> <zoneKey>} — removes a single discovery so re-entering the zone re-triggers
+ * the notification.
+ */
+@Singleton
+@SubCommand(ZoneDiscoverySubCommand.class)
+public class ZoneDiscoveryRemoveSubCommand extends AbstractZoneDiscoverySubCommand {
+
+    @Override
+    public String getName() {
+        return "remove";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove a single zone discovery from a player";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final String[] stripped = stripName(args);
+        if (stripped.length < 2) {
+            UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone discovery remove <player> <zoneKey>");
+            return;
+        }
+
+        final String targetName = stripped[0];
+        final Zone zone = resolveZone(stripped[1]);
+        if (zone == null) {
+            UtilMessage.message(player, "Zones", "<red>Unknown zone <yellow>%s</yellow>.", stripped[1]);
+            return;
+        }
+
+        clientManager.search(player).offline(targetName).thenAccept(result -> {
+            if (result.isEmpty()) {
+                UtilServer.runTask(core, () -> UtilMessage.message(player, "Zones", "<red>Player <yellow>%s</yellow> was not found.", targetName));
+                return;
+            }
+            final Client target = result.get();
+            discoveryService.remove(target, zone).thenRun(() -> UtilServer.runTask(core, () ->
+                    UtilMessage.message(player, "Zones", "<green>Removed</green> discovery <white>%s</white> from <yellow>%s</yellow>.",
+                            zone.getKey().asString(), target.getName())));
+        });
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        if (argCount == 1) {
+            return ArgumentType.PLAYER.name();
+        }
+        if (argCount == 2) {
+            return zoneArgType();
+        }
+        return ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryResetSubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoveryResetSubCommand.java
@@ -1,0 +1,52 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import org.bukkit.entity.Player;
+
+/**
+ * {@code /zone discovery reset <player>} — wipes all of a player's discoveries (primary testing tool: makes every
+ * discoverable zone notify again on the next visit).
+ */
+@Singleton
+@SubCommand(ZoneDiscoverySubCommand.class)
+public class ZoneDiscoveryResetSubCommand extends AbstractZoneDiscoverySubCommand {
+
+    @Override
+    public String getName() {
+        return "reset";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Wipe all of a player's zone discoveries";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final String[] stripped = stripName(args);
+        if (stripped.length < 1) {
+            UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone discovery reset <player>");
+            return;
+        }
+
+        final String targetName = stripped[0];
+        clientManager.search(player).offline(targetName).thenAccept(result -> {
+            if (result.isEmpty()) {
+                UtilServer.runTask(core, () -> UtilMessage.message(player, "Zones", "<red>Player <yellow>%s</yellow> was not found.", targetName));
+                return;
+            }
+            final Client target = result.get();
+            discoveryService.reset(target).thenRun(() -> UtilServer.runTask(core, () ->
+                    UtilMessage.message(player, "Zones", "<green>Reset</green> all zone discoveries for <yellow>%s</yellow>.", target.getName())));
+        });
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? ArgumentType.PLAYER.name() : ArgumentType.NONE.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoverySubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneDiscoverySubCommand.java
@@ -1,0 +1,62 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.ICommand;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@code /zone discovery <list|add|remove|reset> ...} — groups the zone-discovery management subcommands under
+ * {@code /zone}. Bare invocation prints usage; tab-completion descends into the matching leaf (the command framework
+ * only auto-descends one level, so this group descends to its own children explicitly).
+ */
+@Singleton
+@SubCommand(ZoneCommand.class)
+public class ZoneDiscoverySubCommand extends Command {
+
+    @Override
+    public String getName() {
+        return "discovery";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Manage players' zone discoveries";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        UtilMessage.message(player, "Zones", "<yellow>Usage:</yellow> /zone discovery <list|add|remove|reset> <player>");
+    }
+
+    @Override
+    public List<String> processTabComplete(CommandSender sender, String[] args) {
+        if (args.length <= 1) {
+            final String arg = args.length == 1 ? args[0].toLowerCase() : "";
+            final List<String> completions = new ArrayList<>();
+            for (ICommand sub : getSubCommands()) {
+                if (sub.showTabCompletion(sender) && sub.getName().toLowerCase().startsWith(arg)) {
+                    completions.add(sub.getName());
+                }
+            }
+            return completions;
+        }
+        return getSubCommand(args[0])
+                .filter(sub -> sub.showTabCompletion(sender))
+                .map(sub -> sub.processTabComplete(sender, Arrays.copyOfRange(args, 1, args.length)))
+                .orElseGet(ArrayList::new);
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return ArgumentType.SUBCOMMAND.name();
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneListSubCommand.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/command/commands/admin/zone/ZoneListSubCommand.java
@@ -1,0 +1,125 @@
+package me.mykindos.betterpvp.core.command.commands.admin.zone;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.command.Command;
+import me.mykindos.betterpvp.core.command.SubCommand;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import me.mykindos.betterpvp.core.world.zone.ZoneManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * {@code /zone list [namespace]} — lists every registered zone (including provider-sourced ones such as clan
+ * territories via {@link ZoneManager#getAllZones()}), grouped by key namespace. Namespaces with more than
+ * {@link #FOLD_THRESHOLD} zones collapse to a single count line; pass a namespace to expand just that group.
+ */
+@Singleton
+@SubCommand(ZoneCommand.class)
+public class ZoneListSubCommand extends Command {
+
+    /** Above this many zones in a namespace, the group is folded to a count line unless explicitly expanded. */
+    private static final int FOLD_THRESHOLD = 10;
+    private static final String NAMESPACE = "NAMESPACE";
+
+    private final ZoneManager zoneManager;
+
+    @Inject
+    public ZoneListSubCommand(ZoneManager zoneManager) {
+        this.zoneManager = zoneManager;
+    }
+
+    @Override
+    public String getName() {
+        return "list";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List all registered zones, grouped by namespace";
+    }
+
+    @Override
+    public void execute(Player player, Client client, String... args) {
+        final String filter = args.length > 0 ? args[0].toLowerCase() : null;
+
+        final Map<String, List<Zone>> byNamespace = new TreeMap<>();
+        for (Zone zone : zoneManager.getAllZones()) {
+            byNamespace.computeIfAbsent(zone.getKey().namespace(), ns -> new ArrayList<>()).add(zone);
+        }
+
+        if (byNamespace.isEmpty()) {
+            UtilMessage.message(player, "Zones", "No zones are registered.");
+            return;
+        }
+
+        if (filter != null && !byNamespace.containsKey(filter)) {
+            UtilMessage.message(player, "Zones", "<red>No zones in namespace <yellow>%s</yellow>.", filter);
+            return;
+        }
+
+        final int total = byNamespace.values().stream().mapToInt(List::size).sum();
+        UtilMessage.message(player, "Zones", "<yellow>%s</yellow> zones across <yellow>%s</yellow> namespace(s)%s",
+                total, byNamespace.size(), filter != null ? " <gray>(filtered: " + filter + ")" : "");
+
+        for (Map.Entry<String, List<Zone>> entry : byNamespace.entrySet()) {
+            final String namespace = entry.getKey();
+            if (filter != null && !namespace.equals(filter)) {
+                continue;
+            }
+
+            final List<Zone> zones = entry.getValue();
+            if (filter == null && zones.size() > FOLD_THRESHOLD) {
+                UtilMessage.message(player, "Zones", "<aqua>%s</aqua> <gray>— %s zones <dark_gray>(/zone list %s to expand)",
+                        namespace, zones.size(), namespace);
+                continue;
+            }
+
+            UtilMessage.message(player, "Zones", "<aqua>%s</aqua> <gray>(%s)", namespace, zones.size());
+            zones.sort(Comparator.comparing(zone -> zone.getKey().value()));
+            for (Zone zone : zones) {
+                final String marker = zone.isDiscoverable() ? "<gold>✦</gold> " : "";
+                final String tags = zone.getTags().isEmpty() ? "" : " <dark_gray>" + zone.getTags();
+                final String world = zone.getWorld() != null ? " <dark_gray>(" + zone.getWorld().getName() + ")" : "";
+                UtilMessage.message(player, "Zones", "  %s<white>%s</white> <gray>%s%s%s",
+                        marker, zone.getKey().value(), plain(zone.getDisplayName()), tags, world);
+            }
+        }
+    }
+
+    @Override
+    public List<String> processTabComplete(CommandSender sender, String[] args) {
+        final List<String> completions = new ArrayList<>();
+        if (args.length == 0) {
+            return completions;
+        }
+        if (NAMESPACE.equals(getArgumentType(args.length))) {
+            final String arg = args[args.length - 1].toLowerCase();
+            zoneManager.getAllZones().stream()
+                    .map(zone -> zone.getKey().namespace())
+                    .distinct()
+                    .filter(namespace -> namespace.toLowerCase().startsWith(arg))
+                    .forEach(completions::add);
+        }
+        return completions;
+    }
+
+    @Override
+    public String getArgumentType(int argCount) {
+        return argCount == 1 ? NAMESPACE : ArgumentType.NONE.name();
+    }
+
+    private static String plain(Component component) {
+        return PlainTextComponentSerializer.plainText().serialize(component);
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/scene/mob/sound/SoundProviders.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/scene/mob/sound/SoundProviders.java
@@ -4,10 +4,7 @@ import com.google.common.base.Preconditions;
 import me.mykindos.betterpvp.core.scene.mob.SceneMob;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.sound.Sound;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -116,7 +113,7 @@ public final class SoundProviders {
                 return null;
             }
 
-            return resolved.size() == 1 ? resolved.getFirst() : new LayeredSoundEffect(resolved);
+            return resolved.size() == 1 ? resolved.getFirst() : SoundEffect.layered(resolved);
         };
     }
 
@@ -170,52 +167,6 @@ public final class SoundProviders {
             final float pitch = Math.max(0.5f, Math.min(2.0f, sound.pitch() + jitter));
             return new SoundEffect(Sound.sound(sound.name(), sound.source(), sound.volume(), pitch));
         };
-    }
-
-    /**
-     * A {@link SoundEffect} that <em>is</em> several effects: every play path fans out to each member so
-     * {@link MobSoundBehavior}, which plays a single resolved effect, emits the whole stack from one
-     * cue without any awareness that layering is happening. It reports its first member's {@link Sound}
-     * for {@link #getSound()} so single-sound consumers still see a sensible value.
-     */
-    private static final class LayeredSoundEffect extends SoundEffect {
-
-        private final List<SoundEffect> effects;
-
-        private LayeredSoundEffect(List<SoundEffect> effects) {
-            super(effects.getFirst().getSound());
-            this.effects = effects;
-        }
-
-        @Override
-        public void play(Location location) {
-            effects.forEach(effect -> effect.play(location));
-        }
-
-        @Override
-        public void play(Audience audience) {
-            effects.forEach(effect -> effect.play(audience));
-        }
-
-        @Override
-        public void play(Audience audience, Location location) {
-            effects.forEach(effect -> effect.play(audience, location));
-        }
-
-        @Override
-        public void play(Audience audience, Sound.Emitter emitter) {
-            effects.forEach(effect -> effect.play(audience, emitter));
-        }
-
-        @Override
-        public void broadcast() {
-            effects.forEach(SoundEffect::broadcast);
-        }
-
-        @Override
-        public void broadcast(Sound.Emitter emitter) {
-            effects.forEach(effect -> effect.broadcast(emitter));
-        }
     }
 
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/LayeredSoundEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/LayeredSoundEffect.java
@@ -1,0 +1,55 @@
+package me.mykindos.betterpvp.core.utilities.model;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.sound.Sound;
+import org.bukkit.Location;
+
+import java.util.List;
+
+/**
+ * A {@link SoundEffect} that <em>is</em> several effects: every play path fans out to each member, so a consumer that
+ * plays a single resolved effect emits the whole stack from one cue without any awareness that layering is happening.
+ * It reports its first member's {@link Sound} for {@link #getSound()} so single-sound consumers still see a sensible
+ * value.
+ * <p>
+ * Build one via {@link SoundEffect#layered(SoundEffect...)}.
+ */
+public final class LayeredSoundEffect extends SoundEffect {
+
+    private final List<SoundEffect> effects;
+
+    LayeredSoundEffect(List<SoundEffect> effects) {
+        super(effects.getFirst().getSound());
+        this.effects = List.copyOf(effects);
+    }
+
+    @Override
+    public void play(Location location) {
+        effects.forEach(effect -> effect.play(location));
+    }
+
+    @Override
+    public void play(Audience audience) {
+        effects.forEach(effect -> effect.play(audience));
+    }
+
+    @Override
+    public void play(Audience audience, Location location) {
+        effects.forEach(effect -> effect.play(audience, location));
+    }
+
+    @Override
+    public void play(Audience audience, Sound.Emitter emitter) {
+        effects.forEach(effect -> effect.play(audience, emitter));
+    }
+
+    @Override
+    public void broadcast() {
+        effects.forEach(SoundEffect::broadcast);
+    }
+
+    @Override
+    public void broadcast(Sound.Emitter emitter) {
+        effects.forEach(effect -> effect.broadcast(emitter));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/SoundEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/model/SoundEffect.java
@@ -1,5 +1,6 @@
 package me.mykindos.betterpvp.core.utilities.model;
 
+import com.google.common.base.Preconditions;
 import lombok.Getter;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
@@ -7,6 +8,8 @@ import net.kyori.adventure.sound.Sound;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+
+import java.util.List;
 
 @Getter
 public class SoundEffect {
@@ -44,6 +47,28 @@ public class SoundEffect {
 
     public SoundEffect(final Sound sound) {
         this.sound = sound;
+    }
+
+    /**
+     * Combines several effects into one that plays them all together as a single cue (see {@link LayeredSoundEffect}).
+     *
+     * @param effects the effects to layer; at least one
+     * @return a {@link SoundEffect} that fans every play out to each member
+     */
+    public static SoundEffect layered(final SoundEffect... effects) {
+        Preconditions.checkArgument(effects.length > 0, "At least one sound effect must be provided");
+        return layered(List.of(effects));
+    }
+
+    /**
+     * List form of {@link #layered(SoundEffect...)}.
+     *
+     * @param effects the effects to layer; at least one
+     * @return a {@link SoundEffect} that fans every play out to each member
+     */
+    public static SoundEffect layered(final List<SoundEffect> effects) {
+        Preconditions.checkArgument(!effects.isEmpty(), "At least one sound effect must be provided");
+        return new LayeredSoundEffect(effects);
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/IndexedZoneProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/IndexedZoneProvider.java
@@ -9,9 +9,12 @@ import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -75,5 +78,17 @@ final class IndexedZoneProvider implements ZoneProvider {
             return Stream.empty();
         }
         return bucket.stream().filter(zone -> zone.contains(location));
+    }
+
+    @Override
+    public @NotNull Collection<Zone> zones() {
+        // A zone is filed under every chunk it overlaps, so dedupe across buckets.
+        final Set<Zone> all = new LinkedHashSet<>();
+        for (Long2ObjectMap<List<Zone>> buckets : worlds.values()) {
+            for (List<Zone> bucket : buckets.values()) {
+                all.addAll(bucket);
+            }
+        }
+        return all;
     }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/Zone.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/Zone.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 import me.mykindos.betterpvp.core.utilities.UtilFormat;
+import me.mykindos.betterpvp.core.world.zone.discovery.ZoneDiscovery;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
@@ -41,6 +42,8 @@ public final class Zone {
     private final Set<String> tags;
     /** Rules attached directly to this zone (composition half of the rule system). */
     private final ZoneRuleContainer rules;
+    /** Discovery notification config; when non-null this zone is {@link #isDiscoverable() discoverable}. */
+    private final ZoneDiscovery discovery;
 
     @Builder
     private Zone(@NotNull Key key,
@@ -48,13 +51,23 @@ public final class Zone {
                 @NotNull ZoneBounds bounds,
                 int priority,
                 @Singular Set<String> tags,
-                @Nullable ZoneRuleContainer rules) {
+                @Nullable ZoneRuleContainer rules,
+                @Nullable ZoneDiscovery discovery) {
         this.key = Objects.requireNonNull(key, "key");
         this.bounds = Objects.requireNonNull(bounds, "bounds");
         this.displayName = displayName != null ? displayName : Component.text(UtilFormat.cleanString(key.value()));
         this.priority = priority;
         this.tags = Set.copyOf(tags);
         this.rules = rules != null ? rules : new ZoneRuleContainer();
+        this.discovery = discovery;
+    }
+
+    /**
+     * @return whether this zone fires a first-visit discovery notification (i.e. it was built with a
+     * {@link ZoneDiscovery})
+     */
+    public boolean isDiscoverable() {
+        return discovery != null;
     }
 
     /**

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneManager.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -102,6 +104,29 @@ public class ZoneManager {
 
     public @NotNull Optional<Zone> getZone(@NotNull Key key) {
         return Optional.ofNullable(registered.get(key));
+    }
+
+    /**
+     * Enumerates every zone known to the manager — registered zones, ambient zones, and any zones surfaced by external
+     * {@link ZoneProvider#zones() providers} (e.g. clan territories) — deduped by {@link Zone#getKey() key}, with
+     * registered/ambient zones taking precedence. Intended for admin/listing tooling, not the per-move resolution path.
+     *
+     * @return all known zones, deduped by key
+     */
+    public @NotNull Collection<Zone> getAllZones() {
+        final Map<Key, Zone> all = new LinkedHashMap<>();
+        for (Zone zone : registered.values()) {
+            all.putIfAbsent(zone.getKey(), zone);
+        }
+        for (Zone zone : ambient) {
+            all.putIfAbsent(zone.getKey(), zone);
+        }
+        for (ZoneProvider provider : providers) {
+            for (Zone zone : provider.zones()) {
+                all.putIfAbsent(zone.getKey(), zone);
+            }
+        }
+        return all.values();
     }
 
     // </editor-fold>

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneProvider.java
@@ -3,6 +3,8 @@ package me.mykindos.betterpvp.core.world.zone;
 import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -22,4 +24,15 @@ public interface ZoneProvider {
      * @return a stream of zones that contain the location (already filtered by containment)
      */
     @NotNull Stream<Zone> zonesAt(@NotNull Location location);
+
+    /**
+     * Best-effort enumeration of every zone this provider could resolve, used for admin/listing tooling (e.g.
+     * {@code /zone list}). Resolution still happens via {@link #zonesAt(Location)}; providers that cannot cheaply
+     * enumerate their zones (e.g. purely predicate-based sources) may leave this returning an empty collection.
+     *
+     * @return all zones this provider knows about, or an empty collection if it cannot enumerate them
+     */
+    default @NotNull Collection<Zone> zones() {
+        return List.of();
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveredEvent.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveredEvent.java
@@ -1,0 +1,20 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import me.mykindos.betterpvp.core.framework.events.CustomEvent;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import org.bukkit.entity.Player;
+
+/**
+ * Fired the first time a player discovers a {@link Zone#isDiscoverable() discoverable} zone (after the notification has
+ * been shown and the discovery scheduled for persistence). Other modules can listen for this to grant rewards,
+ * achievements, etc. without coupling to the discovery system.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class ZoneDiscoveredEvent extends CustomEvent {
+
+    Player player;
+    Zone zone;
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscovery.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscovery.java
@@ -1,0 +1,52 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import lombok.Builder;
+import lombok.Value;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Per-zone discovery notification config, attached to a {@link Zone} via its builder. Its mere presence marks a zone as
+ * <i>discoverable</i> ({@link Zone#isDiscoverable()}) — the first time a player enters such a zone they get a title, a
+ * sound and a chat line, and the moment is recorded in the database.
+ * <p>
+ * Sensible defaults mean {@code ZoneDiscovery.builder().build()} is enough for most zones: the title defaults to
+ * {@link #DEFAULT_TITLE}, the sound to {@link #DEFAULT_SOUND}, and — because they depend on the zone — the subtitle
+ * defaults to the zone's display name (white, undecorated) and the message to an "Unlocked area" line, both resolved at
+ * notification time. Set any field to override its default.
+ */
+@Value
+@Builder
+public class ZoneDiscovery {
+
+    /** Default title line shown on discovery. */
+    public static final Component DEFAULT_TITLE = Component.text("Area Discovered", NamedTextColor.GOLD, TextDecoration.BOLD);
+    /** Default sound played on discovery. */
+    public static final SoundEffect DEFAULT_SOUND = new SoundEffect("minecraft", "ui.toast.challenge_complete", 1.1f);
+
+    /** Title line. */
+    @Builder.Default
+    @Nullable Component title = DEFAULT_TITLE;
+    /** Subtitle line; when {@code null} the notifier falls back to the zone's display name in white, undecorated. */
+    @Nullable Component subtitle;
+    /** Chat line; when {@code null} the notifier falls back to a default "Unlocked area" message. */
+    @Nullable Component message;
+
+    /** Sound played on discovery. */
+    @Builder.Default
+    SoundEffect sound = DEFAULT_SOUND;
+
+    /** Title fade-in time in seconds. */
+    @Builder.Default
+    double fadeIn = 0.3;
+    /** Title stay (visible) time in seconds. */
+    @Builder.Default
+    double stay = 5.0;
+    /** Title fade-out time in seconds. */
+    @Builder.Default
+    double fadeOut = 0.5;
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryListener.java
@@ -1,0 +1,41 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.mykindos.betterpvp.core.client.events.AsyncClientLoadEvent;
+import me.mykindos.betterpvp.core.client.events.ClientUnloadEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.world.zone.PlayerEnterZoneEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/**
+ * Wires the zone-discovery system into the event bus: detects first-visit discoveries on zone entry, preloads a
+ * client's discoveries when they load, and clears the cache when they unload.
+ */
+@BPvPListener
+@Singleton
+public class ZoneDiscoveryListener implements Listener {
+
+    private final ZoneDiscoveryService discoveryService;
+
+    @Inject
+    public ZoneDiscoveryListener(ZoneDiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @EventHandler
+    public void onEnterZone(PlayerEnterZoneEvent event) {
+        discoveryService.discover(event.getPlayer(), event.getZone());
+    }
+
+    @EventHandler
+    public void onClientLoad(AsyncClientLoadEvent event) {
+        discoveryService.loadForClient(event.getClient());
+    }
+
+    @EventHandler
+    public void onClientUnload(ClientUnloadEvent event) {
+        discoveryService.clear(event.getClient().getUniqueId());
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryRecord.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryRecord.java
@@ -1,0 +1,17 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+/**
+ * A single persisted zone discovery, joined with its zone for display. Returned by
+ * {@link ZoneDiscoveryRepository#listForClient(long)} and surfaced by the {@code /zone discovery list} command.
+ */
+@Value
+public class ZoneDiscoveryRecord {
+
+    String zoneKey;
+    String displayName;
+    LocalDateTime discoveredAt;
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryRepository.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryRepository.java
@@ -1,0 +1,155 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.database.Database;
+import org.jooq.Record;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static me.mykindos.betterpvp.core.utilities.SnowflakeIdGenerator.ID_GENERATOR;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.table;
+
+/**
+ * Persistence for zone discoveries. The {@code zones} table holds (snowflake id, unique zone key, display name) and is
+ * populated lazily on first discovery; {@code zone_discoveries} links a client to a zone with a timestamp.
+ * <p>
+ * Uses the dynamic jOOQ DSL ({@code table(name(...))} / {@code field(name(...), Type.class)}) so no generated jOOQ
+ * classes are required for these tables.
+ */
+@Singleton
+@CustomLog
+public class ZoneDiscoveryRepository {
+
+    private static final long DB_TIMEOUT_SECONDS = 3;
+
+    private final Database database;
+
+    @Inject
+    public ZoneDiscoveryRepository(Database database) {
+        this.database = database;
+    }
+
+    /**
+     * Inserts the zone row if absent (keeping the display name current on conflict) and returns its snowflake id.
+     *
+     * @param zoneKey     the stable zone key (namespace:value)
+     * @param displayName the zone's plain-text display name
+     * @return the persisted zone id, or {@code null} if the operation failed
+     */
+    public CompletableFuture<Long> ensureZoneId(String zoneKey, String displayName) {
+        final long newId = ID_GENERATOR.nextId();
+        return database.getAsyncDslContext().executeAsync(ctx -> {
+            final Record record = ctx.insertInto(table(name("zones")),
+                            field(name("id"), Long.class),
+                            field(name("zone_key"), String.class),
+                            field(name("display_name"), String.class))
+                    .values(newId, zoneKey, displayName)
+                    .onConflict(field(name("zone_key"), String.class))
+                    .doUpdate()
+                    .set(field(name("display_name"), String.class), displayName)
+                    .returning(field(name("id"), Long.class))
+                    .fetchOne();
+            return record == null ? null : record.get(field(name("id"), Long.class));
+        }).orTimeout(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS).exceptionally(ex -> {
+            log.error("Failed to ensure zone id for {}", zoneKey, ex).submit();
+            return null;
+        });
+    }
+
+    /**
+     * Records a discovery, ignoring duplicates (a client discovers a given zone at most once).
+     */
+    public CompletableFuture<Void> insertDiscovery(long clientId, long zoneId) {
+        return database.getAsyncDslContext().executeAsyncVoid(ctx -> ctx.insertInto(table(name("zone_discoveries")),
+                        field(name("client"), Long.class),
+                        field(name("zone_id"), Long.class))
+                .values(clientId, zoneId)
+                .onConflict(field(name("client"), Long.class), field(name("zone_id"), Long.class))
+                .doNothing()
+                .execute()).exceptionally(ex -> {
+            log.error("Failed to insert zone discovery for client {} zone {}", clientId, zoneId, ex).submit();
+            return null;
+        });
+    }
+
+    /**
+     * @return a map of discovered zone key → zone id for the given client (used to warm in-memory caches on join)
+     */
+    public CompletableFuture<Map<String, Long>> loadForClient(long clientId) {
+        return database.getAsyncDslContext().executeAsync(ctx -> {
+            final Map<String, Long> result = new HashMap<>();
+            ctx.select(field(name("z", "zone_key"), String.class), field(name("z", "id"), Long.class))
+                    .from(table(name("zone_discoveries")).as("d"))
+                    .join(table(name("zones")).as("z"))
+                    .on(field(name("d", "zone_id"), Long.class).eq(field(name("z", "id"), Long.class)))
+                    .where(field(name("d", "client"), Long.class).eq(clientId))
+                    .fetch()
+                    .forEach(record -> result.put(record.value1(), record.value2()));
+            return result;
+        }).orTimeout(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS).exceptionally(ex -> {
+            log.error("Failed to load zone discoveries for client {}", clientId, ex).submit();
+            return new HashMap<>();
+        });
+    }
+
+    /**
+     * @return the client's discoveries joined with each zone's display name and timestamp, newest last
+     */
+    public CompletableFuture<List<ZoneDiscoveryRecord>> listForClient(long clientId) {
+        return database.getAsyncDslContext().executeAsync(ctx -> {
+            final List<ZoneDiscoveryRecord> result = new ArrayList<>();
+            ctx.select(field(name("z", "zone_key"), String.class),
+                            field(name("z", "display_name"), String.class),
+                            field(name("d", "discovered_at"), LocalDateTime.class))
+                    .from(table(name("zone_discoveries")).as("d"))
+                    .join(table(name("zones")).as("z"))
+                    .on(field(name("d", "zone_id"), Long.class).eq(field(name("z", "id"), Long.class)))
+                    .where(field(name("d", "client"), Long.class).eq(clientId))
+                    .orderBy(field(name("d", "discovered_at"), LocalDateTime.class).asc())
+                    .fetch()
+                    .forEach(record -> result.add(new ZoneDiscoveryRecord(record.value1(), record.value2(), record.value3())));
+            return result;
+        }).orTimeout(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS).exceptionally(ex -> {
+            log.error("Failed to list zone discoveries for client {}", clientId, ex).submit();
+            return new ArrayList<>();
+        });
+    }
+
+    /**
+     * Removes a single discovery (by zone key) for a client, if present.
+     */
+    public CompletableFuture<Void> deleteForClientAndKey(long clientId, String zoneKey) {
+        return database.getAsyncDslContext().executeAsyncVoid(ctx -> ctx.deleteFrom(table(name("zone_discoveries")))
+                .where(field(name("client"), Long.class).eq(clientId))
+                .and(field(name("zone_id"), Long.class).in(
+                        ctx.select(field(name("id"), Long.class))
+                                .from(table(name("zones")))
+                                .where(field(name("zone_key"), String.class).eq(zoneKey))))
+                .execute()).exceptionally(ex -> {
+            log.error("Failed to delete zone discovery for client {} zone {}", clientId, zoneKey, ex).submit();
+            return null;
+        });
+    }
+
+    /**
+     * Removes all discoveries for a client.
+     */
+    public CompletableFuture<Void> deleteAllForClient(long clientId) {
+        return database.getAsyncDslContext().executeAsyncVoid(ctx -> ctx.deleteFrom(table(name("zone_discoveries")))
+                .where(field(name("client"), Long.class).eq(clientId))
+                .execute()).exceptionally(ex -> {
+            log.error("Failed to delete all zone discoveries for client {}", clientId, ex).submit();
+            return null;
+        });
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/discovery/ZoneDiscoveryService.java
@@ -1,0 +1,187 @@
+package me.mykindos.betterpvp.core.world.zone.discovery;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.core.client.Client;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.client.repository.ClientManager;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.display.title.TitleComponent;
+import me.mykindos.betterpvp.core.world.zone.Zone;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Owns zone-discovery state and behaviour: tracks which zones each online player has already discovered, shows the
+ * first-visit notification, and persists discoveries via {@link ZoneDiscoveryRepository}.
+ * <p>
+ * The per-player discovered set is preloaded on {@code AsyncClientLoadEvent} (see {@code ZoneDiscoveryListener}); a
+ * player with no loaded set yet is treated as "not ready" and skipped, so a slow DB load can never produce a false
+ * first-visit notification.
+ */
+@Singleton
+@CustomLog
+public class ZoneDiscoveryService {
+
+    private final ZoneDiscoveryRepository repository;
+    private final ClientManager clientManager;
+
+    /** zone keys each online player has discovered; absence of an entry means "not loaded yet". */
+    private final Map<UUID, Set<String>> discovered = new ConcurrentHashMap<>();
+    /** zone key → persisted zone id, warmed from loads and upserts to avoid re-resolving the id. */
+    private final Map<String, Long> zoneIdByKey = new ConcurrentHashMap<>();
+
+    @Inject
+    public ZoneDiscoveryService(ZoneDiscoveryRepository repository, ClientManager clientManager) {
+        this.repository = repository;
+        this.clientManager = clientManager;
+    }
+
+    /**
+     * Preloads a client's discovered zones into memory. Intended to run on the async client-load path; it blocks on the
+     * repository read (which itself has a timeout and fallback). Always installs a (possibly empty) set so the client
+     * counts as "loaded".
+     */
+    public void loadForClient(@NotNull Client client) {
+        final Set<String> set = ConcurrentHashMap.newKeySet();
+        try {
+            final Map<String, Long> loaded = repository.loadForClient(client.getId()).join();
+            zoneIdByKey.putAll(loaded);
+            set.addAll(loaded.keySet());
+        } catch (Exception ex) {
+            log.error("Failed to preload zone discoveries for {}", client.getName(), ex).submit();
+        }
+        discovered.put(client.getUniqueId(), set);
+    }
+
+    /**
+     * Handles a player entering a zone: if the zone is discoverable and the player has not discovered it before, shows
+     * the notification immediately, schedules persistence, and fires {@link ZoneDiscoveredEvent}.
+     */
+    public void discover(@NotNull Player player, @NotNull Zone zone) {
+        if (!zone.isDiscoverable()) {
+            return;
+        }
+        final Set<String> set = discovered.get(player.getUniqueId());
+        if (set == null) {
+            return; // discoveries not loaded yet — skip rather than risk a false first-visit
+        }
+        final String key = zone.getKey().asString();
+        if (!set.add(key)) {
+            return; // already discovered
+        }
+
+        notifyDiscovery(player, zone);
+
+        final Client client = clientManager.search().online(player);
+        persist(client.getId(), key, plain(zone.getDisplayName()));
+        UtilServer.callEvent(new ZoneDiscoveredEvent(player, zone));
+    }
+
+    /**
+     * Drops a player's cached discoveries (on unload).
+     */
+    public void clear(@NotNull UUID uuid) {
+        discovered.remove(uuid);
+    }
+
+    // <editor-fold desc="Admin operations (used by /zone discovery, no notification)">
+
+    public CompletableFuture<List<ZoneDiscoveryRecord>> list(@NotNull Client target) {
+        return repository.listForClient(target.getId());
+    }
+
+    public CompletableFuture<Void> addManual(@NotNull Client target, @NotNull Zone zone) {
+        final String key = zone.getKey().asString();
+        final Set<String> set = discovered.get(target.getUniqueId());
+        if (set != null) {
+            set.add(key);
+        }
+        return repository.ensureZoneId(key, plain(zone.getDisplayName())).thenCompose(zoneId -> {
+            if (zoneId == null) {
+                return CompletableFuture.completedFuture(null);
+            }
+            zoneIdByKey.put(key, zoneId);
+            return repository.insertDiscovery(target.getId(), zoneId);
+        });
+    }
+
+    public CompletableFuture<Void> remove(@NotNull Client target, @NotNull Zone zone) {
+        final String key = zone.getKey().asString();
+        final Set<String> set = discovered.get(target.getUniqueId());
+        if (set != null) {
+            set.remove(key);
+        }
+        return repository.deleteForClientAndKey(target.getId(), key);
+    }
+
+    public CompletableFuture<Void> reset(@NotNull Client target) {
+        final Set<String> set = discovered.get(target.getUniqueId());
+        if (set != null) {
+            set.clear();
+        }
+        return repository.deleteAllForClient(target.getId());
+    }
+
+    // </editor-fold>
+
+    private void persist(long clientId, String zoneKey, String displayName) {
+        repository.ensureZoneId(zoneKey, displayName).thenAccept(zoneId -> {
+            if (zoneId == null) {
+                return;
+            }
+            zoneIdByKey.put(zoneKey, zoneId);
+            repository.insertDiscovery(clientId, zoneId);
+        });
+    }
+
+    private void notifyDiscovery(@NotNull Player player, @NotNull Zone zone) {
+        final ZoneDiscovery discovery = Objects.requireNonNull(zone.getDiscovery());
+        final Gamer gamer = clientManager.search().online(player).getGamer();
+
+        final Component subtitle = discovery.getSubtitle() != null ? discovery.getSubtitle() : defaultSubtitle(zone);
+        gamer.getTitleQueue().add(-100, new TitleComponent(discovery.getFadeIn(), discovery.getStay(),
+                discovery.getFadeOut(), true,
+                g -> discovery.getTitle(),
+                g -> subtitle));
+
+        if (discovery.getSound() != null) {
+            discovery.getSound().play(player);
+        }
+
+        final Component message = discovery.getMessage() != null ? discovery.getMessage() : defaultMessage(zone);
+        UtilMessage.message(player, message);
+    }
+
+    /** The zone's display name in white with no decoration. */
+    private static Component defaultSubtitle(@NotNull Zone zone) {
+        return Component.text(plain(zone.getDisplayName()), NamedTextColor.WHITE);
+    }
+
+    /** A blank-padded "Unlocked area: &lt;zone&gt;" chat line. */
+    private static Component defaultMessage(@NotNull Zone zone) {
+        return Component.empty()
+                .appendNewline()
+                .append(Component.text("Unlocked area: ", NamedTextColor.YELLOW))
+                .append(zone.getDisplayName())
+                .appendNewline();
+    }
+
+    private static String plain(@NotNull Component component) {
+        return PlainTextComponentSerializer.plainText().serialize(component);
+    }
+}

--- a/core/src/main/resources/core-migrations/postgres/zone/V20260602_1__Create_zone_discovery_tables.sql
+++ b/core/src/main/resources/core-migrations/postgres/zone/V20260602_1__Create_zone_discovery_tables.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS zones
+(
+    id           BIGINT       PRIMARY KEY,
+    zone_key     VARCHAR(255) NOT NULL UNIQUE,
+    display_name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS zone_discoveries
+(
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    client        BIGINT    NOT NULL REFERENCES clients (id) ON DELETE CASCADE,
+    zone_id       BIGINT    NOT NULL REFERENCES zones (id)   ON DELETE CASCADE,
+    discovered_at TIMESTAMP NOT NULL DEFAULT now(),
+    CONSTRAINT uk_zone_discovery UNIQUE (client, zone_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_zone_discoveries_client ON zone_discoveries (client);


### PR DESCRIPTION
## Describe your changes

Zones can now be marked as discoverable. The first time a player walks into one, they get a title, a sound, and a chat line — and it's recorded so it only happens once per player (and stays remembered across relogs).

- Discoverability is set per zone, with sensible defaults so most zones need no extra config:
  - Title "Area Discovered", the zone's name as the subtitle, an "Unlocked area" chat line, and a chime.
  - Any of those can be overridden per zone.
- The Sundered Gate is now a discoverable area (using the defaults).
- New `/zone list [namespace]` — lists every registered zone grouped by namespace.
  - Big groups (like clan territories) collapse to a count line; pass a namespace to expand just that group.
- New `/zone discovery <list|add|remove|reset> <player>` to manage a player's discoveries.
  - Handy for testing: `reset` a player and areas announce again on the next visit.
  - Works on offline players too.
- Sound layering (several sounds played as one cue) is now reusable anywhere via `SoundEffect.layered`.

Note for deploying: a database table is added by a migration. On an environment that already ran an earlier empty version of this migration, clear its history row (`DELETE FROM global_schema_history WHERE version = '20260602.1';`) so it re-runs.

## Link to issue (if applicable)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes.