### PR TITLE
feat(displayname): add viewer-aware display names

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
@@ -10,6 +10,7 @@ import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.combat.throwables.ThrowableHandler;
 import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
 import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.energy.EnergyService;
 
@@ -28,12 +29,12 @@ public class ChampionsManager {
     private final EffectManager effects;
     private final EnergyService energy;
     private final ThrowableHandler throwables;
-    private final DisplayNameProvider displayNameProvider;
+    private final DisplayNameService displayNameService;
 
     @Inject
     public ChampionsManager(ClientManager clientManager, ChampionsSkillManager skills, RoleManager roles, BuildManager builds,
                             CooldownManager cooldowns, EffectManager effects, EnergyService energy, ThrowableHandler throwables,
-                            DisplayNameProvider displayNameProvider) {
+                            DisplayNameService displayNameService) {
         this.clientManager = clientManager;
         this.skills = skills;
         this.roles = roles;
@@ -42,6 +43,6 @@ public class ChampionsManager {
         this.effects = effects;
         this.energy = energy;
         this.throwables = throwables;
-        this.displayNameProvider = displayNameProvider;
+        this.displayNameService = displayNameService;
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
@@ -13,6 +13,10 @@ import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.energy.EnergyService;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
+
+import java.awt.*;
 
 /**
  * A wrapper containing frequently used dependencies throughout the champions module
@@ -44,5 +48,18 @@ public class ChampionsManager {
         this.energy = energy;
         this.throwables = throwables;
         this.displayNameService = displayNameService;
+    }
+
+    /**
+     * Convenience method for retrieving an entity's display name as a {@link Component}.
+     * This is a shorter way of accessing the {@link DisplayNameService} and its
+     * {@link DisplayNameProvider} directly.
+     *
+     * @param entity the entity whose display name should be retrieved
+     * @param viewer the entity viewing the display name, used for contextual formatting
+     * @return the entity's display name as a {@link Component}
+     */
+    public Component getDisplayNameAsComponent(Entity entity, Entity viewer) {
+        return this.displayNameService.getProvider().getDisplayNameAsComponent(entity, viewer);
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
@@ -9,6 +9,7 @@ import me.mykindos.betterpvp.champions.champions.skills.ChampionsSkillManager;
 import me.mykindos.betterpvp.core.client.repository.ClientManager;
 import me.mykindos.betterpvp.core.combat.throwables.ThrowableHandler;
 import me.mykindos.betterpvp.core.cooldowns.CooldownManager;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 import me.mykindos.betterpvp.core.effects.EffectManager;
 import me.mykindos.betterpvp.core.energy.EnergyService;
 
@@ -27,10 +28,12 @@ public class ChampionsManager {
     private final EffectManager effects;
     private final EnergyService energy;
     private final ThrowableHandler throwables;
+    private final DisplayNameProvider displayNameProvider;
 
     @Inject
     public ChampionsManager(ClientManager clientManager, ChampionsSkillManager skills, RoleManager roles, BuildManager builds,
-                            CooldownManager cooldowns, EffectManager effects, EnergyService energy, ThrowableHandler throwables) {
+                            CooldownManager cooldowns, EffectManager effects, EnergyService energy, ThrowableHandler throwables,
+                            DisplayNameProvider displayNameProvider) {
         this.clientManager = clientManager;
         this.skills = skills;
         this.roles = roles;
@@ -39,5 +42,6 @@ public class ChampionsManager {
         this.effects = effects;
         this.energy = energy;
         this.throwables = throwables;
+        this.displayNameProvider = displayNameProvider;
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/ChampionsManager.java
@@ -16,8 +16,6 @@ import me.mykindos.betterpvp.core.energy.EnergyService;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Entity;
 
-import java.awt.*;
-
 /**
  * A wrapper containing frequently used dependencies throughout the champions module
  */

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -54,7 +54,8 @@ import java.util.function.IntToDoubleFunction;
 public abstract class Skill implements IChampionsSkill {
 
     protected final Champions champions;
-    protected final ChampionsManager championsManager;
+
+    public final ChampionsManager championsManager;
 
     private boolean enabled;
     private int maxLevel;
@@ -409,6 +410,7 @@ public abstract class Skill implements IChampionsSkill {
 
     /**
      * Called when a skill is updated via {@link SkillUpdateEvent event}
+     *
      * @param player
      * @param gamer
      */
@@ -473,7 +475,7 @@ public abstract class Skill implements IChampionsSkill {
 
         // If its a passive that has no action, return standard level
         // Passives such as intimidation and backstab do not gain additional levels from boosters
-        if(this.getType().isPassive() && !(this instanceof ToggleSkill)) {
+        if (this.getType().isPassive() && !(this instanceof ToggleSkill)) {
             return level;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/Skill.java
@@ -54,7 +54,8 @@ import java.util.function.IntToDoubleFunction;
 public abstract class Skill implements IChampionsSkill {
 
     protected final Champions champions;
-    protected final ChampionsManager championsManager;
+
+    public final ChampionsManager championsManager;
 
     private boolean enabled;
     private int maxLevel;
@@ -421,6 +422,7 @@ public abstract class Skill implements IChampionsSkill {
 
     /**
      * Called when a skill is updated via {@link SkillUpdateEvent event}
+     *
      * @param player
      * @param gamer
      */
@@ -489,7 +491,7 @@ public abstract class Skill implements IChampionsSkill {
 
         // If its a passive that has no action, return standard level
         // Passives such as intimidation and backstab do not gain additional levels from boosters
-        if(this.getType().isPassive() && !(this instanceof ToggleSkill)) {
+        if (this.getType().isPassive() && !(this instanceof ToggleSkill)) {
             return level;
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -95,9 +95,9 @@ public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
 
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, getVulnerabilityStrength(level), (long) (getDuration(level) * 1000L));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -95,10 +95,9 @@ public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
 
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, getVulnerabilityStrength(level), (long) (getDuration(level) * 1000L));
-        if (!(target instanceof Player damagee)) return;
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/MarkedForDeath.java
@@ -95,9 +95,9 @@ public class MarkedForDeath extends PrepareArrowSkill implements DebuffSkill {
 
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, getVulnerabilityStrength(level), (long) (getDuration(level) * 1000L));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -85,11 +84,11 @@ public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.SILENCE, (long) (getDuration(level)) * 1000L);
         if (championsManager.getEffects().hasEffect(target, EffectTypes.IMMUNE)) {
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager));
             return;
         }
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -84,11 +84,11 @@ public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.SILENCE, (long) (getDuration(level)) * 1000L);
         if (championsManager.getEffects().hasEffect(target, EffectTypes.IMMUNE)) {
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", this.championsManager.getDisplayNameAsComponent(target, damager));
             return;
         }
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SilencingArrow.java
@@ -85,12 +85,11 @@ public class SilencingArrow extends PrepareArrowSkill implements DebuffSkill {
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.SILENCE, (long) (getDuration(level)) * 1000L);
         if (championsManager.getEffects().hasEffect(target, EffectTypes.IMMUNE)) {
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", Component.text(target.getName(), NamedTextColor.GREEN));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.assassin.silencing-arrow.immune", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager));
             return;
         }
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        if (!(target instanceof Player damagee)) return;
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
@@ -111,8 +111,8 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
                 .receivers(60)
                 .spawn();
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
@@ -111,8 +111,8 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
                 .receivers(60)
                 .spawn();
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/SmokeArrow.java
@@ -111,8 +111,8 @@ public class SmokeArrow extends PrepareArrowSkill implements DebuffSkill {
                 .receivers(60)
                 .spawn();
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -114,8 +114,8 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -114,8 +114,8 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -114,9 +114,8 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        if (!(target instanceof Player damagee)) return;
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -114,18 +114,8 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
-<<<<<<< HEAD
-<<<<<<< HEAD
         UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-=======
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
->>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
-=======
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
->>>>>>> c4e43b0d8 (refactor(champions): centralize display name lookups)
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -114,8 +114,13 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
+<<<<<<< HEAD
         UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+=======
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+>>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -115,12 +115,17 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
     public void onHit(Player damager, LivingEntity target, int level) {
         championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
 <<<<<<< HEAD
+<<<<<<< HEAD
         UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 =======
         UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 >>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
+=======
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+>>>>>>> c4e43b0d8 (refactor(champions): centralize display name lookups)
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/bow/ToxicArrow.java
@@ -113,11 +113,9 @@ public class ToxicArrow extends PrepareArrowSkill implements DebuffSkill {
 
     @Override
     public void onHit(Player damager, LivingEntity target, int level) {
-        final long length = (long) ((getDuration(level)) * 1000L);
-        championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, length);
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        if (!(target instanceof Player damagee)) return;
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        championsManager.getEffects().addEffect(target, EffectTypes.POISON, poisonStrength, (long) ((baseDuration + level) * 1000L));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -101,14 +101,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", Component.text(damagee.getName(), NamedTextColor.GREEN));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", Component.text(damagee.getName(), NamedTextColor.GREEN));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", Component.text(damager.getName(), NamedTextColor.GREEN));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -101,14 +101,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -101,14 +101,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -102,14 +102,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", Component.text(damagee.getName(), NamedTextColor.GREEN));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", Component.text(damagee.getName(), NamedTextColor.GREEN));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", Component.text(damager.getName(), NamedTextColor.GREEN));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -102,14 +102,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Concussion.java
@@ -102,14 +102,14 @@ public class Concussion extends PrepareSkill implements CooldownSkill, Listener,
         if (active.contains(damager.getUniqueId())) {
             event.addReason("Concussion");
             if (championsManager.getEffects().hasEffect(damagee, EffectTypes.CONCUSSED)) {
-                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
+                UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.already-concussed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
                 return;
             }
 
             championsManager.getEffects().addEffect(damagee, damager, EffectTypes.CONCUSSED, concussionStrength, (long) (getDuration(level) * 1000L));
 
-            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager));
-            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee));
+            UtilMessage.message(damager, getName(), "champions.skill.assassin.concussion.gave", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager));
+            UtilMessage.message(damagee, getName(), "champions.skill.assassin.concussion.received", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee));
             active.remove(damager.getUniqueId());
         }
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -168,7 +168,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", this.championsManager.getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
             active.remove(player.getUniqueId());
         });

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -168,7 +168,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
             active.remove(player.getUniqueId());
         });

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Evade.java
@@ -21,14 +21,13 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilLocation;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -116,7 +115,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
     }
 
 
