### PR TITLE
fix(zone): prevent duplicate zone interact dispatch

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneInteractionListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/world/zone/ZoneInteractionListener.java
@@ -2,7 +2,10 @@ package me.mykindos.betterpvp.core.world.zone;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.AllArgsConstructor;
+import me.mykindos.betterpvp.core.Core;
 import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -16,6 +19,10 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
 /**
  * The single place raw Bukkit world interactions become zone interactions. Hooks block break/place/interact, resolves
  * the zone at the location, and runs it through {@link ZoneManager#queryAccess} (the zone's {@link ZoneRule}s plus the
@@ -25,16 +32,15 @@ import org.bukkit.inventory.EquipmentSlot;
  * Runs at {@link EventPriority#LOW} so a zone denial lands before later protection handlers (which early-return on an
  * already-cancelled event). With no rules and no {@code ZoneInteractEvent} handlers, this is a no-op.
  */
+@AllArgsConstructor(onConstructor = @__(@Inject))
 @BPvPListener
 @Singleton
 public class ZoneInteractionListener implements Listener {
 
-    private final ZoneManager zoneManager;
+    private final Set<Player> interactDeniedSet = Collections.newSetFromMap(new WeakHashMap<>());
 
-    @Inject
-    private ZoneInteractionListener(ZoneManager zoneManager) {
-        this.zoneManager = zoneManager;
-    }
+    private final Core core;
+    private final ZoneManager zoneManager;
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     void onBreak(BlockBreakEvent event) {
@@ -56,16 +62,30 @@ public class ZoneInteractionListener implements Listener {
         if (event.getHand() != EquipmentSlot.HAND) {
             return;
         }
+
         final Action action = event.getAction();
+
         if (action != Action.RIGHT_CLICK_BLOCK && action != Action.LEFT_CLICK_BLOCK) {
             return;
         }
+
         final Block block = event.getClickedBlock();
+
         if (block == null || event.useInteractedBlock() == Event.Result.DENY) {
             return;
         }
-        if (denied(event.getPlayer(), block.getLocation(), ZoneInteraction.INTERACT, block)) {
+
+        Player player = event.getPlayer();
+
+        if (this.interactDeniedSet.remove(player)) {
             event.setUseInteractedBlock(Event.Result.DENY);
+            return;
+        }
+
+        if (denied(player, block.getLocation(), ZoneInteraction.INTERACT, block)) {
+            event.setUseInteractedBlock(Event.Result.DENY);
+            this.interactDeniedSet.add(player);
+            UtilServer.runTaskLater(this.core, () -> this.interactDeniedSet.remove(player), 1L);
         }
     }
 


### PR DESCRIPTION
- ZoneInteractionListener: add interactDeniedSet backed by WeakHashMap to skip queryAccess on the duplicate PlayerInteractEvent from the vanilla client's dual-packet UseItemOn/UseItem flow, while still setting useInteractedBlock to DENY on the second event