### PR TITLE
fix(combatlog): remove stale combat log entities

### DIFF
--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLog.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLog.java
@@ -65,7 +65,7 @@ public class CombatLog {
         combatLogSheep.remove();
         CraftInventoryPlayer inventory = UtilInventory.getOfflineInventory(playerName, owner);
         if (inventory == null) {
-            log.error("Failed to retrieve offline inventory for {} ({}) while processing combat log", playerName, owner);
+            log.error("Failed to retrieve offline inventory for {} ({}) while processing combat log", playerName, owner).submit();
             return;
         }
 

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLog.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLog.java
@@ -16,16 +16,20 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.inventory.CraftInventoryPlayer;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.UUID;
 
 @CustomLog
 @Getter
 public class CombatLog {
+
+    public static final NamespacedKey COMBAT_LOG_KEY = new NamespacedKey("betterpvp", "combat_log");
 
     private final UUID owner;
     private final long expiryTime;
@@ -49,6 +53,7 @@ public class CombatLog {
         combatLogSheep.setCustomNameVisible(true);
         combatLogSheep.setRemoveWhenFarAway(false);
 
+        combatLogSheep.getPersistentDataContainer().set(COMBAT_LOG_KEY, PersistentDataType.BOOLEAN, true);
     }
 
     public void onClicked(Player player, WorldHandler worldHandler, OfflineMessagesHandler offlineMessagesHandler) {
@@ -59,6 +64,10 @@ public class CombatLog {
 
         combatLogSheep.remove();
         CraftInventoryPlayer inventory = UtilInventory.getOfflineInventory(playerName, owner);
+        if (inventory == null) {
+            log.error("Failed to retrieve offline inventory for {} ({}) while processing combat log", playerName, owner);
+            return;
+        }
 
         for (ItemStack stack : inventory.getContents()) {
             if (stack == null || stack.getType() == Material.AIR || stack.getType() == Material.IRON_HORSE_ARMOR) {

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogListener.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogListener.java
@@ -17,6 +17,7 @@ import me.mykindos.betterpvp.core.utilities.UtilServer;
 import me.mykindos.betterpvp.core.world.WorldHandler;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -24,6 +25,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.world.EntitiesLoadEvent;
+import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.List;
@@ -139,4 +142,19 @@ public class CombatLogListener implements Listener {
         combatLogManager.removeObject(event.getPlayer().getUniqueId().toString());
     }
 
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent event) {
+        for (LivingEntity livingEntity : event.getWorld().getLivingEntities()) {
+            combatLogManager.removeStaleCombatLogEntity(livingEntity);
+        }
+    }
+
+    @EventHandler
+    public void onEntitiesLoad(final EntitiesLoadEvent event) {
+        for (Entity entity : event.getEntities()) {
+            if (entity instanceof LivingEntity livingEntity) {
+                combatLogManager.removeStaleCombatLogEntity(livingEntity);
+            }
+        }
+    }
 }

--- a/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogManager.java
+++ b/core/src/main/java/me/mykindos/betterpvp/core/combat/combatlog/CombatLogManager.java
@@ -21,4 +21,16 @@ public class CombatLogManager extends Manager<String, CombatLog> {
     public Optional<CombatLog> getCombatLogBySheep(LivingEntity target) {
         return getObjects().values().stream().filter(cl -> cl.getCombatLogSheep().getUniqueId().equals(target.getUniqueId())).findFirst();
     }
+
+    public void removeStaleCombatLogEntity(final LivingEntity livingEntity) {
+        if (!livingEntity.getPersistentDataContainer().has(CombatLog.COMBAT_LOG_KEY)) {
+            return;
+        }
+
+        if (getCombatLogBySheep(livingEntity).isPresent()) {
+            return;
+        }
+
+        livingEntity.remove();
+    }
 }


### PR DESCRIPTION
- CombatLog: mark spawned sheep with persistent combat log data and guard against null offline inventories before dropping items
- CombatLogManager: remove loaded living entities marked as combat logs when no active combat log matches them
- CombatLogListener: scan world and entity load events for stale combat log entities and remove them