-    @EventHandler (priority = EventPriority.LOW)
+    @EventHandler(priority = EventPriority.LOW)
     public void onEvade(DamageEvent event) {
         if (!event.getCause().getCategories().contains(DamageCauseCategory.MELEE)) return;
         if (!(event.getDamagee() instanceof Player player)) return;
@@ -169,9 +168,7 @@ public class Evade extends ChannelSkill implements InteractSkill, CooldownSkill,
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
-            if (ent instanceof Player temp) {
-                UtilMessage.message(temp, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
-            }
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.evade.target-used", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
 
             active.remove(player.getUniqueId());
         });

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -137,8 +137,8 @@ public class Sever extends Skill implements CooldownSkill, Listener, OffensiveSk
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 0.5F);
         } else {
             championsManager.getEffects().addEffect(ent, player, EffectTypes.BLEED, 1, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(ent, player));
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", this.championsManager.getDisplayNameAsComponent(ent, player));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", this.championsManager.getDisplayNameAsComponent(player, ent));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 1.5F);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -16,7 +16,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
@@ -138,8 +137,8 @@ public class Sever extends Skill implements CooldownSkill, Listener, OffensiveSk
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 0.5F);
         } else {
             championsManager.getEffects().addEffect(ent, player, EffectTypes.BLEED, 1, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(ent, player));
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(ent, player));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 1.5F);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Sever.java
@@ -138,8 +138,8 @@ public class Sever extends Skill implements CooldownSkill, Listener, OffensiveSk
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 0.5F);
         } else {
             championsManager.getEffects().addEffect(ent, player, EffectTypes.BLEED, 1, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", Component.text(ent.getName(), NamedTextColor.GREEN));
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", Component.text(player.getName(), NamedTextColor.GREEN));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(ent, player));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.assassin.sever.severed-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SPIDER_HURT, 1.0F, 1.5F);
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -139,8 +139,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -22,7 +22,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilLocation;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
@@ -140,8 +139,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -140,8 +140,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -141,8 +141,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -141,8 +141,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/sword/Slash.java
@@ -141,8 +141,8 @@ public class Slash extends Skill implements InteractSkill, CooldownSkill, Listen
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ENTITY_PLAYER_HURT, 0.8f, 2f);
             hit.getWorld().playSound(hit.getLocation().add(0, 1, 0), Sound.ITEM_TRIDENT_HIT, 0.8f, 1.5f);
 
-            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
@@ -170,7 +170,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
             double damage = calculateDamage(player, target, data);
             UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), damage, getName()));
             if (target instanceof Player damagee) {
-                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
@@ -24,7 +24,6 @@ import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
@@ -171,7 +170,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
             double damage = calculateDamage(player, target, data);
             UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), damage, getName()));
             if (target instanceof Player damagee) {
-                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/SeismicSlam.java
@@ -171,7 +171,7 @@ public class SeismicSlam extends Skill implements InteractSkill, CooldownSkill, 
             double damage = calculateDamage(player, target, data);
             UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), damage, getName()));
             if (target instanceof Player damagee) {
-                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -29,7 +29,6 @@ import me.mykindos.betterpvp.core.scheduler.TaskScheduler;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
@@ -178,10 +177,10 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     public void doTakedown(Player player, LivingEntity target) {
         int level = getLevel(player);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), "Takedown"));
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(player, target, null, new SkillDamageCause(this), getRecoilDamage(level), "Takedown Recoil"));
 
         long duration = (long) (getDuration(level) * 1000L);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -177,10 +177,10 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     public void doTakedown(Player player, LivingEntity target) {
         int level = getLevel(player);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), "Takedown"));
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(player, target, null, new SkillDamageCause(this), getRecoilDamage(level), "Takedown Recoil"));
 
         long duration = (long) (getDuration(level) * 1000L);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/Takedown.java
@@ -178,10 +178,10 @@ public class Takedown extends Skill implements InteractSkill, CooldownSkill, Lis
     public void doTakedown(Player player, LivingEntity target) {
         int level = getLevel(player);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.GREEN), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), "Takedown"));
 
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.GREEN), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         UtilDamage.doDamage(new DamageEvent(player, target, null, new SkillDamageCause(this), getRecoilDamage(level), "Takedown Recoil"));
 
         long duration = (long) (getDuration(level) * 1000L);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
@@ -183,7 +183,7 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
                                         getDamage(level),
                                         "Threatening Shout"));
                                 championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, vulnerabilityStrength, (long) (getDuration(level) * 1000L));
-                                UtilMessage.message(player, getName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+                                UtilMessage.message(player, getName(), "champions.skill.hit-target", ThreateningShout.this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
                                 damagedEntities.add(target);
                             }
                         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
@@ -26,7 +26,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -183,7 +182,7 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
                                         getDamage(level),
                                         "Threatening Shout"));
                                 championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, vulnerabilityStrength, (long) (getDuration(level) * 1000L));
-                                UtilMessage.message(player, getName(), "champions.skill.hit-target", ThreateningShout.this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
+                                UtilMessage.message(player, getName(), "champions.skill.hit-target", ThreateningShout.this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
                                 damagedEntities.add(target);
                             }
                         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/axe/ThreateningShout.java
@@ -182,7 +182,7 @@ public class ThreateningShout extends Skill implements Listener, InteractSkill, 
                                         getDamage(level),
                                         "Threatening Shout"));
                                 championsManager.getEffects().addEffect(target, EffectTypes.VULNERABILITY, vulnerabilityStrength, (long) (getDuration(level) * 1000L));
-                                UtilMessage.message(player, getName(), "champions.skill.hit-target", ThreateningShout.this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
+                                UtilMessage.message(player, getName(), "champions.skill.hit-target", ThreateningShout.this.championsManager.getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
                                 damagedEntities.add(target);
                             }
                         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/BlockTossObject.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/BlockTossObject.java
@@ -327,13 +327,13 @@ public final class BlockTossObject {
                         new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                         damage,
                         skill.getName()));
-                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
+                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
             }
         }
 
         if (!damaged.isEmpty()) {
             Component nameList = Component.join(net.kyori.adventure.text.JoinConfiguration.separator(Component.text(", ")),
-                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, caster)).toList());
+                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, caster)).toList());
             UtilMessage.message(caster, skill.getName(), "champions.skill.hit-target", nameList, skill.getDisplayName().color(NamedTextColor.GREEN));
             caster.playSound(caster.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1.0F, 1.0F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/BlockTossObject.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/BlockTossObject.java
@@ -39,7 +39,6 @@ import org.joml.Vector3f;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.PROJECTILE;
 
@@ -328,13 +327,13 @@ public final class BlockTossObject {
                         new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                         damage,
                         skill.getName()));
-                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
             }
         }
 
         if (!damaged.isEmpty()) {
             Component nameList = Component.join(net.kyori.adventure.text.JoinConfiguration.separator(Component.text(", ")),
-                    damaged.stream().map(player -> Component.text(player.getName(), NamedTextColor.YELLOW)).toList());
+                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, caster)).toList());
             UtilMessage.message(caster, skill.getName(), "champions.skill.hit-target", nameList, skill.getDisplayName().color(NamedTextColor.GREEN));
             caster.playSound(caster.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1.0F, 1.0F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/SkullsplitterProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/SkullsplitterProjectile.java
@@ -191,8 +191,8 @@ public class SkullsplitterProjectile extends Projectile {
                     new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                     bleedSeconds,
                     skill.getName()));
-            UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(damagee.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/SkullsplitterProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/data/SkullsplitterProjectile.java
@@ -10,7 +10,6 @@ import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
@@ -191,8 +190,8 @@ public class SkullsplitterProjectile extends Projectile {
                     new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                     bleedSeconds,
                     skill.getName()));
-            UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
         }
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -216,8 +216,8 @@ public class FleshHook extends ChargeSkill implements InteractSkill, CooldownSki
         UtilDamage.doDamage(ev);
 
         // Cues
-        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, hit), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", this.championsManager.getDisplayNameAsComponent(player, hit), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(hit, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         new SoundEffect(Sound.ENTITY_ARROW_HIT_PLAYER, 2f, 2f).play(player);
 
         throwableItem.getItem().remove();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -26,7 +26,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
@@ -217,8 +216,8 @@ public class FleshHook extends ChargeSkill implements InteractSkill, CooldownSki
         UtilDamage.doDamage(ev);
 
         // Cues
-        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, hit), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, hit), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         new SoundEffect(Sound.ENTITY_ARROW_HIT_PLAYER, 2f, 2f).play(player);
 
         throwableItem.getItem().remove();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/FleshHook.java
@@ -217,8 +217,8 @@ public class FleshHook extends ChargeSkill implements InteractSkill, CooldownSki
         UtilDamage.doDamage(ev);
 
         // Cues
-        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(hit, getClassType().getDisplayName(), "champions.skill.brute.flesh-hook.pulled-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, hit), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         new SoundEffect(Sound.ENTITY_ARROW_HIT_PLAYER, 2f, 2f).play(player);
 
         throwableItem.getItem().remove();

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
@@ -102,7 +102,7 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
                     VelocityData velocityData = new VelocityData(velocity, 1.0D, true, 0.0D, 0.25D, 4.0D, true);
                     UtilVelocity.velocity(target, player, velocityData);
                     UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), getName()));
-                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", this.championsManager.getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                 }
 
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
@@ -17,7 +17,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -103,7 +102,7 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
                     VelocityData velocityData = new VelocityData(velocity, 1.0D, true, 0.0D, 0.25D, 4.0D, true);
                     UtilVelocity.velocity(target, player, velocityData);
                     UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), getName()));
-                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                 }
 
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/brute/sword/WhirlwindSword.java
@@ -103,7 +103,7 @@ public class WhirlwindSword extends Skill implements InteractSkill, CooldownSkil
                     VelocityData velocityData = new VelocityData(velocity, 1.0D, true, 0.0D, 0.25D, 4.0D, true);
                     UtilVelocity.velocity(target, player, velocityData);
                     UtilDamage.doDamage(new DamageEvent(target, player, null, new SkillDamageCause(this), getDamage(level), getName()));
-                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", Component.text(player.getName(), NamedTextColor.GREEN), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getName(), "champions.skill.brute.whirlwind-sword.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                 }
 
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
@@ -134,9 +134,9 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ENDERMAN_SCREAM, 1.5F, 0.0F);
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 1.5F, 0.5F);
 
-                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
-                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 running.remove(damager.getUniqueId());
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
@@ -134,9 +134,9 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ENDERMAN_SCREAM, 1.5F, 0.0F);
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 1.5F, 0.5F);
 
-                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
-                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 running.remove(damager.getUniqueId());
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/BullsCharge.java
@@ -98,7 +98,7 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
         championsManager.getEffects().addEffect(player, EffectTypes.SPEED, getName(), speedStrength, (long) (getSpeedDuration(level) * 1000L));
         UtilSound.playSound(player.getWorld(), player, Sound.ENTITY_ENDERMAN_SCREAM, 1.5F, 0);
         player.getWorld().playEffect(player.getLocation(), Effect.STEP_SOUND, Material.OBSIDIAN);
