### PR TITLE
Added new assassin passives 

### DIFF
--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/listeners/SkillListener.java
@@ -156,8 +156,8 @@ public class SkillListener implements Listener {
         if (skill instanceof CooldownSkill cooldownSkill && !(skill instanceof PrepareArrowSkill)) {
             if (cooldownSkill.isDelayedSkill()) {
 
-                // if they already have a cooldown, prevent as usual
-                if (cooldownManager.hasCooldown(player, skill.getName())) {
+                // on cooldown and not mid-sequence - prevent as usual
+                if (cooldownManager.hasCooldown(player, skill.getName()) && !cooldownSkill.canReactivate(player)) {
                     if (cooldownSkill.showCooldownFinished()) {
                         cooldownManager.informCooldown(player, skill.getName());
                     }
@@ -168,6 +168,11 @@ public class SkillListener implements Listener {
                 // prevent spamming by cancelling if player is already tracked as using a delayed skill
                 final @NotNull UUID id = player.getUniqueId();
                 if (delayedCooldowns.containsKey(id)) {
+                    // ...unless this is the same skill advancing to its next step (e.g. mark -> lunge)
+                    DelayedEntry pending = delayedCooldowns.get(id);
+                    if (pending.skill == cooldownSkill && cooldownSkill.canReactivate(player)) {
+                        return;
+                    }
                     event.setCancelled(true);
                     return;
                 }
@@ -264,7 +269,8 @@ public class SkillListener implements Listener {
 
                 for (BuildSkill buildSkill : build.getActiveSkills()) {
                     // Skip if not a toggle skill
-                    if (!(buildSkill.getSkill() instanceof ToggleSkill)) continue;
+                    if (!(buildSkill.getSkill() instanceof ToggleSkill toggleSkill)
+                            || !toggleSkill.canToggleWith(droppedItem)) continue;
 
                     // Check if they have booster
                     int level = getLevel(player, buildSkill);

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Meditation.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/Meditation.java
@@ -1,0 +1,718 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.ChampionsManager;
+import me.mykindos.betterpvp.champions.champions.skills.Skill;
+import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
+import me.mykindos.betterpvp.champions.champions.skills.types.CooldownToggleSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.DefensiveSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.HealthSkill;
+import me.mykindos.betterpvp.champions.combat.damage.SkillDamageCause;
+import me.mykindos.betterpvp.champions.combat.damage.SkillDamageModifier;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.combat.events.CustomEntityVelocityEvent;
+import me.mykindos.betterpvp.core.combat.events.DamageEvent;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.components.champions.events.PlayerCanUseSkillEvent;
+import me.mykindos.betterpvp.core.components.champions.events.PlayerUseSkillEvent;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.locale.Translations;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilDamage;
+import me.mykindos.betterpvp.core.utilities.UtilEntity;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
+import me.mykindos.betterpvp.core.utilities.UtilVelocity;
+import me.mykindos.betterpvp.core.utilities.math.VelocityData;
+import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
+import me.mykindos.betterpvp.core.utilities.model.display.actionbar.ActionBar;
+import me.mykindos.betterpvp.core.utilities.model.display.component.TimedComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerAttemptPickupItemEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerVelocityEvent;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+@BPvPListener
+public class Meditation extends Skill implements CooldownToggleSkill, DefensiveSkill, HealthSkill, Listener {
+    private final Map<Player, Channel> channels = new HashMap<>();
+    private final Map<Player, Protection> protection = new HashMap<>();
+    private final Map<Player, PendingBurst> pendingBursts = new HashMap<>();
+    private long duration;
+    private long interval;
+    private long finalPhase;
+    private long cancelDelay;
+    private long exitDuration;
+    private double healing;
+    private double finalHealing;
+    private double exitReduction;
+    private double burstReflectRatio; // fraction of blocked damage released on exit
+    private double burstMaxDamage;    // hard cap on the burst regardless of how much was blocked
+    private double burstRadius;
+    private double burstKnockback;
+    private long burstTelegraph;      // wind-up between leaving Meditation and the burst going off
+
+    @Inject
+    public Meditation(Champions champions, ChampionsManager championsManager) {
+        super(champions, championsManager);
+    }
+
+    @Override
+    public String getName() { return "Meditation"; }
+
+    @Override
+    public Role getClassType() { return Role.ASSASSIN; }
+
+    @Override
+    public SkillType getType() { return SkillType.PASSIVE_A; }
+
+    @Override
+    public double getCooldown(int level) { return cooldown; }
+
+    @Override
+    public boolean isDelayedSkill() { return true; }
+
+    @Override
+    public boolean isUsingSkill(Player player) { return channels.containsKey(player); }
+
+    @Override
+    public boolean canReactivate(Player player) {
+        Channel channel = channels.get(player);
+        return channel != null && channel.timeline.canCancel(now());
+    }
+
+    @Override
+    public boolean displayWhenUsed() { return false; }
+
+    @Override
+    public boolean canToggleWith(ItemStack item) {
+        SkillType type = SkillWeapons.getTypeFrom(item);
+        return type == SkillType.SWORD || type == SkillType.AXE;
+    }
+
+    @Override
+    public Component[] getDescription(int level) {
+        return Translations.componentLines("champions.skill.assassin.meditation.description",
+                getValueComponent(ignored -> duration / 1000.0, level),          // {0}
+                getValueComponent(ignored -> timeline(0).totalHealing(), level), // {1}
+                getValueComponent(ignored -> cancelDelay / 1000.0, level),       // {2}
+                getValueComponent(ignored -> exitReduction * 100, level),        // {3}
+                getValueComponent(ignored -> exitDuration / 1000.0, level),      // {4}
+                getValueComponent(this::getCooldown, level),                     // {5}
+                getValueComponent(ignored -> finalPhase / 1000.0, level),        // {6}
+                getValueComponent(ignored -> burstMaxDamage, level),             // {7}
+                getValueComponent(ignored -> burstRadius, level));               // {8}
+    }
+
+    @Override
+    public boolean canUse(Player player) {
+        if (!isEnabled() || getLevel(player) <= 0 || !player.isOnline() || player.isDead()) return false;
+        if (channels.containsKey(player)) return true;
+        // Also prevents the delayed-cooldown updater from restarting a cooldown already committed by end().
+        if (championsManager.getCooldowns().hasCooldown(player, getName())) return false;
+        if (UtilPlayer.isCreativeOrSpectator(player) || player.isInsideVehicle() || player.isGliding()
+                || player.isFlying() || player.isSwimming() || UtilBlock.isInLiquid(player)
+                || player.getVelocity().getY() > 0.05 || !hasGround(player)) {
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.meditation.ground");
+            return false;
+        }
+        if (player.isInvisible() || player.hasPotionEffect(PotionEffectType.INVISIBILITY)
+                || championsManager.getEffects().hasEffect(player, EffectTypes.VANISH)) {
+            UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.meditation.visible");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasGround(Player player) {
+        BoundingBox body = player.getBoundingBox();
+        BoundingBox feet = new BoundingBox(body.getMinX(), body.getMinY() - 0.06, body.getMinZ(),
+                body.getMaxX(), body.getMinY(), body.getMaxZ());
+        int y = (int) Math.floor(feet.getMinY());
+        for (int x = (int) Math.floor(feet.getMinX()); x <= Math.floor(feet.getMaxX()); x++) {
+            for (int z = (int) Math.floor(feet.getMinZ()); z <= Math.floor(feet.getMaxZ()); z++) {
+                if (!player.getWorld().isChunkLoaded(x >> 4, z >> 4)) continue;
+                if (UtilBlock.getBoundingBoxes(player.getWorld().getBlockAt(x, y, z)).stream().anyMatch(feet::overlaps)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void toggle(Player player, int level) {
+        Channel existing = channels.get(player);
+        if (existing != null) {
+            if (existing.timeline.canCancel(now())) end(player, true);
+            return;
+        }
+        long now = now();
+        ActionBar bar = championsManager.getClientManager().search().online(player).getGamer().getActionBar();
+        Channel channel = new Channel(player.getLocation().clone(), timeline(now), bar,
+                getCooldown(level), exitDuration, exitReduction);
+        // Time bar rendered like a live cooldown; a red charge bar trails it once blows start landing.
+        channel.display = new TimedComponent(duration / 1000.0 + 1, false, viewer -> {
+            if (channels.get(player) != channel) return null;
+            double total = channel.timeline.duration / 1000.0;
+            double remaining = Math.max(0, channel.timeline.duration - (now() - now)) / 1000.0;
+            if (remaining <= 0) return null;
+            float progress = (float) Math.max(0, Math.min(1, 1 - remaining / total));
+            Component line = Component.join(JoinConfiguration.separator(Component.space()),
+                    getDisplayName().color(NamedTextColor.WHITE).decorate(TextDecoration.BOLD),
+                    ProgressBar.withProgress(progress).build(),
+                    Component.text(String.format(java.util.Locale.ROOT, "%.1fs", remaining), NamedTextColor.WHITE));
+            double burst = burstDamage(channel.charge);
+            if (burst > 0) {
+                line = line.append(Component.text("   ☠ ", NamedTextColor.DARK_GRAY))
+                        .append(ProgressBar.withLength((float) dangerFraction(channel), 8)
+                                .withProgressColor(NamedTextColor.RED)
+                                .withRemainingColor(NamedTextColor.DARK_GRAY).build())
+                        .append(Component.text(String.format(java.util.Locale.ROOT, " %.0f", burst), NamedTextColor.RED));
+            }
+            return line;
+        });
+        channels.put(player, channel);
+        protection.remove(player);
+        bar.add(getPriority() - 1, channel.display);
+        player.closeInventory();
+        if (channels.get(player) != channel) return; // inventory-close listeners can teleport or dequip
+        player.clearActiveItem();
+        player.setVelocity(new Vector());
+        playActivation(player);
+        particles(channel.anchor, channel.timeline.started, false, 0);
+    }
+
+    private MeditationTimeline timeline(long now) {
+        return new MeditationTimeline(now, duration, interval, finalPhase, cancelDelay, healing, finalHealing);
+    }
+
+    @UpdateEvent
+    public void update() {
+        long now = now();
+        for (Player player : List.copyOf(channels.keySet())) {
+            Channel channel = channels.get(player);
+            if (channel == null) continue;
+            if (!isEnabled() || getLevel(player) <= 0 || !player.isOnline() || player.isDead()
+                    || !player.getWorld().equals(channel.anchor.getWorld()) || UtilPlayer.isCreativeOrSpectator(player)) {
+                clear(player);
+                continue;
+            }
+            player.setVelocity(new Vector());
+            double danger = dangerFraction(channel);
+            // Consume each scheduled heal once, including the tick at exactly the channel's endpoint.
+            while (channels.get(player) == channel && channel.timeline.hasDueHeal(now)) {
+                double amount = channel.timeline.takeHeal(now);
+                if (amount > 0) UtilPlayer.health(player, amount);
+                if (channels.get(player) != channel) break; // healing listeners may invalidate the skill
+                particles(channel.anchor, channel.timeline.started, true, danger);
+                playHeal(player);
+            }
+            if (channels.get(player) != channel) continue;
+            if (channel.timeline.isComplete(now)) {
+                end(player, true);
+            } else if (now >= channel.nextParticles) {
+                particles(channel.anchor, channel.timeline.started, false, danger);
+                if (danger > 0) {
+                    // Pulse climbs in pitch as the burst nears its cap - the tell for anyone still hitting.
+                    channel.anchor.getWorld().playSound(channel.anchor, Sound.BLOCK_RESPAWN_ANCHOR_CHARGE,
+                            0.5f, 0.6f + (float) danger);
+                }
+                channel.nextParticles = now + (long) (200 - danger * 110); // pulses quicken as it fills
+            }
+        }
+        pendingBursts.entrySet().removeIf(entry -> {
+            PendingBurst burst = entry.getValue();
+            long left = burst.fireAt - now;
+            if (left > 0) {
+                telegraphParticles(burst.center, 1 - (double) left / Math.max(1, burstTelegraph));
+                return false;
+            }
+            detonate(entry.getKey(), burst.center, burst.charge);
+            return true;
+        });
+        protection.entrySet().removeIf(entry -> now >= entry.getValue().expires || !isEnabled()
+                || !entry.getKey().isOnline() || entry.getKey().isDead() || getLevel(entry.getKey()) <= 0);
+    }
+
+    private void end(Player player, boolean successful) {
+        Channel channel = channels.remove(player);
+        if (channel == null) return;
+        channel.timeline.end();
+        channel.bar.remove(channel.display);
+        if (!player.isOnline()) return;
+        player.setVelocity(new Vector());
+        if (!player.isDead() && !championsManager.getCooldowns().hasCooldown(player, getName())) {
+            championsManager.getCooldowns().use(player, getName(), channel.cooldown, showCooldownFinished(),
+                    true, isCancellable(), this::shouldDisplayActionBar, getPriority());
+        }
+        if (successful && !player.isDead()) {
+            if (channel.exitDuration > 0 && channel.exitReduction > 0) {
+                protection.put(player, new Protection(now() + channel.exitDuration, channel.exitReduction));
+            }
+            if (burstDamage(channel.charge) > 0) {
+                // Fuse it rather than firing instantly - a short wind-up so anyone in range can sprint clear.
+                pendingBursts.put(player, new PendingBurst(player.getLocation().clone(), channel.charge,
+                        now() + burstTelegraph));
+                player.getWorld().playSound(player.getLocation(), Sound.BLOCK_RESPAWN_ANCHOR_DEPLETE, 1.0f, 0.6f);
+                player.getWorld().playSound(player.getLocation(), Sound.ENTITY_WARDEN_HEARTBEAT, 1.2f, 0.5f);
+            }
+            playEnd(player);
+        }
+    }
+
+    /** Imploding black ring during the fuse, then a black shockwave: capped damage + a shove to everyone near. */
+    private void detonate(Player source, Location center, double charge) {
+        double damage = burstDamage(charge);
+        if (damage <= 0) return;
+        for (LivingEntity target : UtilEntity.getNearbyEnemies(source, center, burstRadius)) {
+            if (target.equals(source)) continue;
+            Vector trajectory = UtilVelocity.getTrajectory2d(center.toVector(), target.getLocation().toVector());
+            UtilVelocity.velocity(target, source, new VelocityData(trajectory, burstKnockback, 0.25, 0.6, true));
+            UtilDamage.doDamage(new DamageEvent(target, source, null, new SkillDamageCause(this), damage, getName()));
+        }
+        Location core = center.clone().add(0, 1, 0);
+        center.getWorld().playSound(center, Sound.ENTITY_GENERIC_EXPLODE, 0.9f, 0.5f);
+        center.getWorld().playSound(center, Sound.ENTITY_WARDEN_SONIC_BOOM, 0.45f, 1.3f);
+        Particle.SQUID_INK.builder().location(core).count(45).offset(0.35, 0.4, 0.35).extra(0.18).receivers(45).spawn();
+        Particle.SMOKE.builder().location(core).count(40).offset(0.2, 0.2, 0.2).extra(0.08).receivers(45).spawn();
+        for (double radius = 0.6; radius <= burstRadius; radius += 0.8) {
+            for (int i = 0; i < 22; i++) {
+                double a = Math.PI * 2 * i / 22;
+                Particle.DUST.builder()
+                        .location(center.clone().add(Math.cos(a) * radius, 0.25, Math.sin(a) * radius))
+                        .data(new Particle.DustOptions(Color.fromRGB(14, 14, 16), 1.5f))
+                        .count(1).extra(0).receivers(45).spawn();
+            }
+        }
+    }
+
+    private void telegraphParticles(Location center, double progress) {
+        double radius = burstRadius * (1 - Math.max(0, Math.min(1, progress))); // ring collapses inward as the fuse burns
+        for (int i = 0; i < 20; i++) {
+            double a = Math.PI * 2 * i / 20;
+            Particle.DUST.builder()
+                    .location(center.clone().add(Math.cos(a) * radius, 0.25, Math.sin(a) * radius))
+                    .data(new Particle.DustOptions(Color.fromRGB(20, 20, 24), 1.2f))
+                    .count(1).extra(0).receivers(40).spawn();
+        }
+    }
+
+    private double burstDamage(double charge) {
+        if (charge <= 0 || burstReflectRatio <= 0 || burstRadius <= 0) return 0;
+        return Math.min(burstMaxDamage, charge * burstReflectRatio);
+    }
+
+    private double dangerFraction(Channel channel) {
+        if (burstMaxDamage <= 0) return channel.charge > 0 ? 1 : 0;
+        return Math.max(0, Math.min(1, burstDamage(channel.charge) / burstMaxDamage));
+    }
+
+    private void clear(Player player) {
+        end(player, false);
+        protection.remove(player);
+        pendingBursts.remove(player); // a forced exit (death, teleport, unequip) drops the fuse
+    }
+
+    private boolean locked(Entity entity) { return entity instanceof Player player && channels.containsKey(player); }
+
+    private boolean lockedSource(Entity entity) {
+        return locked(entity) || entity instanceof Projectile projectile
+                && projectile.getShooter() instanceof Player player && locked(player);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onDamageEarly(DamageEvent event) {
+        if (locked(event.getDamagee()) || lockedSource(event.getDamager()) || lockedSource(event.getDirectEntity())) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Every blow blocked by a meditating player feeds the exit burst. Runs once at MONITOR (not re-invoked like
+     * onDamageEarly) and reads the intended damage even though the event is already cancelled.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onMeditationCharge(DamageEvent event) {
+        if (!(event.getDamagee() instanceof Player player) || !playerSourced(event)) return;
+        Channel channel = channels.get(player);
+        if (channel == null) return;
+        channel.charge += Math.max(0, event.getDamage());
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_SHIELD_BLOCK, 0.6f, 1.5f);
+        Particle.DUST.builder().location(player.getLocation().add(0, 1, 0))
+                .data(new Particle.DustOptions(Color.fromRGB(255, 120, 60), 1.1f))
+                .count(10).offset(0.35, 0.45, 0.35).extra(0).receivers(30).spawn();
+    }
+
+    private boolean playerSourced(DamageEvent event) {
+        if (event.getDamager() instanceof Player) return true;
+        return event.getDirectEntity() instanceof Projectile projectile && projectile.getShooter() instanceof Player;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDamageLate(DamageEvent event) {
+        onDamageEarly(event); // catch damage whose owner was resolved by another listener
+        if (event.isCancelled() || !(event.getDamagee() instanceof Player player)) return;
+        Protection exit = protection.get(player);
+        if (exit != null && now() < exit.expires) {
+            event.addModifier(new SkillDamageModifier.Multiplier(this, 1 - exit.reduction));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onVanillaDamage(EntityDamageEvent event) {
+        // Entity hits are left alone here so they reach BetterPvP's DamageEvent pipeline - onDamageEarly
+        // cancels them there (no damage) and the burst meter reads them. This only stops environmental
+        // damage, which never becomes a DamageEvent.
+        if (event instanceof EntityDamageByEntityEvent) return;
+        if (locked(event.getEntity()) || lockedSource(event.getDamageSource().getCausingEntity())
+                || lockedSource(event.getDamageSource().getDirectEntity())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onUseSkill(PlayerUseSkillEvent event) {
+        if (locked(event.getPlayer()) && event.getSkill() != this) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onCanUseSkill(PlayerCanUseSkillEvent event) {
+        if (locked(event.getPlayer()) && event.getSkill() != this) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onMove(PlayerMoveEvent event) {
+        if (event instanceof PlayerTeleportEvent) return;
+        Channel channel = channels.get(event.getPlayer());
+        if (channel == null || event.getTo() == null || !event.hasChangedPosition()) return;
+        Location destination = channel.anchor.clone();
+        destination.setYaw(event.getTo().getYaw());
+        destination.setPitch(event.getTo().getPitch());
+        // Cancelling uses the movement rollback path. setTo would cause a plugin teleport and end the channel.
+        event.setFrom(destination);
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onVelocity(PlayerVelocityEvent event) {
+        if (locked(event.getPlayer())) {
+            event.setVelocity(new Vector());
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onCustomVelocity(CustomEntityVelocityEvent event) {
+        if (locked(event.getEntity())) {
+            event.setVector(new Vector());
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onAttack(PrePlayerAttackEntityEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInteract(PlayerInteractEvent event) {
+        if (!locked(event.getPlayer())) return;
+        event.setUseItemInHand(Event.Result.DENY);
+        event.setUseInteractedBlock(Event.Result.DENY);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityInteract(PlayerInteractEntityEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityInteractAt(PlayerInteractAtEntityEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onArmorStand(PlayerArmorStandManipulateEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBreak(BlockBreakEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlace(BlockPlaceEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (locked(event.getWhoClicked())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (locked(event.getWhoClicked())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPickup(PlayerAttemptPickupItemEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onSwap(PlayerSwapHandItemsEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onConsume(PlayerItemConsumeEvent event) {
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onLaunch(ProjectileLaunchEvent event) {
+        if (lockedSource(event.getEntity())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDrop(PlayerDropItemEvent event) {
+        // SkillListener handles the Sword / Axe reactivation first; suppress any other item drops.
+        if (locked(event.getPlayer())) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTeleport(PlayerTeleportEvent event) { clear(event.getPlayer()); }
+
+    @EventHandler
+    public void onWorldChange(PlayerChangedWorldEvent event) { clear(event.getPlayer()); }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) { clear(event.getEntity()); }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) { clear(event.getPlayer()); }
+
+    @Override
+    public void invalidatePlayer(Player player, Gamer gamer) { clear(player); }
+
+    @Override
+    public void reload() {
+        List.copyOf(channels.keySet()).forEach(this::clear);
+        protection.clear();
+        pendingBursts.clear();
+        super.reload();
+    }
+
+    @EventHandler
+    public void onDisable(PluginDisableEvent event) {
+        if (event.getPlugin() != champions) return;
+        List.copyOf(channels.keySet()).forEach(this::clear);
+        protection.clear();
+        pendingBursts.clear();
+    }
+
+    protected long now() { return System.currentTimeMillis(); }
+
+    protected void playActivation(Player player) {
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_ACTIVATE, 0.5f, 1.5f);
+    }
+
+    protected void playHeal(Player player) {
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_AMETHYST_BLOCK_CHIME, 0.25f, 1.5f);
+    }
+
+    protected void playEnd(Player player) {
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 1.6f);
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 0.35f, 1.4f);
+    }
+
+    protected void particles(Location anchor, long started, boolean heal, double danger) {
+        double phase = (now() - started) / 1000.0;
+        danger = Math.max(0, Math.min(1, danger));
+        // Calm blue orbit, tinting toward an ominous dark red as the burst charges.
+        Color color = Color.fromRGB(
+                (int) Math.round((heal ? 160 : 100) + (150 - (heal ? 160 : 100)) * danger),
+                (int) Math.round(210 + (10 - 210) * danger),
+                (int) Math.round(230 + (10 - 230) * danger));
+        for (int i = 0; i < 16; i++) {
+            double angle = phase + i * Math.PI / 8;
+            Particle.DUST.builder().location(anchor.clone().add(Math.cos(angle) * 0.8, 0.1, Math.sin(angle) * 0.8))
+                    .data(new Particle.DustOptions(color, 0.9f))
+                    .count(1).extra(0).receivers(30).spawn();
+        }
+        Particle.END_ROD.builder().location(anchor.clone().add(0, 0.8, 0))
+                .count(heal ? 5 : 2).offset(0.35, 0.6, 0.35).extra(0.015).receivers(30).spawn();
+    }
+
+    @Override
+    public void loadSkillConfig() {
+        duration = milliseconds("duration", 4, 0.05);
+        interval = milliseconds("healingInterval", 0.5, 0.05);
+        finalPhase = Math.min(duration, milliseconds("finalPhaseDuration", 1, 0));
+        cancelDelay = Math.min(duration, milliseconds("minimumCancelTime", 1, 0));
+        exitDuration = milliseconds("exitResistanceDuration", 0.5, 0);
+        healing = number("healingPerTick", 1, 0);
+        finalHealing = number("finalHealingPerTick", 2, 0);
+        exitReduction = Math.min(1, number("exitDamageReduction", 0.2, 0));
+        burstReflectRatio = number("burstReflectRatio", 0.6, 0);
+        burstMaxDamage = number("burstMaxDamage", 12, 0);
+        burstRadius = number("burstRadius", 4, 0);
+        burstKnockback = number("burstKnockback", 1.2, 0);
+        burstTelegraph = milliseconds("burstTelegraph", 0.5, 0);
+        cooldown = Double.isFinite(cooldown) ? Math.max(0, cooldown) : 24;
+    }
+
+    private double number(String key, double fallback, double minimum) {
+        double value = getConfig(key, fallback, Number.class).doubleValue();
+        return Double.isFinite(value) ? Math.max(minimum, value) : fallback;
+    }
+
+    @Override
+    protected <T> T getConfig(String name, T defaultValue, Class<T> type) {
+        // Skill's generic defaults are five levels and a one-second cooldown. Seed this new skill's
+        // actual defaults when an existing server has no meditation section yet.
+        Object fallback = switch (name) {
+            case "maxlevel" -> 1;
+            case "cooldown" -> 24.0;
+            case "cooldownDecreasePerLevel" -> 0.0;
+            default -> defaultValue;
+        };
+        return super.getConfig(name, type.cast(fallback), type);
+    }
+
+    private long milliseconds(String key, double fallback, double minimum) {
+        return Math.round(number(key, fallback, minimum) * 1000);
+    }
+
+    private static final class Channel {
+        private final Location anchor;
+        private final MeditationTimeline timeline;
+        private final ActionBar bar;
+        private final double cooldown;
+        private final long exitDuration;
+        private final double exitReduction;
+        private TimedComponent display;
+        private long nextParticles;
+        private double charge; // total damage blocked, released as the exit burst
+
+        private Channel(Location anchor, MeditationTimeline timeline, ActionBar bar, double cooldown,
+                        long exitDuration, double exitReduction) {
+            this.anchor = anchor;
+            this.timeline = timeline;
+            this.bar = bar;
+            this.cooldown = cooldown;
+            this.exitDuration = exitDuration;
+            this.exitReduction = exitReduction;
+        }
+    }
+
+    /** Per-cast healing schedule. Uses scheduled tick times so lag does not change the healing total. */
+    static final class MeditationTimeline {
+        final long started;
+        final long duration;
+        private final long interval;
+        private final long finalPhase;
+        private final long cancelDelay;
+        private final double healing;
+        private final double finalHealing;
+        private long nextTick = 1;
+        private boolean ended;
+
+        MeditationTimeline(long started, long duration, long interval, long finalPhase, long cancelDelay,
+                           double healing, double finalHealing) {
+            this.started = started;
+            this.duration = duration;
+            this.interval = interval;
+            this.finalPhase = finalPhase;
+            this.cancelDelay = cancelDelay;
+            this.healing = healing;
+            this.finalHealing = finalHealing;
+        }
+
+        boolean canCancel(long now) {
+            return !ended && now - started >= cancelDelay;
+        }
+
+        boolean isComplete(long now) {
+            return now - started >= duration;
+        }
+
+        boolean hasDueHeal(long now) {
+            return !ended && nextTick * interval <= Math.min(duration, now - started);
+        }
+
+        double takeHeal(long now) {
+            if (!hasDueHeal(now)) throw new IllegalStateException("No Meditation healing tick is due");
+            return nextTick++ * interval > duration - finalPhase ? finalHealing : healing;
+        }
+
+        double totalHealing() {
+            long ticks = duration / interval;
+            long normalTicks = (duration - finalPhase) / interval;
+            return normalTicks * healing + (ticks - normalTicks) * finalHealing;
+        }
+
+        void end() {
+            ended = true;
+        }
+    }
+
+    private record Protection(long expires, double reduction) { }
+
+    private record PendingBurst(Location center, double charge, long fireAt) { }
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/PredatorsMark.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/skills/assassin/passives/PredatorsMark.java
@@ -1,0 +1,823 @@
+package me.mykindos.betterpvp.champions.champions.skills.skills.assassin.passives;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.CustomLog;
+import me.mykindos.betterpvp.champions.Champions;
+import me.mykindos.betterpvp.champions.champions.ChampionsManager;
+import me.mykindos.betterpvp.champions.champions.skills.Skill;
+import me.mykindos.betterpvp.champions.champions.skills.data.SkillWeapons;
+import me.mykindos.betterpvp.champions.champions.skills.types.CooldownToggleSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.DebuffSkill;
+import me.mykindos.betterpvp.champions.champions.skills.types.MovementSkill;
+import me.mykindos.betterpvp.core.client.gamer.Gamer;
+import me.mykindos.betterpvp.core.combat.death.events.CustomDeathEvent;
+import me.mykindos.betterpvp.core.combat.events.CustomEntityVelocityEvent;
+import me.mykindos.betterpvp.core.combat.events.VelocityType;
+import me.mykindos.betterpvp.core.components.champions.Role;
+import me.mykindos.betterpvp.core.components.champions.SkillType;
+import me.mykindos.betterpvp.core.effects.EffectTypes;
+import me.mykindos.betterpvp.core.framework.updater.UpdateEvent;
+import me.mykindos.betterpvp.core.listener.BPvPListener;
+import me.mykindos.betterpvp.core.locale.Translations;
+import me.mykindos.betterpvp.core.utilities.UtilBlock;
+import me.mykindos.betterpvp.core.utilities.UtilMessage;
+import me.mykindos.betterpvp.core.utilities.UtilPlayer;
+import me.mykindos.betterpvp.core.utilities.UtilServer;
+import me.mykindos.betterpvp.core.utilities.model.ProgressBar;
+import me.mykindos.betterpvp.core.utilities.model.SoundEffect;
+import me.mykindos.betterpvp.core.utilities.model.display.component.TimedComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Color;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Assassin passive. Drop a weapon to mark the enemy in your crosshair: for a few seconds only you see them,
+ * glowing through walls. Drop again within that window to blind them and lunge toward them, stopping short. Land the kill before
+ * the hunt timer runs out and a short window opens to drop once more - dashing back to the spot you leapt from.
+ */
+@Singleton
+@BPvPListener
+@CustomLog
+public class PredatorsMark extends Skill implements CooldownToggleSkill, MovementSkill, DebuffSkill, Listener {
+
+    // Active sequence - one phase at a time per hunter.
+    private final Map<Player, Mark> marks = new WeakHashMap<>();
+    private final Map<Player, Lunge> lunges = new WeakHashMap<>();
+    private final Map<Player, Location> lungeArrivals = new WeakHashMap<>(); // internal arrival teleports
+    private final Map<Player, Hunt> hunts = new WeakHashMap<>();              // stuck lunge; kill the target before it lapses to earn the shadowstep
+    private final Map<Player, Shadowstep> shadowsteps = new WeakHashMap<>();  // open "drop again to escape" window
+    private final Map<Player, ReturnDash> returnDashes = new WeakHashMap<>(); // escape dash in flight
+
+    // Passive preview - a screen-edge vignette while an enemy is markable in the crosshair.
+    private final Set<Player> equippedPlayers = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Map<Player, Player> vignetteTargets = new WeakHashMap<>();  // current preview target, so its death/quit clears the vignette at once
+
+    private double range;
+    private double markDuration;      // glow lifetime, and the window to re-drop and lunge
+    private double blindDuration;     // blindness on the target when the hunter commits the lunge
+    private double lungeSpeed;
+    private double lungeStopDistance; // land this far short of the target - a dive that ends inside them feels bad
+    private double maxLungeDuration;  // hard timeout on an in-flight lunge or return dash
+    private double huntDuration;      // time after a stuck lunge to secure the kill and earn the escape
+    private double returnWindow;      // time after the kill to drop again and dash home
+    private double returnMaxDistance; // give up the escape if the hunter is dragged this far from the anchor
+
+    @Inject
+    public PredatorsMark(Champions champions, ChampionsManager championsManager) {
+        super(champions, championsManager);
+    }
+
+    @Override
+    public String getName() {
+        return "Predators Mark";
+    }
+
+    @Override
+    public Role getClassType() {
+        return Role.ASSASSIN;
+    }
+
+    @Override
+    public SkillType getType() {
+        return SkillType.PASSIVE_A;
+    }
+
+    @Override
+    public Component[] getDescription(int level) {
+        Component blindness = Translations.component("champions.skill.effect.blindness.name").color(NamedTextColor.WHITE);
+        return Translations.componentLines("champions.skill.assassin.predators-mark.description",
+                getValueComponent(ignored -> range, level),           // {0}
+                getValueComponent(ignored -> markDuration, level),     // {1}
+                getValueComponent(ignored -> blindDuration, level),    // {2}
+                getValueComponent(ignored -> huntDuration, level),     // {3}
+                getValueComponent(this::getCooldown, level),           // {4}
+                blindness);                                            // {5}
+    }
+
+    @Override
+    public double getCooldown(int level) {
+        return cooldown;
+    }
+
+    @Override
+    public boolean isDelayedSkill() {
+        return true;
+    }
+
+    @Override
+    public boolean isUsingSkill(Player player) {
+        // The whole sequence counts as "in use" so the delayed-cooldown flow never starts the cooldown itself -
+        // it is committed by hand at each end point (see startCooldown callers), so it does not tick during the
+        // hunt or the escape window.
+        return marks.containsKey(player) || lunges.containsKey(player) || hunts.containsKey(player)
+                || shadowsteps.containsKey(player) || returnDashes.containsKey(player);
+    }
+
+    @Override
+    public boolean canReactivate(Player player) {
+        final long now = System.currentTimeMillis();
+        Mark mark = marks.get(player);
+        if (mark != null && now < mark.expires) return true;
+        Shadowstep step = shadowsteps.get(player);
+        return step != null && now < step.expires();
+    }
+
+    @Override
+    public boolean canUse(Player player) {
+        if (lunges.containsKey(player) || hunts.containsKey(player) || returnDashes.containsKey(player)
+                || player.getGameMode() == GameMode.SPECTATOR) return false;
+        if (shadowsteps.containsKey(player)) return true;
+        if (marks.containsKey(player) || championsManager.getCooldowns().hasCooldown(player, getName())) return true;
+        if (findTarget(player) != null) return true;
+        message(player, "no-target");
+        return false;
+    }
+
+    @Override
+    public boolean displayWhenUsed() {
+        return false;
+    }
+
+    @Override
+    public void toggle(Player player, int level) {
+        // Third drop: spend the shadowstep window.
+        Shadowstep step = shadowsteps.remove(player);
+        if (step != null) {
+            if (System.currentTimeMillis() < step.expires()) {
+                performShadowstep(player, step);
+            }
+            return;
+        }
+
+        // Second drop: spend the mark on a lunge.
+        Mark mark = marks.get(player);
+        if (mark != null) {
+            if (System.currentTimeMillis() >= mark.expires || !validTarget(player, mark.target)) {
+                markLostCue(player);
+                endMark(player, true);
+                return;
+            }
+            if (player.getLocation().distanceSquared(mark.target.getLocation()) > range * range) {
+                message(player, "out-of-range");
+                return;
+            }
+            Player lungeTarget = mark.target;
+            Location anchor = player.getLocation().clone(); // leap point, carried to the shadowstep if this dive lands a kill
+            endMark(player, false); // the lunge/hunt/escape chain now owns the cooldown
+            // Blindness on commit, not on arrival - the lunge itself can still be walled off.
+            championsManager.getEffects().addEffect(lungeTarget, player, EffectTypes.BLINDNESS, 1,
+                    (long) (blindDuration * 1000));
+            Lunge lunge = new Lunge(lungeTarget, player.getWorld(), anchor,
+                    System.currentTimeMillis() + (long) (maxLungeDuration * 1000));
+            lunges.put(player, lunge);
+            playLungeStart(player);
+            advanceLunge(player, lunge);
+            return;
+        }
+
+        // First drop: mark the enemy in the crosshair.
+        Player target = findTarget(player);
+        if (target == null) {
+            message(player, "no-target");
+            return;
+        }
+        long now = System.currentTimeMillis();
+        Mark created = new Mark(target, now + (long) (markDuration * 1000));
+        marks.put(player, created);
+        updateGlow(player, created);
+        UtilMessage.message(player, getClassType().getDisplayName(),
+                "champions.skill.assassin.predators-mark.marked", Component.text(target.getName(), NamedTextColor.RED));
+        Component targetAlert = Translations.component("champions.skill.assassin.predators-mark.marked-by",
+                Component.text(player.getName(), NamedTextColor.RED));
+        UtilMessage.message(target, getClassType().getDisplayName(), Translations.render(targetAlert, target.locale()));
+        showLungeWindowBar(player, created);
+        updateVignette(player, target);
+        playMarkApplied(player, target);
+    }
+
+    private Player findTarget(Player player) {
+        List<Player> enemies = UtilPlayer.getNearbyEnemies(player, player.getLocation(), range);
+        RayTraceResult hit = player.getWorld().rayTrace(player.getEyeLocation(),
+                player.getEyeLocation().getDirection(), range, FluidCollisionMode.NEVER, true, 0,
+                entity -> entity instanceof Player target && enemies.contains(target) && validTarget(player, target));
+        return hit != null && hit.getHitEntity() instanceof Player target ? target : null;
+    }
+
+    private boolean validTarget(Player player, Player target) {
+        return player.isOnline() && !player.isDead() && target.isOnline() && !target.isDead()
+                && player.getGameMode() != GameMode.SPECTATOR
+                && player.getWorld().equals(target.getWorld()) && player.canSee(target)
+                && target.getGameMode() != GameMode.SPECTATOR
+                && UtilPlayer.getNearbyEnemies(player, target.getLocation(), 1).contains(target);
+    }
+
+    @UpdateEvent
+    public void update() {
+        long now = System.currentTimeMillis();
+
+        // Marks: keep the glow and cues alive, or end the mark (and spend the cooldown) if it lapses.
+        for (Player player : List.copyOf(marks.keySet())) {
+            Mark mark = marks.get(player);
+            if (!isEnabled() || getLevel(player) <= 0) {
+                endMark(player, false); // skill switched off or unequipped - no cooldown penalty
+                continue;
+            }
+            if (!validTarget(player, mark.target)) {
+                markLostCue(player);
+                endMark(player, true); // target escaped or died - marking still commits the cooldown
+                continue;
+            }
+            if (now >= mark.expires) {
+                markLostCue(player);
+                endMark(player, true);
+                continue;
+            }
+            updateGlow(player, mark);
+            pulseReticle(player, mark, now);
+            updateVignette(player, player.getLocation().distanceSquared(mark.target.getLocation()) <= range * range
+                    ? mark.target : null);
+        }
+
+        // Drive the in-flight movement and age out the timed states.
+        for (Player player : List.copyOf(lunges.keySet())) {
+            advanceLunge(player, lunges.get(player));
+        }
+        for (Player player : List.copyOf(returnDashes.keySet())) {
+            advanceReturn(player, returnDashes.get(player));
+        }
+        for (Player player : List.copyOf(hunts.keySet())) {
+            if (now >= hunts.get(player).expires()) {
+                hunts.remove(player);
+                if (player.isOnline()) {
+                    startCooldown(player); // hunt lapsed without a kill - commit the cooldown now
+                }
+            }
+        }
+        for (Player player : List.copyOf(shadowsteps.keySet())) {
+            if (now >= shadowsteps.get(player).expires()) {
+                shadowsteps.remove(player);
+                if (player.isOnline()) {
+                    startCooldown(player); // escape window missed - commit the cooldown now
+                    new SoundEffect(Sound.BLOCK_NOTE_BLOCK_BASS, 0.6f, 0.6f).play(player);
+                }
+            }
+        }
+        // Passive preview: show the vignette to anyone holding the weapon with a markable enemy in the crosshair.
+        for (Player player : List.copyOf(equippedPlayers)) {
+            if (!player.isOnline() || getLevel(player) <= 0) {
+                invalidatePlayer(player, null);
+                continue;
+            }
+            if (marks.containsKey(player)) continue;
+            final SkillType held = SkillWeapons.getTypeFrom(player.getInventory().getItemInMainHand());
+            boolean ready = isEnabled() && !player.isDead() && player.getGameMode() != GameMode.SPECTATOR
+                    && !lunges.containsKey(player)
+                    && !championsManager.getCooldowns().hasCooldown(player, getName())
+                    && (held == SkillType.SWORD || held == SkillType.AXE);
+            updateVignette(player, ready ? findTarget(player) : null);
+        }
+    }
+
+    private void updateGlow(Player player, Mark mark) {
+        if (mark.glowing || mark.glowFailed) return;
+        try {
+            UtilPlayer.setGlowing(player, mark.target, true);
+            mark.glowing = true;
+        } catch (Exception ex) {
+            mark.glowFailed = true;
+            log.warn("Could not apply Predator's Mark glow", ex).submit();
+        }
+    }
+
+    private void clearGlow(Player player, Mark mark) {
+        if (!mark.glowing && !mark.glowFailed) return;
+        mark.glowing = false;
+        mark.glowFailed = false;
+        try {
+            UtilPlayer.setGlowing(player, mark.target, false);
+        } catch (Exception ex) {
+            log.warn("Could not clear Predator's Mark glow", ex).submit();
+        }
+    }
+
+    private void updateVignette(Player player, Player target) {
+        Player previous = target == null ? vignetteTargets.remove(player) : vignetteTargets.put(player, target);
+        if ((previous == null) == (target == null)) return;
+        if (!player.isOnline()) return;
+        try {
+            if (target != null) UtilPlayer.setWarningEffect(player, 1);
+            else UtilPlayer.clearWarningEffect(player);
+        } catch (Exception ex) {
+            log.warn("Could not update Predator's Mark vignette", ex).submit();
+        }
+    }
+
+    private void advanceLunge(Player player, Lunge lunge) {
+        if (!isEnabled() || getLevel(player) <= 0 || !validTarget(player, lunge.target())
+                || !player.getWorld().equals(lunge.world()) || System.currentTimeMillis() >= lunge.expires()
+                || player.getLocation().distanceSquared(lunge.target().getLocation()) > range * range) {
+            fizzleLunge(player);
+            return;
+        }
+        final Location start = player.getLocation();
+        final Vector toTarget = lunge.target().getLocation().toVector().subtract(start.toVector());
+        final double distance = toTarget.length();
+        final double targetFeetY = lunge.target().getLocation().getY();
+        if (distance <= lungeStopDistance + 0.1) {
+            // Include a small tolerance so eased movement cannot stall just outside the stop point.
+            if (player.hasLineOfSight(lunge.target())) {
+                finishLunge(player, lunge);
+            } else {
+                fizzleLunge(player); // ducked behind cover at the last moment
+            }
+            return;
+        }
+        // Aim for a point lungeStopDistance short of the target so the dive never ends inside them.
+        final double remaining = distance - lungeStopDistance;
+        final double speed = Math.min(lungeSpeed, remaining <= 1.5 ? Math.min(0.4, remaining) : remaining);
+        final Vector velocity = toTarget.multiply(speed / distance);
+        final CustomEntityVelocityEvent event = UtilServer.callEvent(
+                new CustomEntityVelocityEvent(player, null, VelocityType.CUSTOM, velocity));
+        if (event.isCancelled() || !clearPath(player, event.getVector(), targetFeetY)) {
+            fizzleLunge(player);
+            return;
+        }
+        // Let normal movement packets and Minecraft collision handling move the player smoothly.
+        player.setVelocity(event.getVector());
+        player.setFallDistance(0);
+        lungeTrail(player);
+    }
+
+    /**
+     * Sweeps the player's hitbox toward the target in ~0.1 block steps looking for a wall. The test box ramps
+     * up to a higher target so leaping onto a ledge reads as clear, but never dips below standing height for a
+     * lower one - a downhill lunge clears the ground horizontally then falls under its own velocity, and
+     * following the diagonal would clip the box through the ledge it is leaping off.
+     */
+    private boolean clearPath(Player player, Vector velocity, double targetFeetY) {
+        double distance = velocity.length();
+        if (!Double.isFinite(distance) || distance > 4) return false;
+        final Location start = player.getLocation();
+        final BoundingBox box = player.getBoundingBox();
+        final double startFeetY = start.getY();
+        final int steps = Math.max(1, (int) Math.ceil(distance / 0.1));
+        for (int step = 1; step <= steps; step++) {
+            final double t = (double) step / steps;
+            final double dx = velocity.getX() * t;
+            final double dz = velocity.getZ() * t;
+            final double dy = Math.max(0.0, (targetFeetY - startFeetY) * t); // ramp up to a higher target; never dip below
+            if (blocked(start.clone().add(dx, dy, dz), box.clone().shift(dx, dy, dz))) return false;
+        }
+        return true;
+    }
+
+    private boolean blocked(Location location, BoundingBox box) {
+        return blocked(location, box, true);
+    }
+
+    private boolean blocked(Location location, BoundingBox box, boolean allowStep) {
+        if (!location.getWorld().getWorldBorder().isInside(location)) return true;
+        final double stepTop = box.getMinY() + 0.6; // anything topping out this low, the player just walks up
+        for (int x = (int) Math.floor(box.getMinX()); x <= Math.floor(box.getMaxX()); x++) {
+            for (int y = (int) Math.floor(box.getMinY()); y <= Math.floor(box.getMaxY()); y++) {
+                if (y < location.getWorld().getMinHeight() || y >= location.getWorld().getMaxHeight()) return true;
+                for (int z = (int) Math.floor(box.getMinZ()); z <= Math.floor(box.getMaxZ()); z++) {
+                    if (!location.getWorld().isChunkLoaded(x >> 4, z >> 4)) return true;
+                    for (BoundingBox obstacle : UtilBlock.getBoundingBoxes(location.getWorld().getBlockAt(x, y, z))) {
+                        if (allowStep && obstacle.getMaxY() <= stepTop) continue; // low step, not a wall
+                        if (obstacle.overlaps(box)) return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void finishLunge(Player player, Lunge lunge) {
+        snapLungeArrival(player, lunge);
+        stopLunge(player);
+        player.setFallDistance(0);
+        final double connect = lungeStopDistance + 2.0; // reach check only; snapLungeArrival governs spacing
+        if (validTarget(player, lunge.target()) && player.hasLineOfSight(lunge.target())
+                && player.getLocation().distanceSquared(lunge.target().getLocation()) <= connect * connect) {
+            // Stuck the dive - start the hunt: a countdown to secure the kill and unlock the escape.
+            final Hunt hunt = new Hunt(lunge.target(), lunge.anchor(),
+                    System.currentTimeMillis() + (long) (huntDuration * 1000));
+            hunts.put(player, hunt);
+            showHuntBar(player, hunt);
+            playLungeHit(lunge.target().getLocation());
+        }
+    }
+
+    /** Correct residual motion and target movement without snapping into or through blocks. */
+    private void snapLungeArrival(Player player, Lunge lunge) {
+        final Location start = player.getLocation();
+        final Location target = lunge.target().getLocation();
+        Vector away = start.toVector().subtract(target.toVector());
+        if (away.lengthSquared() < 1.0e-6) {
+            // Exact overlap has no direction; use the side from which the hunter committed the dive.
+            away = lunge.anchor().toVector().subtract(target.toVector());
+            if (away.lengthSquared() < 1.0e-6) {
+                away = start.getDirection().setY(0).multiply(-1);
+                if (away.lengthSquared() < 1.0e-6) away = new Vector(1, 0, 0);
+            }
+        }
+        final Location arrival = target.clone().add(away.normalize().multiply(lungeStopDistance));
+        arrival.setYaw(start.getYaw());
+        arrival.setPitch(start.getPitch());
+        final Vector correction = arrival.toVector().subtract(start.toVector());
+        if (!clearPath(player, correction, arrival.getY())) return;
+
+        // Unlike ordinary movement, a teleport cannot step up out of a partial floor intersection.
+        // Sweep the actual correction as well as the ledge-aware movement path above.
+        final BoundingBox box = player.getBoundingBox();
+        final int steps = Math.max(1, (int) Math.ceil(correction.length() / 0.1));
+        for (int step = 1; step <= steps; step++) {
+            final Vector offset = correction.clone().multiply((double) step / steps);
+            if (blocked(start.clone().add(offset), box.clone().shift(offset), false)) return;
+        }
+        player.setVelocity(new Vector());
+        lungeArrivals.put(player, arrival);
+        try {
+            player.teleport(arrival);
+        } finally {
+            lungeArrivals.remove(player);
+        }
+    }
+
+    /** Stops an in-flight lunge that failed to reach its target, with a short "missed" cue. */
+    private void fizzleLunge(Player player) {
+        if (!lunges.containsKey(player)) return;
+        stopLunge(player);
+        if (!player.isOnline() || getLevel(player) <= 0) return; // unequipped mid-lunge - ownership loss, no cooldown
+        startCooldown(player); // the dive is spent, even if it hit a wall
+        new SoundEffect(Sound.ENTITY_ITEM_BREAK, 0.7f, 0.9f).play(player.getLocation());
+        lungeSpark(player.getLocation().add(0, 1, 0), 8, 0.25);
+    }
+
+    private void stopLunge(Player player) {
+        if (lunges.remove(player) != null && player.isOnline()) {
+            player.setVelocity(new Vector());
+        }
+    }
+
+    /** The marked target dies while the hunt is live: open the shadowstep window for the hunter. */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onMarkedKill(CustomDeathEvent event) {
+        if (!(event.getKilled() instanceof Player victim)) return;
+        for (Player hunter : List.copyOf(hunts.keySet())) {
+            final Hunt hunt = hunts.get(hunter);
+            if (hunt == null || !victim.equals(hunt.target())) continue;
+            hunts.remove(hunter);
+            if (!hunter.isOnline() || getLevel(hunter) <= 0) continue; // ownership loss - no cooldown
+            if (System.currentTimeMillis() >= hunt.expires()
+                    || !hunter.getWorld().equals(hunt.anchor().getWorld())) {
+                startCooldown(hunter); // combo is over but no escape - too slow, or the anchor is a world away
+                continue;
+            }
+            final Shadowstep step = new Shadowstep(hunt.anchor(),
+                    System.currentTimeMillis() + (long) (returnWindow * 1000));
+            shadowsteps.put(hunter, step);
+            showShadowstepBar(hunter, step);
+            playShadowstepOffered(hunter);
+            UtilMessage.message(hunter, getClassType().getDisplayName(),
+                    "champions.skill.assassin.predators-mark.shadowstep-ready");
+        }
+    }
+
+    /** Starts the escape dash back to the leap point. A wall stops it short; too far from the anchor and it just fails. */
+    private void performShadowstep(Player player, Shadowstep step) {
+        startCooldown(player); // the escape is spent whether the dash lands or not
+        final Location anchor = step.anchor().clone();
+        if (!player.getWorld().equals(anchor.getWorld())
+                || player.getLocation().distanceSquared(anchor) > returnMaxDistance * returnMaxDistance) {
+            message(player, "shadowstep-failed"); // dragged too far from the leap point to dash back
+            return;
+        }
+        final ReturnDash dash = new ReturnDash(anchor,
+                System.currentTimeMillis() + (long) (maxLungeDuration * 1000));
+        returnDashes.put(player, dash);
+        shadowstepPuff(player.getLocation());
+        playLungeStart(player);
+        advanceReturn(player, dash);
+    }
+
+    private void advanceReturn(Player player, ReturnDash dash) {
+        if (!isEnabled() || getLevel(player) <= 0 || !player.getWorld().equals(dash.anchor().getWorld())
+                || System.currentTimeMillis() >= dash.expires()) {
+            fizzleReturn(player);
+            return;
+        }
+        final Location start = player.getLocation();
+        final Vector delta = dash.anchor().toVector().subtract(start.toVector());
+        final double distance = delta.length();
+        if (distance <= 1.5) {
+            finishReturn(player);
+            return;
+        }
+        final Vector velocity = delta.multiply(Math.min(lungeSpeed, distance) / distance);
+        final CustomEntityVelocityEvent event = UtilServer.callEvent(
+                new CustomEntityVelocityEvent(player, null, VelocityType.CUSTOM, velocity));
+        if (event.isCancelled() || !clearPath(player, event.getVector(), dash.anchor().getY())) {
+            fizzleReturn(player);
+            return;
+        }
+        player.setVelocity(event.getVector());
+        player.setFallDistance(0);
+        lungeTrail(player);
+    }
+
+    /** The dash reached the leap point. */
+    private void finishReturn(Player player) {
+        if (returnDashes.remove(player) == null) return;
+        if (!player.isOnline()) return;
+        player.setVelocity(new Vector());
+        player.setFallDistance(0);
+        shadowstepPuff(player.getLocation());
+    }
+
+    /** A wall cut the dash short - the hunter stops where it hit. */
+    private void fizzleReturn(Player player) {
+        if (returnDashes.remove(player) == null) return;
+        if (!player.isOnline()) return;
+        player.setVelocity(new Vector());
+        new SoundEffect(Sound.ENTITY_ITEM_BREAK, 0.7f, 0.9f).play(player.getLocation());
+        lungeSpark(player.getLocation().add(0, 1, 0), 8, 0.25);
+    }
+
+    private void stopReturn(Player player) {
+        if (returnDashes.remove(player) != null && player.isOnline()) {
+            player.setVelocity(new Vector());
+        }
+    }
+
+    private void message(Player player, String key) {
+        UtilMessage.message(player, getClassType().getDisplayName(), "champions.skill.assassin.predators-mark." + key);
+    }
+
+    /**
+     * Commits the ability cooldown. Called by hand at every point the sequence can end - a mark that lapses,
+     * a fizzled lunge, a hunt that times out, an escape window missed, or the escape being taken - so the 20s
+     * never ticks while the player is still mid-combo. No-ops if a cooldown is already running.
+     */
+    private void startCooldown(Player player) {
+        if (championsManager.getCooldowns().hasCooldown(player, getName())) return;
+        championsManager.getCooldowns().use(player, getName(), getCooldown(getLevel(player)), showCooldownFinished(),
+                true, isCancellable(), this::shouldDisplayActionBar, getPriority());
+    }
+
+    /**
+     * Ends a placed mark. {@code applyCooldown} commits the cooldown now - pass true when the mark simply lapses
+     * or loses its target, false when something else will own it: the lunge about to start, or an ownership loss
+     * (build change, skill disabled, disconnect, shutdown).
+     */
+    private void endMark(Player player, boolean applyCooldown) {
+        updateVignette(player, null);
+        Mark mark = marks.remove(player);
+        if (mark == null) return;
+        clearGlow(player, mark); // the lunge-window bar clears itself once the mark leaves the map
+        if (applyCooldown) {
+            startCooldown(player);
+        }
+    }
+
+    private void showLungeWindowBar(Player player, Mark mark) {
+        showTimerBar(player, "Lunge", markDuration, () -> marks.get(player) == mark ? mark.expires : null);
+    }
+
+    private void showHuntBar(Player player, Hunt hunt) {
+        showTimerBar(player, "Hunt", huntDuration, () -> hunts.get(player) == hunt ? hunt.expires() : null);
+    }
+
+    private void showShadowstepBar(Player player, Shadowstep step) {
+        showTimerBar(player, "Shadowstep", returnWindow, () -> shadowsteps.get(player) == step ? step.expires() : null);
+    }
+
+    /**
+     * A self-managed action-bar countdown drawn like a live cooldown bar - bold white label, green-fill bar,
+     * white seconds. Sits just below the ability cooldown's priority (lower wins) so it shows over the
+     * "Predators Mark" recharge running underneath. Not a real cooldown - that would leave a stale "recharged"
+     * bar afterwards. The provider returns null once its state is gone, ending the bar at once.
+     */
+    private void showTimerBar(Player player, String label, double window, Supplier<Long> expiresAt) {
+        final Gamer gamer = championsManager.getClientManager().search().online(player).getGamer();
+        gamer.getActionBar().add(getPriority() - 1, new TimedComponent(window + 1, false, viewer -> {
+            final Long expires = expiresAt.get();
+            if (expires == null || !shouldDisplayActionBar(viewer)) return null;
+            final double remaining = (expires - System.currentTimeMillis()) / 1000.0;
+            if (remaining <= 0) return null;
+            final float progress = (float) Math.max(0, Math.min(1, 1 - remaining / window));
+            return Component.join(JoinConfiguration.separator(Component.space()),
+                    Component.text(label, NamedTextColor.WHITE, TextDecoration.BOLD),
+                    ProgressBar.withProgress(progress).build(),
+                    Component.text(String.format("%.1fs", remaining), NamedTextColor.WHITE));
+        }));
+    }
+
+    // --- Presentation -------------------------------------------------------------------------------------
+
+    /** The moment a mark lands: a lock-on cue for the hunter, a heartbeat for the prey. */
+    private void playMarkApplied(Player caster, Player target) {
+        new SoundEffect(Sound.ENTITY_ARROW_HIT_PLAYER, 1.6f, 0.8f).play(caster);
+        new SoundEffect(Sound.ENTITY_WOLF_GROWL, 0.7f, 0.5f).play(caster);
+        new SoundEffect(Sound.ENTITY_WARDEN_HEARTBEAT, 1.2f, 1.0f).play(target);
+
+        final Location center = target.getLocation();
+        for (int i = 0; i < 18; i++) {
+            final double angle = Math.PI * 2 * i / 18;
+            final Location point = center.clone().add(Math.cos(angle) * 0.95, 0.15, Math.sin(angle) * 0.95);
+            Particle.DUST.builder().location(point).count(1).extra(0)
+                    .data(new Particle.DustOptions(Color.fromRGB(150, 12, 12), 1.4f))
+                    .receivers(caster).spawn();
+        }
+    }
+
+    /** Soft descending tone for the hunter when a mark ends without a lunge. */
+    private void markLostCue(Player caster) {
+        if (!caster.isOnline()) return;
+        new SoundEffect(Sound.BLOCK_NOTE_BLOCK_BASS, 0.6f, 0.7f).play(caster);
+    }
+
+    /** Hunter-only reticle bobbing over the marked target while the lunge window is open. */
+    private void pulseReticle(Player caster, Mark mark, long now) {
+        if (now < mark.nextPulse) return;
+        mark.nextPulse = now + 250;
+        final Location head = mark.target.getLocation().add(0, 2.35, 0);
+        Particle.DUST.builder().location(head).count(5).offset(0.12, 0.10, 0.12).extra(0)
+                .data(new Particle.DustOptions(Color.fromRGB(185, 28, 28), 1.1f))
+                .receivers(caster).spawn();
+    }
+
+    /** The skill's one particle - a violet puff, reused at every beat. Dust only; nothing that blocks the view. */
+    private void lungeSpark(Location at, int count, double spread) {
+        Particle.DUST.builder().location(at).count(count).offset(spread, spread, spread).extra(0)
+                .data(new Particle.DustOptions(Color.fromRGB(122, 40, 190), 1.3f)).receivers(30).spawn();
+    }
+
+    private void playLungeStart(Player player) {
+        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_FLAP, 0.8f, 1.5f);
+        new SoundEffect(Sound.ENTITY_PHANTOM_FLAP, 0.7f, 0.7f).play(player.getLocation());
+        lungeSpark(player.getLocation().add(0, 1, 0), 12, 0.25);
+    }
+
+    private void lungeTrail(Player player) {
+        lungeSpark(player.getLocation().add(0, 1, 0), 3, 0.15);
+    }
+
+    private void playLungeHit(Location target) {
+        final Location at = target.clone().add(0, 1, 0);
+        new SoundEffect(Sound.ENTITY_PHANTOM_BITE, 0.8f, 0.8f).play(at);
+        lungeSpark(at, 12, 0.3);
+    }
+
+    /** Private cue to the hunter that the shadowstep window is open. */
+    private void playShadowstepOffered(Player player) {
+        new SoundEffect(Sound.ENTITY_ILLUSIONER_PREPARE_MIRROR, 1.6f, 0.6f).play(player);
+        new SoundEffect(Sound.BLOCK_NOTE_BLOCK_CHIME, 0.8f, 0.6f).play(player);
+    }
+
+    /** The violet burst at each end of a shadowstep, low at the hunter's feet and identical at both ends. */
+    private void shadowstepPuff(Location at) {
+        new SoundEffect(Sound.ENTITY_ENDERMAN_TELEPORT, 1.2f, 0.7f).play(at);
+        lungeSpark(at.clone().add(0, 0.3, 0), 24, 0.45);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+
+    @Override
+    public void trackPlayer(Player player, Gamer gamer) {
+        equippedPlayers.add(player);
+    }
+
+    @Override
+    public void invalidatePlayer(Player player, Gamer gamer) {
+        endMark(player, false);
+        stopLunge(player);
+        stopReturn(player);
+        hunts.remove(player);
+        shadowsteps.remove(player);
+        equippedPlayers.remove(player);
+    }
+
+    private void removePlayer(Player player) {
+        // Death and teleport do not unequip the skill; keep preview tracking for the next valid tick.
+        // Abandoning a live combo by self-teleport or quitting still commits the cooldown (death resets it anyway).
+        if (!player.isDead() && (hunts.containsKey(player) || shadowsteps.containsKey(player)
+                || returnDashes.containsKey(player))) {
+            startCooldown(player);
+        }
+        endMark(player, false);
+        stopLunge(player);
+        stopReturn(player);
+        hunts.remove(player);
+        shadowsteps.remove(player);
+        for (Player owner : List.copyOf(marks.keySet())) {
+            if (marks.get(owner).target.equals(player)) {
+                markLostCue(owner);
+                endMark(owner, true); // the target they committed to has left - the cooldown stands
+            }
+        }
+        for (Player owner : List.copyOf(lunges.keySet())) {
+            if (lunges.get(owner).target().equals(player)) stopLunge(owner);
+        }
+        for (Player owner : List.copyOf(vignetteTargets.keySet())) {
+            if (vignetteTargets.get(owner).equals(player)) updateVignette(owner, null);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTeleport(PlayerTeleportEvent event) {
+        if (event.getTo().equals(lungeArrivals.get(event.getPlayer()))) return;
+        // Covers world changes and external teleports without steering across a teleport.
+        removePlayer(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        removePlayer(event.getPlayer());
+        equippedPlayers.remove(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        removePlayer(event.getEntity());
+    }
+
+    @EventHandler
+    public void onDisable(PluginDisableEvent event) {
+        if (event.getPlugin() != champions) return;
+        List.copyOf(marks.keySet()).forEach(player -> endMark(player, false));
+        List.copyOf(lunges.keySet()).forEach(this::stopLunge);
+        List.copyOf(returnDashes.keySet()).forEach(this::stopReturn);
+        List.copyOf(vignetteTargets.keySet()).forEach(player -> updateVignette(player, null));
+        hunts.clear();
+        shadowsteps.clear();
+        equippedPlayers.clear();
+    }
+
+    @Override
+    public void loadSkillConfig() {
+        range = Math.max(0.1, getConfig("range", 20.0, Number.class).doubleValue());
+        markDuration = Math.max(0.1, getConfig("markDuration", 7.0, Number.class).doubleValue());
+        blindDuration = Math.max(0, getConfig("blindDuration", 1.5, Number.class).doubleValue());
+        lungeSpeed = Math.max(0.1, Math.min(3, getConfig("lungeSpeed", 1.5, Number.class).doubleValue()));
+        lungeStopDistance = Math.max(0, getConfig("lungeStopDistance", 3.0, Number.class).doubleValue());
+        maxLungeDuration = Math.max(0.1, getConfig("maxLungeDuration", 2.0, Number.class).doubleValue());
+        huntDuration = Math.max(0.5, getConfig("huntDuration", 8.0, Number.class).doubleValue());
+        returnWindow = Math.max(0.5, getConfig("returnWindow", 4.0, Number.class).doubleValue());
+        returnMaxDistance = Math.max(1, getConfig("returnMaxDistance", 40.0, Number.class).doubleValue());
+    }
+
+    /** A placed mark: the glowing target and the deadline to re-drop and lunge. */
+    private static final class Mark {
+        private final Player target;
+        private final long expires;
+        private boolean glowing;
+        private boolean glowFailed;
+        private long nextPulse;
+
+        private Mark(Player target, long expires) {
+            this.target = target;
+            this.expires = expires;
+        }
+    }
+
+    /** A lunge in flight toward its target. {@code world} guards against the target changing dimensions mid-air. */
+    private record Lunge(Player target, World world, Location anchor, long expires) { }
+
+    /** A stuck lunge: killing {@code target} before {@code expires} earns the shadowstep back to {@code anchor}. */
+    private record Hunt(Player target, Location anchor, long expires) { }
+
+    /** The open escape window - drop again before {@code expires} to dash back to {@code anchor}. */
+    private record Shadowstep(Location anchor, long expires) { }
+
+    /** The escape dash itself, in flight toward {@code anchor} until it arrives or {@code expires}. */
+    private record ReturnDash(Location anchor, long expires) { }
+}

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/CooldownSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/CooldownSkill.java
@@ -59,4 +59,13 @@ public interface CooldownSkill extends IChampionsSkill {
         return false;
     }
 
+    /**
+     * Whether the skill will accept another activation right now even though it is tracked as in use or already
+     * on cooldown - for multi-step skills that re-use the same input for each step (e.g. mark, then lunge, then
+     * escape). Checked by {@link me.mykindos.betterpvp.champions.champions.skills.listeners.SkillListener}.
+     */
+    default boolean canReactivate(Player player) {
+        return false;
+    }
+
 }

--- a/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ToggleSkill.java
+++ b/champions/src/main/java/me/mykindos/betterpvp/champions/champions/skills/types/ToggleSkill.java
@@ -3,10 +3,16 @@ package me.mykindos.betterpvp.champions.champions.skills.types;
 
 import me.mykindos.betterpvp.core.components.champions.IChampionsSkill;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 public interface ToggleSkill extends IChampionsSkill {
 
 
     void toggle(Player player, int level);
+
+    /** Whether this skill accepts the weapon being dropped. Defaults to the existing shared weapon rules. */
+    default boolean canToggleWith(ItemStack item) {
+        return true;
+    }
 
 }

--- a/champions/src/main/resources/configs/skills/skills.yml
+++ b/champions/src/main/resources/configs/skills/skills.yml
@@ -1,6 +1,38 @@
 skills:
   # canUseWhileSlowed, canUseWhileSilenced, canUseWhileLevitating, and canUseInLiquid are optional config options
   assassin:
+    meditation:
+      enabled: true
+      maxlevel: 1
+      cooldown: 24.0
+      cooldownDecreasePerLevel: 0.0
+      duration: 4.0
+      healingInterval: 0.5
+      healingPerTick: 1.5
+      finalHealingPerTick: 3.5
+      finalPhaseDuration: 1.0
+      minimumCancelTime: 1.0
+      exitDamageReduction: 0.35
+      exitResistanceDuration: 1.5
+      burstReflectRatio: 0.6
+      burstMaxDamage: 12.0
+      burstRadius: 4.0
+      burstKnockback: 1.2
+      burstTelegraph: 0.5
+    predatorsmark:
+      enabled: true
+      maxlevel: 1
+      cooldown: 20.0
+      cooldownDecreasePerLevel: 0.0
+      markDuration: 7.0
+      range: 20.0
+      blindDuration: 1.5
+      lungeSpeed: 1.5
+      lungeStopDistance: 3.0
+      maxLungeDuration: 2.0
+      huntDuration: 8.0
+      returnWindow: 4.0
+      returnMaxDistance: 40.0
     leap:
       enabled: true
       cooldown: 9.0

--- a/champions/src/main/resources/translations/champions_en.properties
+++ b/champions/src/main/resources/translations/champions_en.properties
@@ -384,6 +384,46 @@ champions.skill.assassin.combo-attack.description.6=
 champions.skill.assassin.combo-attack.description.7=Not attacking for {2} seconds
 champions.skill.assassin.combo-attack.description.8=will reset your bonus damage
 
+# Assassin - Meditation
+champions.skill.assassin.meditation.name=Meditation
+champions.skill.assassin.meditation.description.lines=19
+champions.skill.assassin.meditation.description.1=Drop your Sword / Axe to activate
+champions.skill.assassin.meditation.description.2=
+champions.skill.assassin.meditation.description.3=Sit and meditate for {0} seconds. While meditating
+champions.skill.assassin.meditation.description.4=you cannot move, attack, or be hurt.
+champions.skill.assassin.meditation.description.5=
+champions.skill.assassin.meditation.description.6=You heal up to {1} health over that time, and heal
+champions.skill.assassin.meditation.description.7=faster during the last {6}s.
+champions.skill.assassin.meditation.description.8=
+champions.skill.assassin.meditation.description.9=Every hit you block while meditating stores energy.
+champions.skill.assassin.meditation.description.10=When you stop, it explodes after a short delay for
+champions.skill.assassin.meditation.description.11=up to {7} damage, knocking back enemies within {8} blocks.
+champions.skill.assassin.meditation.description.12=
+champions.skill.assassin.meditation.description.13=After {2}s you can drop your weapon again to stop
+champions.skill.assassin.meditation.description.14=early. Once you leave, you take {3}% less damage
+champions.skill.assassin.meditation.description.15=for {4} seconds.
+champions.skill.assassin.meditation.description.16=
+champions.skill.assassin.meditation.description.17=You must be standing on solid ground.
+champions.skill.assassin.meditation.description.18=
+champions.skill.assassin.meditation.description.19=Cooldown: {5}
+champions.skill.assassin.meditation.ground=You must be standing on solid ground to meditate.
+champions.skill.assassin.meditation.visible=You must be visible to meditate.
+
+# Assassin - Predators Mark
+champions.skill.assassin.predators-mark.description.lines=12
+champions.skill.assassin.predators-mark.description.1=Drop your Sword / Axe to activate
+champions.skill.assassin.predators-mark.description.2=
+champions.skill.assassin.predators-mark.description.3=Aim at an enemy up to {0} blocks away to mark them.
+champions.skill.assassin.predators-mark.description.4=Only you can see them for {1} seconds, glowing through walls.
+champions.skill.assassin.predators-mark.description.5=
+champions.skill.assassin.predators-mark.description.6=Drop again before the mark fades to lunge toward them,
+champions.skill.assassin.predators-mark.description.7=inflicting {5} for {2} seconds.
+champions.skill.assassin.predators-mark.description.8=
+champions.skill.assassin.predators-mark.description.9=Kill them within {3} seconds, then drop once more
+champions.skill.assassin.predators-mark.description.10=to dash back to where you leapt from.
+champions.skill.assassin.predators-mark.description.11=
+champions.skill.assassin.predators-mark.description.12=Cooldown: {4}
+
 # Assassin - Recall
 champions.skill.assassin.recall.description.lines=6
 champions.skill.assassin.recall.description.1=Drop your Sword / Axe to activate
@@ -1492,6 +1532,7 @@ champions.skill.assassin.illusion.name=Illusion
 champions.skill.assassin.leap.name=Leap
 champions.skill.assassin.marked-for-death.name=Marked for Death
 champions.skill.assassin.phantom-blade.name=Phantom Blade
+champions.skill.assassin.predators-mark.name=Predator's Mark
 champions.skill.assassin.recall.name=Recall
 champions.skill.assassin.sever.name=Sever
 champions.skill.assassin.shocking-strikes.name=Shocking Strikes
@@ -1976,6 +2017,14 @@ champions.skill.assassin.combo-attack.ended={0} {1} has ended at +{2}
 
 # --- SmokeBomb ---
 champions.skill.assassin.smoke-bomb.reappeared=You have reappeared.
+
+# --- PredatorsMark ---
+champions.skill.assassin.predators-mark.no-target=Look directly at an enemy within range to mark them.
+champions.skill.assassin.predators-mark.marked=Successfully marked {0}. Drop your Sword / Axe again to lunge.
+champions.skill.assassin.predators-mark.marked-by=You have been marked by {0}.
+champions.skill.assassin.predators-mark.out-of-range=Your marked enemy is too far away to lunge at.
+champions.skill.assassin.predators-mark.shadowstep-ready=Mark eliminated - drop your Sword / Axe again to dash back to cover.
+champions.skill.assassin.predators-mark.shadowstep-failed=Your escape route is blocked.
 
 # --- Farshot ---
 champions.skill.ranger.farshot.damage={0} did {1} damage.


### PR DESCRIPTION
## Describe your changes
Meditation: drop weapon to root in place and channel for a few seconds. While channeling you can't move or act and take no damage; you heal on a fixed schedule that speeds up for the final stretch. Every hit blocked during the channel feeds an exit burst by leaving (naturally or by dropping again after a minimum time) it winds up briefly then detonates for capped AoE damage + knockback. Leaving early grants a short damage-reduction window.

Predator's Mark: mark a target you're aiming at; only you see them, glowing through walls, for a limited time. Drop again to lunge at them (applies Blindness on arrival). Kill the mark within the hunt window and drop once more to shadowstep back to where you lunged from.

https://github.com/user-attachments/assets/c8320da9-927f-4ce9-ace9-1e58cfd7f7df

<img width="887" height="831" alt="meditation" src="https://github.com/user-attachments/assets/43775106-16f6-465d-b5f4-2bcd93c96116" />

https://github.com/user-attachments/assets/09bb8ee4-5531-4b22-ab31-51c4385d2566

<img width="973" height="638" alt="phantommark" src="https://github.com/user-attachments/assets/3af5ba4f-9c9e-4629-b8d4-dffe751f8384" />

## Link to issue (if applicable)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes.


