### PR TITLE
Change poison damage per level from 3 to 2

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/PoisonListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/listeners/effects/PoisonListener.java
@@ -39,7 +39,7 @@ public class PoisonListener implements Listener {
                 return;
             }
 
-            event.setDamage(Math.min(damagee.getHealth(), effect.getAmplifier() * 3));
+            event.setDamage(Math.min(damagee.getHealth(), effect.getAmplifier() * 2));
             if (damagee.getHealth() - event.getDamage() < 2) {
                 //set damage to make the final damage leave the player at 2 health
                 event.setDamage(damagee.getHealth() - 2);

--- a/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/PoisonEffect.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/effects/types/negative/PoisonEffect.java
@@ -23,12 +23,12 @@ public class PoisonEffect extends VanillaEffectType {
 
     @Override
     public String getDescription(int level) {
-        return "<white>Poison " + UtilFormat.getRomanNumeral(level) + "</white> deals <val>" + (level * 3) + "</val> damage every <stat>" + (25d/20d) + "</stat> seconds";
+        return "<white>Poison " + UtilFormat.getRomanNumeral(level) + "</white> deals <val>" + (level * 2) + "</val> damage every <stat>" + (25d/20d) + "</stat> seconds";
     }
 
     @Override
     public String getGenericDescription() {
-        return "<white>" + getName() + "</white>" + " deals <green>3</green> damage per level every <yellow>" + (25d/20d) + "</yellow> seconds";
+        return "<white>" + getName() + "</white>" + " deals <green>2</green> damage per level every <yellow>" + (25d/20d) + "</yellow> seconds";
     }
 }
 


### PR DESCRIPTION
Poison does a lot of damage right now. Reduce it from 3 to 2 per level and look into either changing how it works, or reverting it back to 1 and adjust poison levels from there