-        running.put(player.getUniqueId(), System.currentTimeMillis() + (long)(getSpeedDuration(level) * 1000));
+        running.put(player.getUniqueId(), System.currentTimeMillis() + (long) (getSpeedDuration(level) * 1000));
         return true;
     }
 
@@ -134,11 +134,9 @@ public class BullsCharge extends Skill implements Listener, InteractSkill, Coold
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ENDERMAN_SCREAM, 1.5F, 0.0F);
                 damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 1.5F, 0.5F);
 
-                if (event.getDamagee() instanceof Player damaged) {
-                    UtilMessage.message(damaged, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-                }
+                UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
-                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(event.getDamagee().getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 running.remove(damager.getUniqueId());
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
@@ -151,7 +151,7 @@ public class ShieldSmash extends Skill implements InteractSkill, CooldownSkill, 
             }
 
             // Inform them
-            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN));
         }
 
         if (hit) { // entity hit

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
@@ -21,7 +21,6 @@ import me.mykindos.betterpvp.core.framework.customtypes.KeyValue;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
 import me.mykindos.betterpvp.core.utilities.events.EntityProperty;
@@ -152,7 +151,7 @@ public class ShieldSmash extends Skill implements InteractSkill, CooldownSkill, 
             }
 
             // Inform them
-            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN));
         }
 
         if (hit) { // entity hit

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/axe/ShieldSmash.java
@@ -152,7 +152,7 @@ public class ShieldSmash extends Skill implements InteractSkill, CooldownSkill, 
             }
 
             // Inform them
-            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(ent, "core.prefix.skill", "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN));
         }
 
         if (hit) { // entity hit

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
@@ -8,7 +8,6 @@ import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.combat.events.EntityCanHurtEntityEvent;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.model.projectile.Projectile;
 import org.bukkit.Location;
@@ -135,8 +134,8 @@ public class AxeProjectile extends Projectile {
                 new SkillDamageCause(skill, false, DamageCause.DEFAULT_DELAY, true).withBukkitCause(PROJECTILE),
                 damage,
                 skill.getName()));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/AxeProjectile.java
@@ -135,8 +135,8 @@ public class AxeProjectile extends Projectile {
                 new SkillDamageCause(skill, false, DamageCause.DEFAULT_DELAY, true).withBukkitCause(PROJECTILE),
                 damage,
                 skill.getName()));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(damagee.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(damagee, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, damagee), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 
     @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
@@ -5,7 +5,6 @@ import me.mykindos.betterpvp.champions.combat.damage.SkillDamageCause;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.projectile.ReturningLinkProjectile;
@@ -125,7 +124,7 @@ public class BattlebindProjectile extends ReturningLinkProjectile {
         event.setDamageDelay(0);
         UtilDamage.doDamage(event);
 
-        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
@@ -125,7 +125,7 @@ public class BattlebindProjectile extends ReturningLinkProjectile {
         event.setDamageDelay(0);
         UtilDamage.doDamage(event);
 
-        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
@@ -5,9 +5,12 @@ import me.mykindos.betterpvp.champions.combat.damage.SkillDamageCause;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
+<<<<<<< HEAD
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.projectile.LinkProjectile;
 import net.kyori.adventure.text.Component;
+=======
+>>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -136,8 +139,11 @@ public class BattlebindProjectile extends LinkProjectile {
         event.setDamageDelay(0);
         UtilDamage.doDamage(event);
 
+<<<<<<< HEAD
         skill.bind(caster, hit, level);
 
+=======
+>>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
         UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
         UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
@@ -5,12 +5,8 @@ import me.mykindos.betterpvp.champions.combat.damage.SkillDamageCause;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-<<<<<<< HEAD
 import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
 import me.mykindos.betterpvp.core.utilities.model.projectile.LinkProjectile;
-import net.kyori.adventure.text.Component;
-=======
->>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -139,11 +135,8 @@ public class BattlebindProjectile extends LinkProjectile {
         event.setDamageDelay(0);
         UtilDamage.doDamage(event);
 
-<<<<<<< HEAD
         skill.bind(caster, hit, level);
 
-=======
->>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
         UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
         UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/data/BattlebindProjectile.java
@@ -138,7 +138,7 @@ public class BattlebindProjectile extends LinkProjectile {
 
         skill.bind(caster, hit, level);
 
-        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
@@ -158,9 +158,9 @@ public class HiltSmash extends Skill implements CooldownSkill, Listener, Offensi
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.knight.hilt-smash.failed", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 1.0F, 0.0F);
         } else {
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             championsManager.getEffects().addEffect(ent, player, EffectTypes.SLOWNESS, slowStrength, (long) (getDuration(level) * 1000));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(ent, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(ent, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             UtilDamage.doDamage(new DamageEvent(ent, player, null, new SkillDamageCause(this), getDamage(level), getName()));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1.0F, 1.2F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
@@ -25,7 +25,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilServer;
@@ -159,9 +158,9 @@ public class HiltSmash extends Skill implements CooldownSkill, Listener, Offensi
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.knight.hilt-smash.failed", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 1.0F, 0.0F);
         } else {
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             championsManager.getEffects().addEffect(ent, player, EffectTypes.SLOWNESS, slowStrength, (long) (getDuration(level) * 1000));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(ent, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(ent, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             UtilDamage.doDamage(new DamageEvent(ent, player, null, new SkillDamageCause(this), getDamage(level), getName()));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1.0F, 1.2F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/HiltSmash.java
@@ -159,9 +159,9 @@ public class HiltSmash extends Skill implements CooldownSkill, Listener, Offensi
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.knight.hilt-smash.failed", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_ATTACK, 1.0F, 0.0F);
         } else {
-            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(ent, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ent), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             championsManager.getEffects().addEffect(ent, player, EffectTypes.SLOWNESS, slowStrength, (long) (getDuration(level) * 1000));
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(ent.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(ent, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             UtilDamage.doDamage(new DamageEvent(ent, player, null, new SkillDamageCause(this), getDamage(level), getName()));
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1.0F, 1.2F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
@@ -141,7 +141,7 @@ public class Riposte extends ChannelSkill implements CooldownSkill, InteractSkil
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             if (ent instanceof Player target) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             }
 
             active.remove(player.getUniqueId());

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
@@ -24,7 +24,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -141,7 +140,7 @@ public class Riposte extends ChannelSkill implements CooldownSkill, InteractSkil
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             if (ent instanceof Player target) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             }
 
             active.remove(player.getUniqueId());

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/knight/sword/Riposte.java
@@ -140,7 +140,7 @@ public class Riposte extends ChannelSkill implements CooldownSkill, InteractSkil
 
             UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.used", getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             if (ent instanceof Player target) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.knight.riposte.target-used", this.championsManager.getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN), Component.text(String.valueOf(level), NamedTextColor.GREEN));
             }
 
             active.remove(player.getUniqueId());

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
@@ -115,7 +115,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
                 AttributeInstance targetMaxHealth = target.getAttribute(Attribute.MAX_HEALTH);
                 if (targetMaxHealth != null) {
                     double targetHeal = UtilEntity.health(target, 4d * healthBoostStrength);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                     target.playSound(target, Sound.ENTITY_VILLAGER_WORK_CLERIC, 1f, 1.1f);
                     target.spawnParticle(Particle.HEART, target.getLocation().add(new Vector(0, 1, 0)), 6, 0.5, 0.5, 0.5);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
@@ -114,7 +114,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
                 AttributeInstance targetMaxHealth = target.getAttribute(Attribute.MAX_HEALTH);
                 if (targetMaxHealth != null) {
                     double targetHeal = UtilEntity.health(target, 4d * healthBoostStrength);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", this.championsManager.getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                     target.playSound(target, Sound.ENTITY_VILLAGER_WORK_CLERIC, 1f, 1.1f);
                     target.spawnParticle(Particle.HEART, target.getLocation().add(new Vector(0, 1, 0)), 6, 0.5, 0.5, 0.5);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/DefensiveAura.java
@@ -20,7 +20,6 @@ import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
 import net.kyori.adventure.text.Component;
@@ -115,7 +114,7 @@ public class DefensiveAura extends Skill implements InteractSkill, CooldownSkill
                 AttributeInstance targetMaxHealth = target.getAttribute(Attribute.MAX_HEALTH);
                 if (targetMaxHealth != null) {
                     double targetHeal = UtilEntity.health(target, 4d * healthBoostStrength);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.mage.defensive-aura.casted-on", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
                     target.playSound(target, Sound.ENTITY_VILLAGER_WORK_CLERIC, 1f, 1.1f);
                     target.spawnParticle(Particle.HEART, target.getLocation().add(new Vector(0, 1, 0)), 6, 0.5, 0.5, 0.5);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -190,8 +190,8 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
             double damage = getDamage(distance, fissureCast.getLevel());
             UtilDamage.doDamage(new DamageEvent(livingEntity, fissureCast.getPlayer(), null, new SkillDamageCause(this), damage, "Fissure"));
 
-            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(livingEntity.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(fissureCast.getPlayer().getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(livingEntity, fissureCast.getPlayer()), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(fissureCast.getPlayer(), livingEntity), getDisplayName().color(NamedTextColor.GREEN));
 
             fissureCast.getEntitiesHit().add(livingEntity.getUniqueId());
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -25,7 +25,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.world.blocks.WorldBlockHandler;
@@ -190,8 +189,8 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
             double damage = getDamage(distance, fissureCast.getLevel());
             UtilDamage.doDamage(new DamageEvent(livingEntity, fissureCast.getPlayer(), null, new SkillDamageCause(this), damage, "Fissure"));
 
-            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(livingEntity, fissureCast.getPlayer()), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(fissureCast.getPlayer(), livingEntity), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(livingEntity, fissureCast.getPlayer()), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(fissureCast.getPlayer(), livingEntity), getDisplayName().color(NamedTextColor.GREEN));
 
             fissureCast.getEntitiesHit().add(livingEntity.getUniqueId());
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/axe/Fissure.java
@@ -189,8 +189,8 @@ public class Fissure extends Skill implements InteractSkill, CooldownSkill, List
             double damage = getDamage(distance, fissureCast.getLevel());
             UtilDamage.doDamage(new DamageEvent(livingEntity, fissureCast.getPlayer(), null, new SkillDamageCause(this), damage, "Fissure"));
 
-            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(livingEntity, fissureCast.getPlayer()), getDisplayName().color(NamedTextColor.GREEN));
-            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(fissureCast.getPlayer(), livingEntity), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(fissureCast.getPlayer(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(livingEntity, fissureCast.getPlayer()), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(livingEntity, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(fissureCast.getPlayer(), livingEntity), getDisplayName().color(NamedTextColor.GREEN));
 
             fissureCast.getEntitiesHit().add(livingEntity.getUniqueId());
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/BlockTossObject.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/BlockTossObject.java
@@ -327,13 +327,13 @@ public final class BlockTossObject {
                         new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                         damage,
                         skill.getName()));
-                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
+                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
             }
         }
 
         if (!damaged.isEmpty()) {
             Component nameList = Component.join(net.kyori.adventure.text.JoinConfiguration.separator(Component.text(", ")),
-                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, caster)).toList());
+                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, caster)).toList());
             UtilMessage.message(caster, skill.getName(), "champions.skill.hit-target", nameList, skill.getDisplayName().color(NamedTextColor.GREEN));
             caster.playSound(caster.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1.0F, 1.0F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/BlockTossObject.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/mage/data/BlockTossObject.java
@@ -39,7 +39,6 @@ import org.joml.Vector3f;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.PROJECTILE;
 
@@ -328,13 +327,13 @@ public final class BlockTossObject {
                         new SkillDamageCause(skill).withBukkitCause(PROJECTILE),
                         damage,
                         skill.getName()));
-                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+                UtilMessage.message(ent, skill.getName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, ent), skill.getDisplayName().color(NamedTextColor.GREEN));
             }
         }
 
         if (!damaged.isEmpty()) {
             Component nameList = Component.join(net.kyori.adventure.text.JoinConfiguration.separator(Component.text(", ")),
-                    damaged.stream().map(player -> Component.text(player.getName(), NamedTextColor.YELLOW)).toList());
+                    damaged.stream().map(player -> this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, caster)).toList());
             UtilMessage.message(caster, skill.getName(), "champions.skill.hit-target", nameList, skill.getDisplayName().color(NamedTextColor.GREEN));
             caster.playSound(caster.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1.0F, 1.0F);
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -13,7 +13,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -81,8 +80,8 @@ public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill,
     public void onHit(Player damager, LivingEntity target, int level) {
 
         championsManager.getEffects().addEffect(target, damager, EffectTypes.LEVITATION, levitationStrength, (int) (getDuration(level) * 1000));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -81,8 +81,8 @@ public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill,
     public void onHit(Player damager, LivingEntity target, int level) {
 
         championsManager.getEffects().addEffect(target, damager, EffectTypes.LEVITATION, levitationStrength, (int) (getDuration(level) * 1000));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/LevitatingShot.java
@@ -80,8 +80,8 @@ public class LevitatingShot extends PrepareArrowSkill implements OffensiveSkill,
     public void onHit(Player damager, LivingEntity target, int level) {
 
         championsManager.getEffects().addEffect(target, damager, EffectTypes.LEVITATION, levitationStrength, (int) (getDuration(level) * 1000));
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
 
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
@@ -196,9 +196,9 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
             championsManager.getEffects().addEffect(target, damager, EffectTypes.SPEED, getSpeedStrength(level), (long) (getDuration(level) * 1000L));
         }
 
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         if (!damager.equals(target)) {
-            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }
@@ -220,8 +220,8 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
                     event.addModifier(new SkillDamageModifier.Flat(this, getExtraDamage(level)));
                     iterator.remove();
                     event.getDamagee().getWorld().playSound(event.getDamagee().getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 1.0f);
-                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(event.getDamagee(), event.getDamager()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(event.getDamager(), event.getDamagee()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(event.getDamagee(), event.getDamager()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameAsComponent(event.getDamager(), event.getDamagee()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 }
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
@@ -196,9 +196,9 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
             championsManager.getEffects().addEffect(target, damager, EffectTypes.SPEED, getSpeedStrength(level), (long) (getDuration(level) * 1000L));
         }
 
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        if (!damager.equals(target) && target instanceof Player targetPlayer) {
-            UtilMessage.message(targetPlayer, getClassType().getDisplayName(), "champions.skill.hit-by-alt", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        if (!damager.equals(target)) {
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }
@@ -220,8 +220,8 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
                     event.addModifier(new SkillDamageModifier.Flat(this, getExtraDamage(level)));
                     iterator.remove();
                     event.getDamagee().getWorld().playSound(event.getDamagee().getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 1.0f);
-                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(event.getDamagee().getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", Component.text(event.getDamager().getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(event.getDamagee(), event.getDamager()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(event.getDamager(), event.getDamagee()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 }
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/MarkOfTheWolf.java
@@ -196,9 +196,9 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
             championsManager.getEffects().addEffect(target, damager, EffectTypes.SPEED, getSpeedStrength(level), (long) (getDuration(level) * 1000L));
         }
 
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         if (!damager.equals(target)) {
-            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }
@@ -220,8 +220,8 @@ public class MarkOfTheWolf extends PrepareArrowSkill implements TeamSkill, BuffS
                     event.addModifier(new SkillDamageModifier.Flat(this, getExtraDamage(level)));
                     iterator.remove();
                     event.getDamagee().getWorld().playSound(event.getDamagee().getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 1.0f);
-                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(event.getDamagee(), event.getDamager()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(event.getDamager(), event.getDamagee()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamager(), getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(event.getDamagee(), event.getDamager()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                    UtilMessage.message(event.getDamagee(), getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(event.getDamager(), event.getDamagee()), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
                 }
             }
         }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
@@ -20,7 +20,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -200,8 +199,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
                 b.setMetadata("isTetherBat", new FixedMetadataValue(champions, true));
             });
 
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(enemy, player));
-            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, enemy));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(enemy, player));
+            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, enemy));
 
             bat.setLeashHolder(enemy);
 
@@ -361,8 +360,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
         championsManager.getEffects().addEffect(enemy, player, EffectTypes.SLOWNESS, 1, (long) (getSlowDuration(level) * 1000));
         player.getWorld().playSound(enemy.getLocation(), Sound.ITEM_ARMOR_UNEQUIP_WOLF, 1.0F, 2.0F);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(enemy, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, enemy), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(enemy, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, enemy), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
@@ -199,8 +199,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
                 b.setMetadata("isTetherBat", new FixedMetadataValue(champions, true));
             });
 
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(enemy, player));
-            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, enemy));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", this.championsManager.getDisplayNameAsComponent(enemy, player));
+            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", this.championsManager.getDisplayNameAsComponent(player, enemy));
 
             bat.setLeashHolder(enemy);
 
@@ -360,8 +360,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
         championsManager.getEffects().addEffect(enemy, player, EffectTypes.SLOWNESS, 1, (long) (getSlowDuration(level) * 1000));
         player.getWorld().playSound(enemy.getLocation(), Sound.ITEM_ARMOR_UNEQUIP_WOLF, 1.0F, 2.0F);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(enemy, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, enemy), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(enemy, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, enemy), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/bow/TetherShot.java
@@ -200,8 +200,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
                 b.setMetadata("isTetherBat", new FixedMetadataValue(champions, true));
             });
 
-            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", Component.text(enemy.getName(), NamedTextColor.YELLOW));
-            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", Component.text(player.getName(), NamedTextColor.YELLOW));
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(enemy, player));
+            UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.ranger.tether-shot.tethered-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, enemy));
 
             bat.setLeashHolder(enemy);
 
@@ -361,8 +361,8 @@ public class TetherShot extends PrepareArrowSkill implements InteractSkill, Cool
         championsManager.getEffects().addEffect(enemy, player, EffectTypes.SLOWNESS, 1, (long) (getSlowDuration(level) * 1000));
         player.getWorld().playSound(enemy.getLocation(), Sound.ITEM_ARMOR_UNEQUIP_WOLF, 1.0F, 2.0F);
 
-        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(enemy.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(enemy, player), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(enemy, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, enemy), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
     }
 
     @EventHandler

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/data/DaggerProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/data/DaggerProjectile.java
@@ -5,7 +5,6 @@ import me.mykindos.betterpvp.champions.combat.damage.SkillDamageCause;
 import me.mykindos.betterpvp.core.combat.events.DamageEvent;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.model.projectile.Projectile;
 import org.bukkit.Location;
@@ -84,8 +83,8 @@ public class DaggerProjectile extends Projectile {
                 damage,
                 skill.getName()));
 
-        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 
     public void remove() {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/data/DaggerProjectile.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/data/DaggerProjectile.java
@@ -84,8 +84,8 @@ public class DaggerProjectile extends Projectile {
                 damage,
                 skill.getName()));
 
-        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(caster.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
-        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(hit.getName(), NamedTextColor.YELLOW), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(hit, skill.getClassType().getDisplayName(), "champions.skill.hit-by", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(caster, hit), skill.getDisplayName().color(NamedTextColor.GREEN));
+        UtilMessage.message(caster, skill.getClassType().getDisplayName(), "champions.skill.hit-target", this.skill.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(hit, caster), skill.getDisplayName().color(NamedTextColor.GREEN));
     }
 
     public void remove() {

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -207,7 +207,7 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 BarbedTargetData barbedData = targetEntry.getValue();
 
                 if (currentTime - barbedData.hitTime > damageResetTimeMs) {
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), Component.text(target.getName()));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player));
                     targetIterator.remove();
                 }
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -207,7 +207,7 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 BarbedTargetData barbedData = targetEntry.getValue();
 
                 if (currentTime - barbedData.hitTime > damageResetTimeMs) {
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), this.championsManager.getDisplayNameAsComponent(target, player));
                     targetIterator.remove();
                 }
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BarbedArrows.java
@@ -207,7 +207,7 @@ public class BarbedArrows extends Skill implements PassiveSkill, DamageSkill {
                 BarbedTargetData barbedData = targetEntry.getValue();
 
                 if (currentTime - barbedData.hitTime > damageResetTimeMs) {
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.ranger.barbed-arrows.fallen-out", getDisplayName().color(NamedTextColor.GREEN), this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player));
                     targetIterator.remove();
                 }
             }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
@@ -237,15 +237,15 @@ public class BioticQuiver extends Skill implements PassiveSkill, CooldownSkill, 
             target.getWorld().spawnParticle(Particle.HEART, target.getLocation().add(0, 1.5, 0), 5, 0.5, 0.5, 0.5, 0);
             target.getWorld().playSound(target.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 2, 1.5F);
 
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             if (!damager.equals(target)) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
 
         } else {
             championsManager.getEffects().addEffect(target, damager, EffectTypes.ANTI_HEAL, 1, (long) (getNaturalRegenerationDisabledDuration(level) * 1000));
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
@@ -21,7 +21,6 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -238,15 +237,15 @@ public class BioticQuiver extends Skill implements PassiveSkill, CooldownSkill, 
             target.getWorld().spawnParticle(Particle.HEART, target.getLocation().add(0, 1.5, 0), 5, 0.5, 0.5, 0.5, 0);
             target.getWorld().playSound(target.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 2, 1.5F);
 
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             if (!damager.equals(target)) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
 
         } else {
             championsManager.getEffects().addEffect(target, damager, EffectTypes.ANTI_HEAL, 1, (long) (getNaturalRegenerationDisabledDuration(level) * 1000));
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/passives/BioticQuiver.java
@@ -238,15 +238,15 @@ public class BioticQuiver extends Skill implements PassiveSkill, CooldownSkill, 
             target.getWorld().spawnParticle(Particle.HEART, target.getLocation().add(0, 1.5, 0), 5, 0.5, 0.5, 0.5, 0);
             target.getWorld().playSound(target.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 2, 1.5F);
 
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             if (!damager.equals(target)) {
-                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+                UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by-alt", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
             }
 
         } else {
             championsManager.getEffects().addEffect(target, damager, EffectTypes.ANTI_HEAL, 1, (long) (getNaturalRegenerationDisabledDuration(level) * 1000));
-            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+            UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, target), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         }
 
     }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
@@ -213,7 +213,7 @@ public class Bullseye extends ChannelSkill implements CooldownSkill, InteractSki
             bullsEyeData.keySet().removeIf(playerUUID -> damager == Bukkit.getPlayer(playerUUID));
             event.addModifier(new SkillDamageModifier.Flat(this, getBonusDamage(playerLevel)));
             damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_VILLAGER_WORK_FLETCHER, 2f, 1.2f);
-            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.GREEN), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN));
 
             //apply cooldown
             championsManager.getCooldowns().removeCooldown(damager, getName(), true);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
@@ -212,7 +212,7 @@ public class Bullseye extends ChannelSkill implements CooldownSkill, InteractSki
             bullsEyeData.keySet().removeIf(playerUUID -> damager == Bukkit.getPlayer(playerUUID));
             event.addModifier(new SkillDamageModifier.Flat(this, getBonusDamage(playerLevel)));
             damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_VILLAGER_WORK_FLETCHER, 2f, 1.2f);
-            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN));
 
             //apply cooldown
             championsManager.getCooldowns().removeCooldown(damager, getName(), true);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/Bullseye.java
@@ -21,7 +21,6 @@ import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -213,7 +212,7 @@ public class Bullseye extends ChannelSkill implements CooldownSkill, InteractSki
             bullsEyeData.keySet().removeIf(playerUUID -> damager == Bukkit.getPlayer(playerUUID));
             event.addModifier(new SkillDamageModifier.Flat(this, getBonusDamage(playerLevel)));
             damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_VILLAGER_WORK_FLETCHER, 2f, 1.2f);
-            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN));
+            UtilMessage.message(damagee, getName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN));
 
             //apply cooldown
             championsManager.getCooldowns().removeCooldown(damager, getName(), true);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
@@ -27,7 +27,6 @@ import me.mykindos.betterpvp.core.utilities.UtilBlock;
 import me.mykindos.betterpvp.core.utilities.UtilDamage;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.utilities.UtilEntity;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilTime;
 import me.mykindos.betterpvp.core.utilities.UtilVelocity;
@@ -160,8 +159,8 @@ public class WolfsPounce extends ChargeSkill implements InteractSkill, CooldownS
         championsManager.getEffects().addEffect(damagee, damager, EffectTypes.SLOWNESS, slowStrength, (long) (getSlowDuration(level) * 1000));
 
         // Cues
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 0.5f);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
@@ -160,8 +160,8 @@ public class WolfsPounce extends ChargeSkill implements InteractSkill, CooldownS
         championsManager.getEffects().addEffect(damagee, damager, EffectTypes.SLOWNESS, slowStrength, (long) (getSlowDuration(level) * 1000));
 
         // Cues
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(damagee.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(damager.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 0.5f);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/ranger/sword/WolfsPounce.java
@@ -159,8 +159,8 @@ public class WolfsPounce extends ChargeSkill implements InteractSkill, CooldownS
         championsManager.getEffects().addEffect(damagee, damager, EffectTypes.SLOWNESS, slowStrength, (long) (getSlowDuration(level) * 1000));
 
         // Cues
-        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
-        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damager, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(damagee, damager), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
+        UtilMessage.message(damagee, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(damager, damagee), getDisplayName().color(NamedTextColor.GREEN).append(Component.text(" " + level, NamedTextColor.GREEN)));
         damager.getWorld().playSound(damager.getLocation(), Sound.ENTITY_WOLF_AMBIENT, 0.5f, 0.5f);
     }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -116,7 +116,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
             }
 
             championsManager.getEffects().addEffect(target, EffectTypes.SPEED, speedStrength, (long) (duration * 1000));
-            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
+            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
             player.playSound(player.getLocation(), Sound.BLOCK_CONDUIT_AMBIENT, 2.0f, 2.0f);
             healthReduction += getHealthReductionPerPlayerAffected(level);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -116,7 +116,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
             }
 
             championsManager.getEffects().addEffect(target, EffectTypes.SPEED, speedStrength, (long) (duration * 1000));
-            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", Component.text(player.getName(), NamedTextColor.YELLOW), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
+            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
             player.playSound(player.getLocation(), Sound.BLOCK_CONDUIT_AMBIENT, 2.0f, 2.0f);
             healthReduction += getHealthReductionPerPlayerAffected(level);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Bloodshed.java
@@ -116,7 +116,7 @@ public class Bloodshed extends Skill implements InteractSkill, CooldownSkill, He
             }
 
             championsManager.getEffects().addEffect(target, EffectTypes.SPEED, speedStrength, (long) (duration * 1000));
-            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
+            UtilMessage.message(target, getName(), "champions.skill.warlock.bloodshed.gave-speed", this.championsManager.getDisplayNameAsComponent(player, target), Translations.component("champions.skill.effect.speed", Component.text(UtilFormat.getRomanNumeral(speedStrength))).color(NamedTextColor.WHITE), Component.text(String.valueOf(getDuration(level)), NamedTextColor.GREEN));
             player.playSound(player.getLocation(), Sound.BLOCK_CONDUIT_AMBIENT, 2.0f, 2.0f);
             healthReduction += getHealthReductionPerPlayerAffected(level);
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -129,7 +129,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
             healthReduction += getHealthReductionPerPlayerAffected(level);
 
             championsManager.getEffects().addEffect(ally, EffectTypes.IMMUNE, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", Component.text(player.getName(), NamedTextColor.GREEN));
+            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ally));
             UtilServer.callEvent(new EffectClearEvent(ally));
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -128,7 +128,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
             healthReduction += getHealthReductionPerPlayerAffected(level);
 
             championsManager.getEffects().addEffect(ally, EffectTypes.IMMUNE, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ally));
+            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", this.championsManager.getDisplayNameAsComponent(player, ally));
             UtilServer.callEvent(new EffectClearEvent(ally));
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/axe/Cleanse.java
@@ -15,7 +15,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.effects.EffectTypes;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import me.mykindos.betterpvp.core.effects.events.EffectClearEvent;
@@ -129,7 +128,7 @@ public class Cleanse extends Skill implements InteractSkill, CooldownSkill, List
             healthReduction += getHealthReductionPerPlayerAffected(level);
 
             championsManager.getEffects().addEffect(ally, EffectTypes.IMMUNE, (long) (getDuration(level) * 1000L));
-            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, ally));
+            UtilMessage.message(ally, "core.prefix.cleanse", "champions.skill.warlock.cleanse.cleansed", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, ally));
             UtilServer.callEvent(new EffectClearEvent(ally));
         }
 

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
@@ -246,8 +246,8 @@ public class BloodCompass extends Skill implements CooldownToggleSkill, Listener
                     show(player, nearbyAllies, target);
 
                     player.playSound(player.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1.0f, 1.0f);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
 
                     new BukkitRunnable() {
                         @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
@@ -11,7 +11,6 @@ import me.mykindos.betterpvp.core.components.champions.Role;
 import me.mykindos.betterpvp.core.components.champions.SkillType;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
 import me.mykindos.betterpvp.core.locale.Translations;
-import me.mykindos.betterpvp.core.utilities.UtilFormat;
 import me.mykindos.betterpvp.core.utilities.UtilMath;
 import me.mykindos.betterpvp.core.utilities.UtilMessage;
 import me.mykindos.betterpvp.core.utilities.UtilPlayer;
@@ -247,8 +246,8 @@ public class BloodCompass extends Skill implements CooldownToggleSkill, Listener
                     show(player, nearbyAllies, target);
 
                     player.playSound(player.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1.0f, 1.0f);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameService().getProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
 
                     new BukkitRunnable() {
                         @Override

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/warlock/passives/BloodCompass.java
@@ -247,8 +247,8 @@ public class BloodCompass extends Skill implements CooldownToggleSkill, Listener
                     show(player, nearbyAllies, target);
 
                     player.playSound(player.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1.0f, 1.0f);
-                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", Component.text(player.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
-                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", Component.text(target.getName(), NamedTextColor.YELLOW), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(target, getClassType().getDisplayName(), "champions.skill.hit-by", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(player, target), getDisplayName().color(NamedTextColor.GREEN));
+                    UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.hit-target", this.championsManager.getDisplayNameProvider().getDisplayNameAsComponent(target, player), getDisplayName().color(NamedTextColor.GREEN));
 
                     new BukkitRunnable() {
                         @Override

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
@@ -13,6 +13,7 @@ import me.mykindos.betterpvp.clans.clans.loot.ClanEnergyLoot;
 import me.mykindos.betterpvp.clans.commands.ClansCommandLoader;
 import me.mykindos.betterpvp.clans.display.ClanHudInfo;
 import me.mykindos.betterpvp.clans.display.ClansSidebarListener;
+import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
 import me.mykindos.betterpvp.clans.injector.ClansInjectorModule;
 import me.mykindos.betterpvp.clans.leaderboards.ClansLeaderboardLoader;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
@@ -21,6 +22,7 @@ import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.config.ConfigInjectorModule;
 import me.mykindos.betterpvp.core.database.Database;
+import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
 import me.mykindos.betterpvp.core.framework.CurrentMode;
 import me.mykindos.betterpvp.core.framework.ModuleLoadedEvent;
@@ -103,6 +105,8 @@ public class Clans extends BPvPPlugin {
             injector = core.getInjector().createChildInjector(new ClansInjectorModule(this),
                     new ConfigInjectorModule(this, fields));
             injector.injectMembers(this);
+
+            injector.getInstance(DisplayNameService.class).setProvider(injector.getInstance(ClansDisplayNameProvider.class));
 
             database.getConnection().runDatabaseMigrations(getClass().getClassLoader(), "classpath:clans-migrations/postgres/", "clans");
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/Clans.java
@@ -14,6 +14,7 @@ import me.mykindos.betterpvp.clans.clans.loot.ClanEnergyLoot;
 import me.mykindos.betterpvp.clans.commands.ClansCommandLoader;
 import me.mykindos.betterpvp.clans.display.ClanHudInfo;
 import me.mykindos.betterpvp.clans.display.ClansSidebarListener;
+import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
 import me.mykindos.betterpvp.clans.injector.ClansInjectorModule;
 import me.mykindos.betterpvp.clans.leaderboards.ClansLeaderboardLoader;
 import me.mykindos.betterpvp.clans.listener.ClansListenerLoader;
@@ -25,6 +26,7 @@ import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.config.ConfigInjectorModule;
 import me.mykindos.betterpvp.core.database.Database;
+import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
 import me.mykindos.betterpvp.core.framework.CurrentMode;
 import me.mykindos.betterpvp.core.framework.ModuleLoadedEvent;
@@ -109,6 +111,8 @@ public class Clans extends BPvPPlugin {
             injector = core.getInjector().createChildInjector(new ClansInjectorModule(this),
                     new ConfigInjectorModule(this, fields));
             injector.injectMembers(this);
+
+            injector.getInstance(DisplayNameService.class).setProvider(injector.getInstance(ClansDisplayNameProvider.class));
 
             database.getConnection().runDatabaseMigrations(getClass().getClassLoader(), "classpath:clans-migrations/postgres/", "clans");
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanManager.java
@@ -219,7 +219,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param uuid the unique identifier of the player whose clan is to be retrieved
      * @return an {@code Optional} containing the player's clan if found,
-     *         or an empty {@code Optional} if no associated clan exists
+     * or an empty {@code Optional} if no associated clan exists
      */
     public Optional<Clan> getClanByPlayer(UUID uuid) {
         final Player player = Bukkit.getPlayer(uuid);
@@ -236,7 +236,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param name the name of the clan to search for; this parameter is case-insensitive
      * @return an {@code Optional} containing the {@code Clan} if one exists with the specified name,
-     *         or an empty {@code Optional} if no such clan is found
+     * or an empty {@code Optional} if no such clan is found
      */
     public Optional<Clan> getClanByName(String name) {
         return objects.values().stream().filter(clan -> clan.getName().equalsIgnoreCase(name)).findFirst();
@@ -257,7 +257,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param chunk the chunk to check for clan ownership
      * @return an {@link Optional} containing the clan that owns the chunk, or an empty {@link Optional}
-     *         if the chunk is not owned by any clan
+     * if the chunk is not owned by any clan
      */
     public Optional<Clan> getClanByChunk(Chunk chunk) {
         PersistentDataContainer pdc = chunk.getPersistentDataContainer();
@@ -280,7 +280,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * Checks if the specified chunk is adjacent to any chunk claimed by other clans.
      *
      * @param chunk the chunk to check for adjacency
-     * @param clan the clan that owns the specified chunk
+     * @param clan  the clan that owns the specified chunk
      * @return true if the specified chunk is adjacent to a chunk claimed by other clans, false otherwise
      */
     public boolean adjacentOtherClans(@NotNull Chunk chunk, @NotNull Clan clan) {
@@ -305,7 +305,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * Checks if the specified chunk is adjacent to any chunk belonging to the given clan.
      *
      * @param chunk the chunk to check
-     * @param clan the clan whose territory to compare against
+     * @param clan  the clan whose territory to compare against
      * @return true if the given chunk is adjacent to a chunk owned by the specified clan, false otherwise
      */
     public boolean adjacentToOwnClan(@NotNull Chunk chunk, @NotNull Clan clan) {
@@ -374,7 +374,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * Sets a claim cooldown on the specified chunk by storing the cooldown expiration timestamp
      * in the chunk's persistent data container.
      *
-     * @param chunk the chunk for which the claim cooldown is being set
+     * @param chunk    the chunk for which the claim cooldown is being set
      * @param duration the cooldown duration in milliseconds to be added to the current time
      */
     public void setClaimCooldown(Chunk chunk, long duration) {
@@ -402,7 +402,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param serialized the serialized representation of a chunk to match against clan territories
      * @return an {@code Optional<Clan>} containing the clan whose territory matches the given chunk string,
-     *         or an empty {@code Optional} if no match is found
+     * or an empty {@code Optional} if no match is found
      */
     public Optional<Clan> getClanByChunkString(String serialized) {
         return objects.values().stream()
@@ -434,10 +434,10 @@ public class ClanManager extends Manager<Long, Clan> {
      * @param clanA The first clan to evaluate. Can be null.
      * @param clanB The second clan to evaluate. Can be null.
      * @return The relationship between the two clans as a {@link ClanRelation}.
-     *         If either clan is null, {@code ClanRelation.NEUTRAL} is returned.
-     *         If both clans are the same, {@code ClanRelation.SELF} is returned. Other
-     *         specific relationships (e.g., ally, enemy, pillage) are determined
-     *         based on their interactions.
+     * If either clan is null, {@code ClanRelation.NEUTRAL} is returned.
+     * If both clans are the same, {@code ClanRelation.SELF} is returned. Other
+     * specific relationships (e.g., ally, enemy, pillage) are determined
+     * based on their interactions.
      */
     public ClanRelation getRelation(@Nullable IClan clanA, @Nullable IClan clanB) {
         if (clanA == null || clanB == null) {
@@ -556,7 +556,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param player the player whose location and direction will be used to find wilderness
      * @return the closest wilderness location backwards from the player's current location,
-     *         or null if no wilderness location is found within the checked range
+     * or null if no wilderness location is found within the checked range
      */
     public Location closestWildernessBackwards(Player player) {
         List<Location> locations = new ArrayList<>();
@@ -640,7 +640,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * Retrieves and formats a list of enemy clans for the specified player's clan.
      *
      * @param player the player for whom the enemy list is being generated
-     * @param clan the clan whose enemies are being listed
+     * @param clan   the clan whose enemies are being listed
      * @return a formatted string containing the names of enemy clans, separated by commas
      */
     public String getEnemyList(Player player, Clan clan) {
@@ -660,7 +660,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * Generates a formatted string representation of the enemies of a specified clan, including their dominance-related information.
      *
      * @param player the player for whom the enemy list is being generated; used to determine the player's clan and its relation to enemy clans.
-     * @param clan the clan whose enemies are to be listed.
+     * @param clan   the clan whose enemies are to be listed.
      * @return a formatted string of the enemy list, including each enemy's display color and dominance information.
      */
     public String getEnemyListDom(Player player, Clan clan) {
@@ -688,10 +688,10 @@ public class ClanManager extends Manager<Long, Clan> {
         if (clan.getMembers() != null && !clan.getMembers().isEmpty()) {
             for (ClanMember member : clan.getMembers()) {
 
-                    membersString.append(!membersString.isEmpty() ? "<gray>, " : "").append("<yellow>")
-                            .append(member.getRoleIcon())
-                            .append(UtilFormat.getOnlineStatus(member.getUuid()))
-                            .append(UtilFormat.spoofNameForLunar(member.getClientName()));
+                membersString.append(!membersString.isEmpty() ? "<gray>, " : "").append("<yellow>")
+                        .append(member.getRoleIcon())
+                        .append(UtilFormat.getOnlineStatus(member.getUuid()))
+                        .append(UtilFormat.spoofNameForLunar(member.getClientName()));
 
             }
         }
@@ -727,7 +727,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param player the player whose allies are to be retrieved
      * @return a list of allies, including members of the player's clan and allied clans.
-     *         If the player does not belong to any clan, an empty list is returned.
+     * If the player does not belong to any clan, an empty list is returned.
      */
     public List<ClanMember> getAllies(Player player) {
         ArrayList<ClanMember> allyList = new ArrayList<>(List.of());
@@ -753,7 +753,7 @@ public class ClanManager extends Manager<Long, Clan> {
      * @param player the player attempting to inflict damage
      * @param target the intended target player
      * @return true if the player can hurt the target under the given conditions,
-     *         false otherwise
+     * false otherwise
      */
     public boolean canHurt(Player player, Player target) {
         Clan playerClan = getClanByPlayer(player).orElse(null);
@@ -776,7 +776,7 @@ public class ClanManager extends Manager<Long, Clan> {
      *
      * @param player the player whose ability to cast is being checked
      * @return {@code true} if the player is allowed to cast abilities,
-     *          {@code false} otherwise
+     * {@code false} otherwise
      */
     public boolean canCast(Player player) {
         if (zoneManager.hasTagAt(player.getLocation(), Zones.SAFE)) {
@@ -814,7 +814,7 @@ public class ClanManager extends Manager<Long, Clan> {
 
     /**
      * Applies dominance changes between two clans based on a kill event.
-     *
+     * <p>
      * This method determines the dominance impact when one clan (killed) is defeated by another clan (killer).
      * It checks multiple conditions, such as whether both clans are valid, are enemies, and whether dominance settings allow for an increase.
      * Dominance is then adjusted accordingly for both clans, triggering events and updating the repository as necessary.
@@ -875,10 +875,10 @@ public class ClanManager extends Manager<Long, Clan> {
      * between two clans. The returned string includes the dominance value and indicates
      * any changes that may occur with the next kill, based on dominance thresholds.
      *
-     * @param clan the clan for which the dominance string is being calculated
+     * @param clan      the clan for which the dominance string is being calculated
      * @param enemyClan the enemy clan to compare dominance against
      * @return a string representation of the dominance status between the two clans,
-     *         or an empty string if no significant dominance relationship is found
+     * or an empty string if no significant dominance relationship is found
      */
     public String getDominanceString(IClan clan, IClan enemyClan) {
         Optional<ClanEnemy> enemyOptional = clan.getEnemy(enemyClan);
@@ -907,10 +907,10 @@ public class ClanManager extends Manager<Long, Clan> {
     /**
      * Generates a simple dominance string representation between two clans based on their dominance values.
      *
-     * @param clan the clan for which the dominance interaction is being calculated
+     * @param clan      the clan for which the dominance interaction is being calculated
      * @param enemyClan the enemy clan against which the dominance interaction is being calculated
      * @return a {@link Component} representing the dominance status, which may include a dominance percentage
-     *         with associated color codes indicating the state, or an empty component if dominance is not present
+     * with associated color codes indicating the state, or an empty component if dominance is not present
      */
     public Component getSimpleDominanceString(IClan clan, IClan enemyClan) {
         Optional<ClanEnemy> enemyOptional = clan.getEnemy(enemyClan);
@@ -939,8 +939,8 @@ public class ClanManager extends Manager<Long, Clan> {
     /**
      * Adds insurance for a clan based on the block and insurance type provided.
      *
-     * @param clan the clan for which insurance is being added
-     * @param block the block related to the insurance
+     * @param clan          the clan for which insurance is being added
+     * @param block         the block related to the insurance
      * @param insuranceType the type of insurance being applied
      */
     public void addInsurance(Clan clan, Block block, InsuranceType insuranceType) {
@@ -948,8 +948,8 @@ public class ClanManager extends Manager<Long, Clan> {
 
         Block targetBlock = block;
 
-        if(targetBlock.getBlockData() instanceof Door door) {
-            if(door.getHalf() == Bisected.Half.TOP) {
+        if (targetBlock.getBlockData() instanceof Door door) {
+            if (door.getHalf() == Bisected.Half.TOP) {
                 targetBlock = block.getRelative(0, -1, 0);
             }
         }
@@ -1064,14 +1064,29 @@ public class ClanManager extends Manager<Long, Clan> {
 
     public ClansStat.ClansStatBuilder<?, ?> addClanInfo(Player player, ClansStat.ClansStatBuilder<?, ?> builder) {
         this.getClanByPlayer(player).ifPresentOrElse((clan) -> {
-            builder.clanName(clan.getName());
-            builder.clanId(clan.getId());
-        },
+                    builder.clanName(clan.getName());
+                    builder.clanId(clan.getId());
+                },
                 () -> {
-            builder.clanName(ClansStat.NO_CLAN_NAME);
-            builder.clanId(null);
+                    builder.clanName(ClansStat.NO_CLAN_NAME);
+                    builder.clanId(null);
                 });
         return builder;
     }
 
+    public Component getClanFullName(ClanRelation clanRelation, IClan clan) {
+        return UtilMessage.deserialize(clanRelation.getPrimaryMiniColor() + "Clan" + clan.getName() + clanRelation.getPrimaryClosingMiniColor());
+    }
+
+    public Component getClanShortName(ClanRelation clanRelation, IClan clan) {
+        return UtilMessage.deserialize(clanRelation.getPrimaryMiniColor() + clan.getName() + clanRelation.getPrimaryClosingMiniColor());
+    }
+
+    public Component getPlayerName(ClanRelation clanRelation, String playerName) {
+        return UtilMessage.deserialize(clanRelation.getPrimaryMiniColor() + playerName + clanRelation.getPrimaryClosingMiniColor());
+    }
+
+    public Component getPlayerName(ClanRelation clanRelation, Player player) {
+        return this.getPlayerName(clanRelation, player.getName() + clanRelation.getPrimaryClosingMiniColor());
+    }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/clans/ClanRelation.java
@@ -40,8 +40,15 @@ public enum ClanRelation {
         return "<" + primary.toString().toLowerCase() + ">";
     }
 
+    public String getPrimaryClosingMiniColor() {
+        return "</" + primary.toString().toLowerCase() + ">";
+    }
+
     public String getSecondaryMiniColor() {
         return "<" + secondary.toString().toLowerCase() + ">";
     }
 
+    public String getSecondaryClosingMiniColor() {
+        return "</" + secondary.toString().toLowerCase() + ">";
+    }
 }

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/displayname/ClansDisplayNameProvider.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/displayname/ClansDisplayNameProvider.java
@@ -1,0 +1,49 @@
+package me.mykindos.betterpvp.clans.displayname;
+
+import com.google.inject.Inject;
+import lombok.AllArgsConstructor;
+import me.mykindos.betterpvp.clans.clans.ClanManager;
+import me.mykindos.betterpvp.clans.clans.ClanRelation;
+import me.mykindos.betterpvp.core.displayname.CoreDisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+/**
+ * Clan implementation of {@link DisplayNameProvider}.
+ * <p>
+ * This implementation is registered by Clans to replace Core's default
+ * display name provider. Player display names are formatted according to
+ * the relationship between the viewer's clan and the target player's clan.
+ */
+@AllArgsConstructor(onConstructor = @__(@Inject))
+public class ClansDisplayNameProvider implements DisplayNameProvider {
+
+    private final CoreDisplayNameProvider coreDisplayNameProvider;
+    private final ClanManager clanManager;
+
+    /**
+     * Gets the formatted display name for an entity from the perspective of the
+     * supplied viewer.
+     *
+     * @param entity the entity whose display name is being requested
+     * @param viewer the entity viewing the display name
+     * @return the entity's display name formatted according to the clan
+     * relationship between the viewer and the player
+     */
+    @Override
+    public Component getDisplayNameAsComponent(final Entity entity, final Entity viewer) {
+        if (!(entity instanceof Player player) || !(viewer instanceof Player viewingPlayer)) {
+            return this.coreDisplayNameProvider.getDisplayNameAsComponent(entity, viewer);
+        }
+
+        final ClanRelation clanRelation = this.clanManager.getRelation(
+                this.clanManager.getClanByPlayer(viewingPlayer).orElse(null),
+                this.clanManager.getClanByPlayer(player).orElse(null)
+        );
+
+        return this.clanManager.getPlayerName(clanRelation, player);
+    }
+
+}

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -2,6 +2,7 @@ package me.mykindos.betterpvp.clans.injector;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.OptionalBinder;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathFrequencyFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathLocalityFactor;
@@ -11,6 +12,8 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.PlayerDeathFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
+import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 
 public class ClansInjectorModule extends AbstractModule {
 
@@ -24,6 +27,8 @@ public class ClansInjectorModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Clans.class).toInstance(plugin);
+
+        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setBinding().to(ClansDisplayNameProvider.class);
 
         // Battle fatigue strategies. Adding/removing a factor or punishment is a
         // single line here — the manager and hold service never name a concrete

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -2,7 +2,6 @@ package me.mykindos.betterpvp.clans.injector;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.multibindings.OptionalBinder;
 import me.mykindos.betterpvp.clans.Clans;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathFrequencyFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.DeathLocalityFactor;
@@ -13,7 +12,6 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
 import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
-import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 
 public class ClansInjectorModule extends AbstractModule {
 
@@ -28,7 +26,7 @@ public class ClansInjectorModule extends AbstractModule {
     protected void configure() {
         bind(Clans.class).toInstance(plugin);
 
-        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setBinding().to(ClansDisplayNameProvider.class);
+        bind(ClansDisplayNameProvider.class);
 
         // Battle fatigue strategies. Adding/removing a factor or punishment is a
         // single line here — the manager and hold service never name a concrete

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -12,6 +12,7 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
 import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
+<<<<<<< HEAD
 import me.mykindos.betterpvp.clans.world.island.CrewAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.InstanceAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.IslandAllocator;
@@ -23,6 +24,8 @@ import me.mykindos.betterpvp.clans.world.travel.guard.AllocatingTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.AlreadyOnIslandTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.CombatTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.DepartingTravelGuard;
+=======
+>>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
 
 public class ClansInjectorModule extends AbstractModule {
 

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -11,12 +11,12 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.PlayerDeathFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
+import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
 import me.mykindos.betterpvp.clans.world.island.CrewAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.InstanceAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.IslandAllocator;
 import me.mykindos.betterpvp.clans.world.island.RoutingIslandAllocator;
 import me.mykindos.betterpvp.clans.world.island.RoutingTravelTransport;
-import me.mykindos.betterpvp.clans.world.island.SoloAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.TravelTransport;
 import me.mykindos.betterpvp.clans.world.travel.TravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.AllocatingTravelGuard;
@@ -36,6 +36,8 @@ public class ClansInjectorModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Clans.class).toInstance(plugin);
+
+        bind(ClansDisplayNameProvider.class);
 
         // Battle fatigue strategies. Adding/removing a factor or punishment is a
         // single line here — the manager and hold service never name a concrete

--- a/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
+++ b/clans/src/main/java/me/mykindos/betterpvp/clans/injector/ClansInjectorModule.java
@@ -12,7 +12,6 @@ import me.mykindos.betterpvp.clans.clans.fatigue.factor.RepeatKillerFactor;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.FatiguePunishment;
 import me.mykindos.betterpvp.clans.clans.fatigue.punishment.SlownessPunishment;
 import me.mykindos.betterpvp.clans.displayname.ClansDisplayNameProvider;
-<<<<<<< HEAD
 import me.mykindos.betterpvp.clans.world.island.CrewAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.InstanceAllocationPolicy;
 import me.mykindos.betterpvp.clans.world.island.IslandAllocator;
@@ -24,8 +23,6 @@ import me.mykindos.betterpvp.clans.world.travel.guard.AllocatingTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.AlreadyOnIslandTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.CombatTravelGuard;
 import me.mykindos.betterpvp.clans.world.travel.guard.DepartingTravelGuard;
-=======
->>>>>>> d4a6abc87 (refactor(displayname): centralize display name resolution)
 
 public class ClansInjectorModule extends AbstractModule {
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/displayname/CoreDisplayNameProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/displayname/CoreDisplayNameProvider.java
@@ -1,0 +1,31 @@
+package me.mykindos.betterpvp.core.displayname;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Entity;
+
+/**
+ * Default implementation of {@link DisplayNameProvider}.
+ * <p>
+ * This implementation is registered by Core as the default Guice binding
+ * using an {@code OptionalBinder}. Server implementations may override this
+ * binding to provide custom display name formatting.
+ * <p>
+ * If no overriding implementation is registered, entity names are formatted
+ * using a yellow colour.
+ */
+public class CoreDisplayNameProvider implements DisplayNameProvider {
+
+    /**
+     * Gets the default formatted display name for an entity.
+     *
+     * @param entity the entity whose display name is being requested
+     * @param viewer the entity viewing the display name
+     * @return the entity's name formatted with the default colour
+     */
+    @Override
+    public Component getDisplayNameAsComponent(final Entity entity, final Entity viewer) {
+        return Component.text(entity.getName(), NamedTextColor.YELLOW);
+    }
+
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/displayname/DisplayNameProvider.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/displayname/DisplayNameProvider.java
@@ -1,0 +1,47 @@
+package me.mykindos.betterpvp.core.displayname;
+
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
+
+/**
+ * Provides the formatted display name for an entity.
+ * <p>
+ * Core registers a default implementation through Guice which formats entity
+ * names using a yellow colour. Server implementations may override this
+ * binding to provide custom formatting without requiring shared modules to
+ * know which server type is currently running.
+ * <p>
+ * The returned display name represents the authoritative formatted name for
+ * an entity and should be used wherever a formatted entity name is required.
+ */
+public interface DisplayNameProvider {
+
+    /**
+     * Gets the formatted display name for an entity from the perspective of a
+     * specific viewer.
+     * <p>
+     * The {@code viewer} allows implementations to return different display
+     * names depending on who is viewing the entity, such as ally, enemy or
+     * team-specific formatting.
+     *
+     * @param entity the entity whose display name is being requested
+     * @param viewer the entity viewing the display name
+     * @return the formatted display name as an Adventure {@link Component}
+     */
+    Component getDisplayNameAsComponent(Entity entity, Entity viewer);
+
+    /**
+     * Gets the formatted display name as a MiniMessage serialized string.
+     * <p>
+     * This is a convenience method for APIs and systems that require
+     * MiniMessage strings instead of Adventure components.
+     *
+     * @param entity the entity whose display name is being requested
+     * @param viewer the entity viewing the display name
+     * @return the formatted display name serialized as MiniMessage
+     */
+    default String getDisplayNameAsString(final Entity entity, final Entity viewer) {
+        return UtilMessage.serialize(this.getDisplayNameAsComponent(entity, viewer));
+    }
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/displayname/DisplayNameService.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/displayname/DisplayNameService.java
@@ -1,0 +1,16 @@
+package me.mykindos.betterpvp.core.displayname;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor(onConstructor = @__(@Inject))
+@Getter
+@Setter
+@Singleton
+public class DisplayNameService {
+
+    private DisplayNameProvider provider;
+}

--- a/core/src/main/java/me/mykindos/betterpvp/core/injector/CoreInjectorModule.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/injector/CoreInjectorModule.java
@@ -1,6 +1,7 @@
 package me.mykindos.betterpvp.core.injector;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.OptionalBinder;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.chat.filter.IFilterService;
@@ -9,6 +10,8 @@ import me.mykindos.betterpvp.core.chat.ignore.IIgnoreService;
 import me.mykindos.betterpvp.core.chat.ignore.impl.DefaultIgnoreService;
 import me.mykindos.betterpvp.core.database.connection.IDatabaseConnection;
 import me.mykindos.betterpvp.core.database.connection.PostgresDatabaseConnection;
+import me.mykindos.betterpvp.core.displayname.CoreDisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 import me.mykindos.betterpvp.core.framework.blockbreak.global.GlobalBlockBreakRules;
 import me.mykindos.betterpvp.core.framework.blockbreak.global.GlobalBlockBreakRulesImpl;
 import me.mykindos.betterpvp.core.framework.blockbreak.packet.BlockBreakProgressService;
@@ -34,6 +37,9 @@ public class CoreInjectorModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Core.class).toInstance(plugin);
+
+        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setDefault().to(CoreDisplayNameProvider.class);
+        bind(CoreDisplayNameProvider.class);
 
         bind(IDatabaseConnection.class).to(PostgresDatabaseConnection.class);
         bind(IFilterService.class).to(DatabaseFilterService.class);

--- a/core/src/main/java/me/mykindos/betterpvp/core/injector/CoreInjectorModule.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/injector/CoreInjectorModule.java
@@ -1,7 +1,6 @@
 package me.mykindos.betterpvp.core.injector;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.OptionalBinder;
 import lombok.CustomLog;
 import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.chat.filter.IFilterService;
@@ -11,7 +10,7 @@ import me.mykindos.betterpvp.core.chat.ignore.impl.DefaultIgnoreService;
 import me.mykindos.betterpvp.core.database.connection.IDatabaseConnection;
 import me.mykindos.betterpvp.core.database.connection.PostgresDatabaseConnection;
 import me.mykindos.betterpvp.core.displayname.CoreDisplayNameProvider;
-import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.framework.blockbreak.global.GlobalBlockBreakRules;
 import me.mykindos.betterpvp.core.framework.blockbreak.global.GlobalBlockBreakRulesImpl;
 import me.mykindos.betterpvp.core.framework.blockbreak.packet.BlockBreakProgressService;
@@ -38,8 +37,8 @@ public class CoreInjectorModule extends AbstractModule {
     protected void configure() {
         bind(Core.class).toInstance(plugin);
 
-        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setDefault().to(CoreDisplayNameProvider.class);
         bind(CoreDisplayNameProvider.class);
+        bind(DisplayNameService.class).asEagerSingleton();
 
         bind(IDatabaseConnection.class).to(PostgresDatabaseConnection.class);
         bind(IFilterService.class).to(DatabaseFilterService.class);

--- a/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/utilities/UtilMessage.java
@@ -234,6 +234,10 @@ public class UtilMessage {
         return deserialize(String.format(message, args));
     }
 
+    public static String serialize(final Component component) {
+        return miniMessage.serialize(component);
+    }
+
     /**
      * Creates a component with a click event that copies text to the clipboard when clicked, and a hover event that shows "Click to Copy"
      * @param commandText The text to show in the message, which will have the hover and click events

--- a/game/src/main/java/me/mykindos/betterpvp/game/GamePlugin.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/GamePlugin.java
@@ -10,6 +10,7 @@ import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.config.Config;
 import me.mykindos.betterpvp.core.config.ConfigInjectorModule;
 import me.mykindos.betterpvp.core.database.Database;
+import me.mykindos.betterpvp.core.displayname.DisplayNameService;
 import me.mykindos.betterpvp.core.framework.BPvPPlugin;
 import me.mykindos.betterpvp.core.framework.CurrentMode;
 import me.mykindos.betterpvp.core.framework.ModuleLoadedEvent;
@@ -20,6 +21,7 @@ import me.mykindos.betterpvp.core.framework.updater.UpdateEventExecutor;
 import me.mykindos.betterpvp.core.locale.TranslationService;
 import me.mykindos.betterpvp.game.achievements.loader.GameAchievementLoader;
 import me.mykindos.betterpvp.game.command.loader.GameCommandLoader;
+import me.mykindos.betterpvp.game.displayname.GameDisplayNameProvider;
 import me.mykindos.betterpvp.game.framework.ServerController;
 import me.mykindos.betterpvp.game.framework.listener.state.GameMapHandler;
 import me.mykindos.betterpvp.game.framework.listener.state.TransitionHandler;
@@ -71,6 +73,8 @@ public final class GamePlugin extends BPvPPlugin {
 
         injector = core.getInjector().createChildInjector(new GlobalInjectorModule(this), new ConfigInjectorModule(this, fields));
         injector.injectMembers(this);
+
+        injector.getInstance(DisplayNameService.class).setProvider(injector.getInstance(GameDisplayNameProvider.class));
 
         database.getConnection().runDatabaseMigrations(getClass().getClassLoader(), "classpath:game-migrations/postgres", "game");
         Bukkit.getPluginManager().callEvent(new ModuleLoadedEvent("Game"));

--- a/game/src/main/java/me/mykindos/betterpvp/game/displayname/GameDisplayNameProvider.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/displayname/GameDisplayNameProvider.java
@@ -1,0 +1,53 @@
+package me.mykindos.betterpvp.game.displayname;
+
+import com.google.inject.Inject;
+import lombok.AllArgsConstructor;
+import me.mykindos.betterpvp.core.displayname.CoreDisplayNameProvider;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
+import me.mykindos.betterpvp.game.framework.ServerController;
+import me.mykindos.betterpvp.game.framework.TeamGame;
+import me.mykindos.betterpvp.game.framework.model.team.Team;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+/**
+ * Game implementation of {@link DisplayNameProvider}.
+ * <p>
+ * This implementation is registered by Game to replace Core's default
+ * display name provider. Player display names are formatted according to
+ * the current game.
+ */
+@AllArgsConstructor(onConstructor = @__(@Inject))
+public class GameDisplayNameProvider implements DisplayNameProvider {
+
+    private final CoreDisplayNameProvider coreDisplayNameProvider;
+    private final ServerController serverController;
+
+    /**
+     * Gets the formatted display name for an entity from the perspective of the
+     * supplied viewer.
+     *
+     * @param entity the entity whose display name is being requested
+     * @param viewer the entity viewing the display name
+     * @return the entity's display name formatted according to the current game
+     */
+    @Override
+    public Component getDisplayNameAsComponent(final Entity entity, final Entity viewer) {
+        if (!(entity instanceof Player player)) {
+            return this.coreDisplayNameProvider.getDisplayNameAsComponent(entity, viewer);
+        }
+
+        if (!(this.serverController.getCurrentGame() instanceof TeamGame<?> teamGame)) {
+            return this.coreDisplayNameProvider.getDisplayNameAsComponent(player, viewer);
+        }
+
+        final Team playerTeam = teamGame.getPlayerTeam(player);
+        if (playerTeam == null) {
+            return this.coreDisplayNameProvider.getDisplayNameAsComponent(player, viewer);
+        }
+
+        return Component.text(player.getName(), playerTeam.getProperties().color());
+    }
+
+}

--- a/game/src/main/java/me/mykindos/betterpvp/game/guice/GlobalInjectorModule.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/guice/GlobalInjectorModule.java
@@ -1,10 +1,8 @@
 package me.mykindos.betterpvp.game.guice;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Names;
 import lombok.CustomLog;
-import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 import me.mykindos.betterpvp.game.GamePlugin;
 import me.mykindos.betterpvp.game.displayname.GameDisplayNameProvider;
 import me.mykindos.betterpvp.game.framework.GameRegistry;
@@ -34,7 +32,7 @@ public class GlobalInjectorModule extends AbstractModule {
         // Bind plugin
         bind(GamePlugin.class).toInstance(plugin);
 
-        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setBinding().to(GameDisplayNameProvider.class);
+        bind(GameDisplayNameProvider.class);
 
         // Bind map providers
         bind(MappedWorld.class).annotatedWith(Names.named("Waiting Lobby")).toProvider(WaitingLobbyProvider.class);

--- a/game/src/main/java/me/mykindos/betterpvp/game/guice/GlobalInjectorModule.java
+++ b/game/src/main/java/me/mykindos/betterpvp/game/guice/GlobalInjectorModule.java
@@ -1,9 +1,12 @@
 package me.mykindos.betterpvp.game.guice;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Names;
 import lombok.CustomLog;
+import me.mykindos.betterpvp.core.displayname.DisplayNameProvider;
 import me.mykindos.betterpvp.game.GamePlugin;
+import me.mykindos.betterpvp.game.displayname.GameDisplayNameProvider;
 import me.mykindos.betterpvp.game.framework.GameRegistry;
 import me.mykindos.betterpvp.game.framework.ServerController;
 import me.mykindos.betterpvp.game.framework.listener.state.GameMapHandler;
@@ -30,6 +33,8 @@ public class GlobalInjectorModule extends AbstractModule {
     protected void configure() {
         // Bind plugin
         bind(GamePlugin.class).toInstance(plugin);
+
+        OptionalBinder.newOptionalBinder(binder(), DisplayNameProvider.class).setBinding().to(GameDisplayNameProvider.class);
 
         // Bind map providers
         bind(MappedWorld.class).annotatedWith(Names.named("Waiting Lobby")).toProvider(WaitingLobbyProvider.class);


### PR DESCRIPTION
- CoreDisplayNameProvider: provide the default display name binding and return yellow entity names when no server-specific formatter overrides it
- ClansDisplayNameProvider: format player names by clan relation from the viewer's perspective and fall back to the core provider for non-player entities
- GameDisplayNameProvider: format player names with team colours in team games and fall back to the core provider when no team formatting applies

## Describe your changes

## Link to issue (if applicable)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.
